### PR TITLE
[FEAT] rbr hex reader, dtype optimise, dim-order swap for stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ data/temp.nc
 data/moor/raw/odb_2026/*
 
 
+# Legacy reference scripts — originals kept locally, not tracked
+oceanarray/legacy/02_aqdp_ploter.py
+
 # Caldip prototype and dev scripts (superseded by ../caldip/ package)
 oceanarray/caldip.py
 debug_caldip.py

--- a/oceanarray/cli.py
+++ b/oceanarray/cli.py
@@ -289,6 +289,43 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return 0 if all_ok else 1
 
 
+def cmd_list(args: argparse.Namespace) -> int:
+    """Print allowed instrument types and file_type values for mooring YAML files."""
+    from . import parameters as P
+
+    topic = getattr(args, "topic", None)
+
+    instr_col = max(len(k) for k in P.INSTRUMENT_FILE_TYPES) + 2
+    file_col = max(len(", ".join(v)) for v in P.INSTRUMENT_FILE_TYPES.values()) + 2
+
+    if topic in (None, "instruments", "file-types"):
+        print()
+        print("  Mooring YAML — allowed values for instrument: and file_type:")
+        print()
+        print(f"  {'instrument':<{instr_col}}  {'file_type (seasenselib reader)'}")
+        print(f"  {'-' * instr_col}  {'-' * file_col}")
+        for name in sorted(P.INSTRUMENT_FILE_TYPES):
+            readers = ", ".join(P.INSTRUMENT_FILE_TYPES[name])
+            print(f"  {name:<{instr_col}}  {readers}")
+
+        if P._EXTRA_FILE_TYPES:
+            print()
+            print("  Additional file_type values (specialist / deprecated):")
+            print(f"  {'-' * instr_col}  {'-' * file_col}")
+            for ft, note in sorted(P._EXTRA_FILE_TYPES.items()):
+                print(f"  {ft:<{instr_col}}  {note}")
+
+        print()
+        print("  Notes:")
+        print("    instrument:  human-readable name stored in instrument_type")
+        print("                 coordinates; drives Aquadopp-specific plots,")
+        print("                 declination correction, and tilt QC.")
+        print("    file_type:   selects the seasenselib reader for stage 1.")
+        print()
+
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build and return the top-level argument parser for the oceanarray CLI."""
     parser = argparse.ArgumentParser(
@@ -507,6 +544,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Display the figure interactively (works alongside --output)",
     )
     p_plot.set_defaults(func=cmd_plot)
+
+    p_list = sub.add_parser(
+        "list",
+        help="List allowed instrument types and file_type values for mooring YAML files.",
+    )
+    p_list.add_argument(
+        "topic",
+        nargs="?",
+        choices=["instruments", "file-types"],
+        default=None,
+        help="Filter output: 'instruments' or 'file-types' (default: show both).",
+    )
+    p_list.set_defaults(func=cmd_list)
 
     return parser
 

--- a/oceanarray/mooring_level.py
+++ b/oceanarray/mooring_level.py
@@ -18,8 +18,11 @@ import numpy as np
 import xarray as xr
 import yaml
 from . import parameters as P
-from .utilities import _status
+from .utilities import _status, cast_output_dtypes, drop_all_zero_vars
 
+# Canonical allowed values for the ``instrument:`` field in mooring YAML files.
+# Defined in parameters.py alongside the instrument→file_type mapping.
+KNOWN_INSTRUMENT_TYPES: frozenset = P.KNOWN_INSTRUMENT_TYPES
 
 STACK_VARS = [
     "temperature",
@@ -384,6 +387,13 @@ class MooringStacker:
                 continue
             serial = _safe_serial(entry.get("serial", ""))
             instr_type = entry.get("instrument", "unknown")
+            if instr_type not in KNOWN_INSTRUMENT_TYPES:
+                print(
+                    f"  WARNING: instrument '{instr_type}' (s/n {serial}) is not in "
+                    f"KNOWN_INSTRUMENT_TYPES {sorted(KNOWN_INSTRUMENT_TYPES)}. "
+                    "Aquadopp-specific plots and processing will be skipped. "
+                    "Allowed values: microcat, aquadopp."
+                )
             hab = entry.get("hab")
             if hab is None:
                 continue
@@ -741,7 +751,16 @@ class MooringStacker:
 
         if output_path.exists():
             output_path.unlink()
-        ds_out.to_netcdf(output_path)
+        # Beam velocities are superseded by ENU components in the stacked file.
+        beam_vel_vars = [v for v in ds_out.data_vars if v.startswith("velocity_beam")]
+        if beam_vel_vars:
+            ds_out = ds_out.drop_vars(beam_vel_vars)
+        ds_out = drop_all_zero_vars(ds_out, ["amplitude_beam", "analog_input_"])
+        # OceanSITES convention: time is the unlimited (first) dimension.
+        ds_out = ds_out.transpose("time", "N_LEVELS")
+        ds_out = cast_output_dtypes(ds_out)
+        _enc = {v: {"zlib": True, "complevel": 5} for v in ds_out.data_vars}
+        ds_out.to_netcdf(output_path, encoding=_enc)
         _status("file", str(output_path.relative_to(self.base_dir)))
         return True
 
@@ -812,7 +831,7 @@ class MooringGridder:
             ds.close()
             return False
 
-        pressure = ds["pressure"].values.astype(np.float64)  # (N_LEVELS, time)
+        pressure = ds["pressure"].values.astype(np.float64)  # (time, N_LEVELS)
         # Variables that are meaningful at the stacked per-instrument level but
         # should not be interpolated onto the pressure grid.  Instrument-frame
         # and beam-frame velocities are excluded because the XYZ→ENU rotation
@@ -847,7 +866,7 @@ class MooringGridder:
             v
             for v in ds.data_vars
             if v != "pressure"
-            and ds[v].dims == ("N_LEVELS", "time")
+            and ds[v].dims == ("time", "N_LEVELS")
             and not v.endswith("_qc")
             and v not in _GRID_EXCLUDE
         ]
@@ -885,13 +904,13 @@ class MooringGridder:
                     var_data[_v][~np.isfinite(var_data[_v])] = np.nan
 
         for t in range(n_time):
-            p_col = pressure[:, t]
+            p_col = pressure[t, :]
             p_valid_mask = np.isfinite(p_col)
             if p_valid_mask.sum() < 2:
                 continue
 
             for vname in grid_vars:
-                v_col = var_data[vname][:, t]
+                v_col = var_data[vname][t, :]
                 both_valid = p_valid_mask & np.isfinite(v_col)
                 if both_valid.sum() < 2:
                     continue
@@ -954,6 +973,8 @@ class MooringGridder:
         ds.close()
         if output_path.exists():
             output_path.unlink()
-        ds_out.to_netcdf(output_path)
+        ds_out = cast_output_dtypes(ds_out)
+        _enc = {v: {"zlib": True, "complevel": 5} for v in ds_out.data_vars}
+        ds_out.to_netcdf(output_path, encoding=_enc)
         _status("file", str(output_path.relative_to(self.base_dir)))
         return True

--- a/oceanarray/parameters.py
+++ b/oceanarray/parameters.py
@@ -164,3 +164,37 @@ INSTRUMENT_ABBREV = {
     "tr1050": "TR",
     "adcp": "AD",
 }
+
+# ---------------------------------------------------------------------------
+# Instrument type → allowed file_type values for the mooring YAML.
+#
+# ``instrument:``  is the human-readable name stored in instrument_type
+#                  coordinates and used to dispatch Aquadopp-specific plots,
+#                  declination correction, tilt QC, etc.
+#
+# ``file_type:``   is the seasenselib reader key that controls how the raw
+#                  file is parsed.  Each instrument may have several variants.
+#
+# To add a new instrument class: add an entry here.  Everything that checks
+# instrument type (reports, mooring_level, plotters) reads KNOWN_INSTRUMENT_TYPES
+# from this dict.
+# ---------------------------------------------------------------------------
+INSTRUMENT_FILE_TYPES: dict = {
+    "microcat": ["sbe-cnv", "sbe-ascii", "sbe-hex"],
+    "aquadopp": ["nortek-aqd", "nortek-ascii", "nortek-csv"],
+    "tr1050": [
+        "rbr-hex-oa"
+    ],  # RBR TR-1050 thermistor chain; -oa until seasenselib supports it
+}
+
+# Derived: set of allowed ``instrument:`` values in mooring YAML files.
+KNOWN_INSTRUMENT_TYPES: frozenset = frozenset(INSTRUMENT_FILE_TYPES.keys())
+
+# File types accepted by the stage1 reader but not yet tied to a canonical
+# instrument name (deprecated, legacy, or not yet standardised).
+_EXTRA_FILE_TYPES: dict = {
+    "nortek-csv-oa": "aquadopp (DEPRECATED internal reader; use nortek-csv)",
+    "rbr-rsk": "RBR instruments (instrument name not yet standardised)",
+    "rbr-dat": "RBR instruments (instrument name not yet standardised)",
+    "rbr-matlab-legacy": "RBR instruments (DEPRECATED legacy format)",
+}

--- a/oceanarray/plotters/_current.py
+++ b/oceanarray/plotters/_current.py
@@ -163,7 +163,7 @@ def plot_multi_aquadopp_trajectories(
     Parameters
     ----------
     ds : xr.Dataset
-        Stacked mooring dataset with shape (N_LEVELS, time).  Must contain
+        Stacked mooring dataset with shape (time, N_LEVELS).  Must contain
         *instr_type_var*, *serial_var*, *hab_var*, *u_var*, *v_var*.
     u_var, v_var : str
         Eastward and northward velocity variables (m s⁻¹).
@@ -178,6 +178,11 @@ def plot_multi_aquadopp_trajectories(
     -------
     matplotlib.figure.Figure or None
         None if no Aquadopp instruments are found in the dataset.
+
+    Notes
+    -----
+    Adapted from ``02_aqdp_ploter.py`` by L. Moscatel (lmoscat),
+    Universitat de Barcelona.
 
     """
     instr_types = ds[instr_type_var].values
@@ -200,11 +205,11 @@ def plot_multi_aquadopp_trajectories(
     trajs = []
     all_temps: list = []
     for i in aqd_idx:
-        u = np.nan_to_num(ds[u_var].values[i], nan=0.0)
-        v = np.nan_to_num(ds[v_var].values[i], nan=0.0)
+        u = np.nan_to_num(ds[u_var].values[:, i], nan=0.0)
+        v = np.nan_to_num(ds[v_var].values[:, i], nan=0.0)
         x = np.concatenate([[0.0], np.cumsum(u[:-1] * dt)])
         y = np.concatenate([[0.0], np.cumsum(v[:-1] * dt)])
-        temp = ds[temp_var].values[i] if has_temp else None
+        temp = ds[temp_var].values[:, i] if has_temp else None
         trajs.append((i, x, y, temp))
         if temp is not None:
             all_temps.append(temp[np.isfinite(temp)])
@@ -308,7 +313,7 @@ def plot_aquadopp_speed_profile(
     Parameters
     ----------
     ds : xr.Dataset
-        Stacked mooring dataset with shape (N_LEVELS, time).
+        Stacked mooring dataset with shape (time, N_LEVELS).
     speed_var : str
         Preferred speed variable name; computed from u/v if absent.
     u_var, v_var : str
@@ -320,6 +325,11 @@ def plot_aquadopp_speed_profile(
     -------
     matplotlib.figure.Figure or None
         None if no Aquadopp instruments are found.
+
+    Notes
+    -----
+    Adapted from ``02_aqdp_ploter.py`` by L. Moscatel (lmoscat),
+    Universitat de Barcelona.
 
     """
     instr_types = ds[instr_type_var].values
@@ -334,10 +344,10 @@ def plot_aquadopp_speed_profile(
     records = []
     for i in aqd_idx:
         if speed_var in ds.data_vars:
-            spd = ds[speed_var].values[i].ravel()
+            spd = ds[speed_var].values[:, i].ravel()
         elif u_var in ds.data_vars and v_var in ds.data_vars:
-            u = ds[u_var].values[i]
-            v = ds[v_var].values[i]
+            u = ds[u_var].values[:, i]
+            v = ds[v_var].values[:, i]
             spd = np.sqrt(u**2 + v**2)
         else:
             continue

--- a/oceanarray/read_rbr_hex.py
+++ b/oceanarray/read_rbr_hex.py
@@ -1,0 +1,541 @@
+r"""Reader for RBR TR-1050 (and similar) binary-hex data files.
+
+The ``.hex`` file format produced by Ruskin stores the header as human-readable
+text followed by the instrument data as ASCII hex characters.  The binary
+payload uses BCD-encoded timestamps in 12-byte event records (``\\x00\\x00\\x00TIM``
+or ``\\x00\\x00\\x00STP`` + 6 BCD bytes) and 3-byte raw ADC counts per channel per
+sample.
+
+Usage::
+
+    import xarray as xr
+    from oceanarray.read_rbr_hex import read_rbr_hex
+
+    ds = read_rbr_hex("13875_recovery.hex")
+    print(ds)
+
+Calibration
+-----------
+Raw 24-bit counts are stored in ``channel_{n}`` (uint32).  When the header
+contains exactly four calibration coefficients, the Steinhart-Hart equation is
+applied and the result is stored as a separate variable named after the channel
+(e.g. ``temp``).  See :func:`_apply_rbr_cal` for the equation.  If the
+coefficient count is not four, the variable falls back to raw / 16777215 and
+a warning is encoded in the ``calibration_method`` attribute.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import xarray as xr
+
+
+# ---------------------------------------------------------------------------
+# BCD helpers
+# ---------------------------------------------------------------------------
+
+
+def _bcd(b: int) -> int:
+    """Decode one byte of packed BCD: upper nibble * 10 + lower nibble."""
+    return (b >> 4) * 10 + (b & 0xF)
+
+
+def _bcd_datetime(b6: bytes) -> datetime.datetime:
+    """Decode 6 BCD bytes → datetime (YY MM DD HH MM SS, year base 2000)."""
+    return datetime.datetime(
+        2000 + _bcd(b6[0]),
+        _bcd(b6[1]),
+        _bcd(b6[2]),
+        _bcd(b6[3]),
+        _bcd(b6[4]),
+        _bcd(b6[5]),
+    )
+
+
+def _bcd_timedelta(b3: bytes) -> int:
+    """Decode 3 BCD bytes → sample period in seconds (HH MM SS)."""
+    return _bcd(b3[0]) * 3600 + _bcd(b3[1]) * 60 + _bcd(b3[2])
+
+
+# ---------------------------------------------------------------------------
+# Text header parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_text_header(lines: List[str]) -> Dict:
+    """Extract metadata from the human-readable header section."""
+    meta: Dict = {
+        "model": None,
+        "firmware": None,
+        "serial": None,
+        "n_channels": 1,
+        "n_samples": 0,
+        "n_bytes_data": 0,
+        "channel_names": {},  # from Channel[N].name= lines (raw.txt format)
+        "column_names": [],  # from whitespace-separated header line (hex format)
+        "channel_units": {},
+        "channel_calibration": {},
+        "host_time": None,
+        "logger_time": None,
+        "logging_start": None,
+        "logging_end": None,
+        "sample_period_str": None,
+        "timestamps": [],
+    }
+
+    cal_channel: Optional[int] = None
+    cal_coeffs: List[float] = []
+    cal_units: str = ""
+
+    for raw_line in lines:
+        is_indented = raw_line and raw_line[0] in (" ", "\t")
+        line = raw_line.strip()
+
+        m = re.match(r"RBR\s+([\w\-]+)\s+([\d.]+)\s+0*(\d+)", line)
+        if m:
+            meta["model"] = m.group(1)
+            meta["firmware"] = m.group(2)
+            meta["serial"] = m.group(3)
+            continue
+
+        m = re.match(r"Host time\s+(\S+\s+\S+)", line)
+        if m:
+            meta["host_time"] = m.group(1)
+            continue
+
+        m = re.match(r"Logger time\s+(\S+\s+\S+)", line)
+        if m:
+            meta["logger_time"] = m.group(1)
+            continue
+
+        m = re.match(r"Logging start\s+(\S+\s+\S+)", line)
+        if m:
+            meta["logging_start"] = m.group(1)
+            continue
+
+        m = re.match(r"Logging end\s+(\S+\s+\S+)", line)
+        if m:
+            meta["logging_end"] = m.group(1)
+            continue
+
+        m = re.match(r"Sample period\s+(\S+)", line)
+        if m:
+            meta["sample_period_str"] = m.group(1)
+            continue
+
+        m = re.match(
+            r"Number of channels\s*=\s*(\d+).*number of samples\s*=\s*(\d+)", line
+        )
+        if m:
+            meta["n_channels"] = int(m.group(1))
+            meta["n_samples"] = int(m.group(2))
+            continue
+
+        m = re.match(r"Number of bytes of data\s+(\d+)", line)
+        if m:
+            meta["n_bytes_data"] = int(m.group(1))
+            continue
+
+        # Column header line (hex format): indented, all tokens are purely alphabetic.
+        # Appears between "Number of bytes in header" and "Number of bytes of data".
+        # e.g. "                               Temp "
+        if (
+            not meta["column_names"]
+            and meta["n_bytes_data"] == 0
+            and raw_line.startswith(" ")
+            and line
+            and all(tok.isalpha() for tok in line.split())
+        ):
+            meta["column_names"] = line.split()
+            continue
+
+        # Channel names and units: e.g. "Channel[1].name=Temperature"
+        m = re.match(r"Channel\[(\d+)\]\.name=(.+)", line)
+        if m:
+            meta["channel_names"][int(m.group(1))] = m.group(2).strip()
+            continue
+
+        m = re.match(r"Channel\[(\d+)\]\.units=(.+)", line)
+        if m:
+            meta["channel_units"][int(m.group(1))] = m.group(2).strip()
+            continue
+
+        m = re.match(r"Channel\[(\d+)\]\.calibration=(.+)", line)
+        if m:
+            cal_channel = int(m.group(1))
+            cal_coeffs = [float(x) for x in m.group(2).split()]
+            meta["channel_calibration"][cal_channel] = cal_coeffs
+            continue
+
+        # Multi-line calibration (indented continuation — hex file format)
+        if cal_channel is not None and is_indented and line:
+            float_parts = [float(p) for p in line.split() if _is_float(p)]
+            # Non-float token at the end is the units label (e.g. "Degrees_C")
+            non_float = [p for p in line.split() if not _is_float(p)]
+            if non_float:
+                cal_units = non_float[-1].replace("_", " ")
+            cal_coeffs.extend(float_parts)
+            meta["channel_calibration"][cal_channel] = list(cal_coeffs)
+            meta["channel_units"][cal_channel] = cal_units
+            continue
+        elif not is_indented:
+            cal_channel = None
+            cal_units = ""
+
+        # In-line calibration (hex file: "Calibration  1: value" + indented lines)
+        m = re.match(r"Calibration\s+(\d+):\s+([-\d.Ee+]+)", line)
+        if m:
+            cal_channel = int(m.group(1))
+            cal_coeffs = [float(m.group(2))]
+            meta["channel_calibration"][cal_channel] = list(cal_coeffs)
+            continue
+
+        # Timestamps / reset stamps
+        m = re.match(
+            r"(?:Timestamp|Reset stamp)\s+(\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2})"
+            r"\s+at sample\s+(\d+)\s+of type:\s+(.+)",
+            line,
+        )
+        if m:
+            meta["timestamps"].append(
+                {
+                    "time": m.group(1),
+                    "sample": int(m.group(2)),
+                    "type": m.group(3).strip(),
+                }
+            )
+            continue
+
+    return meta
+
+
+def _is_float(s: str) -> bool:
+    """Return True if *s* can be parsed as a float."""
+    try:
+        float(s)
+    except ValueError:
+        return False
+    else:
+        return True
+
+
+def _apply_rbr_cal(raw_counts: np.ndarray, coeffs: list[float]) -> np.ndarray:
+    """Apply RBR Steinhart-Hart calibration to raw 24-bit ADC counts.
+
+    Parameters
+    ----------
+    raw_counts : np.ndarray
+        Raw 24-bit unsigned integer counts from the instrument.
+    coeffs : list of float
+        Four calibration coefficients [c0, c1, c2, c3] from the HEX header.
+
+    Returns
+    -------
+    np.ndarray
+        Temperature in degrees Celsius (float64).
+
+    Notes
+    -----
+    The RBR TR-1050 (and similar thermistor-based loggers) use a
+    Steinhart-Hart form.  With x = raw / (2^24 − 1) and R = (1−x)/x::
+
+        1/T_K = c0 + c1·ln(R) + c2·ln(R)² + c3·ln(R)³
+        T(°C) = 1/T_K − 273.15
+
+    Verified against Ruskin _eng.txt output; residual error < 3 µK (rounding
+    in Ruskin's intermediate _raw.txt representation).
+
+    """
+    if len(coeffs) != 4:
+        raise ValueError(f"Expected 4 calibration coefficients, got {len(coeffs)}")  # noqa: TRY003
+    c0, c1, c2, c3 = coeffs
+    x = raw_counts.astype(np.float64) / 16777215.0
+    ln_r = np.log((1.0 - x) / x)
+    inv_tk = c0 + c1 * ln_r + c2 * ln_r**2 + c3 * ln_r**3
+    return 1.0 / inv_tk - 273.15
+
+
+# ---------------------------------------------------------------------------
+# Binary data parsing
+# ---------------------------------------------------------------------------
+
+_EVENT_MARKER_LEN = 12  # \x00\x00\x00 + 3-char tag + 6 BCD bytes
+
+
+def _parse_binary_header(
+    raw: bytes,
+) -> Tuple[datetime.datetime, datetime.datetime, int]:
+    """Parse the 48-byte binary header: returns (log_start, log_end, period_seconds)."""
+    log_start = _bcd_datetime(raw[0:6])
+    log_end = _bcd_datetime(raw[6:12])
+    period_s = _bcd_timedelta(raw[12:15])
+    return log_start, log_end, period_s
+
+
+def _find_events(
+    data: bytes, rec_bytes: int
+) -> List[Tuple[int, str, datetime.datetime]]:
+    """Scan the data section and return [(sample_index, marker, timestamp), ...].
+
+    ``sample_index`` is the 0-based index of the data record immediately
+    following each event (i.e. the record that event anchors).
+    """
+    events: List[Tuple[int, str, datetime.datetime]] = []
+    pos = 0
+    sample_count = 0
+
+    while pos < len(data):
+        # 12-byte event record: \x00\x00\x00 + 3 alpha + 6 BCD bytes
+        if (
+            pos + _EVENT_MARKER_LEN <= len(data)
+            and data[pos : pos + 3] == b"\x00\x00\x00"
+            and data[pos + 3 : pos + 6].isalpha()
+        ):
+            marker = data[pos + 3 : pos + 6].decode("ascii")
+            try:
+                ts = _bcd_datetime(data[pos + 6 : pos + 12])
+                events.append((sample_count, marker, ts))
+            except (ValueError, OverflowError):
+                pass  # malformed timestamp; ignore
+            pos += _EVENT_MARKER_LEN
+        elif pos + rec_bytes <= len(data):
+            sample_count += 1
+            pos += rec_bytes
+        else:
+            break  # trailing partial record
+
+    return events
+
+
+def _build_time_array(
+    n_samples: int,
+    period_s: int,
+    events: List[Tuple[int, str, datetime.datetime]],
+    fallback_start: datetime.datetime,
+) -> np.ndarray:
+    """Return a (n_samples,) datetime64[ms] array.
+
+    Each TIM event anchors its associated sample exactly; samples between
+    consecutive anchors are spaced by ``period_s``.  If no TIM events are
+    found, ``fallback_start`` (logging start from the binary header) is used
+    for sample 0.
+    """
+    times = np.empty(n_samples, dtype="datetime64[ms]")
+    period_ms = int(period_s * 1000)
+
+    # Collect only TIM anchors (exclude STP and other markers)
+    anchors = [(idx, ts) for idx, marker, ts in events if marker == "TIM"]
+
+    if not anchors:
+        # No TIM events — use fallback
+        t0 = np.datetime64(fallback_start, "ms")
+        times[:] = t0 + np.arange(n_samples, dtype="int64") * period_ms
+        return times
+
+    # Fill blocks between consecutive TIM anchors
+    for i, (anchor_idx, anchor_ts) in enumerate(anchors):
+        t0 = np.datetime64(anchor_ts, "ms")
+        next_anchor_idx = anchors[i + 1][0] if i + 1 < len(anchors) else n_samples
+        block_len = next_anchor_idx - anchor_idx
+        if block_len > 0:
+            times[anchor_idx:next_anchor_idx] = (
+                t0 + np.arange(block_len, dtype="int64") * period_ms
+            )
+
+    # Fill any samples before the first TIM anchor (rare, but handle it)
+    first_anchor_idx, first_anchor_ts = anchors[0]
+    if first_anchor_idx > 0:
+        t0 = np.datetime64(first_anchor_ts, "ms") - first_anchor_idx * period_ms
+        times[:first_anchor_idx] = (
+            t0 + np.arange(first_anchor_idx, dtype="int64") * period_ms
+        )
+
+    return times
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def read_rbr_hex(file_path: str | Path) -> xr.Dataset:
+    """Read an RBR binary-hex data file and return an xarray Dataset.
+
+    Parameters
+    ----------
+    file_path : str or Path
+        Path to the ``.hex`` file.
+
+    Returns
+    -------
+    xarray.Dataset
+        - ``time`` coordinate (datetime64[ms]).
+        - ``channel_{n}`` — raw 24-bit ADC counts (uint32) for each channel.
+        - One calibrated variable per channel (e.g. ``temp``) in engineering
+          units, derived via :func:`_apply_rbr_cal` when four coefficients are
+          present in the header.  Global attributes record instrument model,
+          firmware, serial number, logging window, and sample period.
+
+    """
+    file_path = Path(file_path)
+
+    # ------------------------------------------------------------------
+    # Read file and split into text header / hex data
+    # ------------------------------------------------------------------
+    raw_bytes = file_path.read_bytes()
+    text = raw_bytes.decode("latin-1").replace("\r\n", "\n").replace("\r", "\n")
+    lines = text.split("\n")
+
+    # Text header ends just before the '|...|' progress bar line
+    data_start_line = None
+    for i, line in enumerate(lines):
+        if line.startswith("|") and line.count("|") >= 2:
+            data_start_line = i + 1
+            break
+
+    if data_start_line is None:
+        raise ValueError(f"Could not find hex data section in {file_path.name}")  # noqa: TRY003
+
+    meta = _parse_text_header(lines[:data_start_line])
+
+    # Decode hex characters to bytes (strip all non-hex chars)
+    hex_str = re.sub(r"[^0-9A-Fa-f]", "", "".join(lines[data_start_line:]))
+    raw = bytes.fromhex(hex_str)
+
+    # ------------------------------------------------------------------
+    # Binary header (first 48 bytes)
+    # ------------------------------------------------------------------
+    N_HDR = 48
+    log_start, log_end, period_s = _parse_binary_header(raw[:N_HDR])
+
+    # Prefer sample period from binary header; fall back to text header
+    if period_s == 0 and meta.get("sample_period_str"):
+        h, m, s = (int(x) for x in meta["sample_period_str"].split(":"))
+        period_s = h * 3600 + m * 60 + s
+
+    # ------------------------------------------------------------------
+    # Data section
+    # ------------------------------------------------------------------
+    n_channels = meta["n_channels"]
+    n_samples = meta["n_samples"]
+    rec_bytes = 3 * n_channels
+
+    data_section = raw[N_HDR:]
+    events = _find_events(data_section, rec_bytes)
+
+    # ------------------------------------------------------------------
+    # Extract raw channel data into separate arrays
+    # ------------------------------------------------------------------
+    channel_data: List[List[int]] = [[] for _ in range(n_channels)]
+    pos = 0
+
+    while pos < len(data_section):
+        if (
+            pos + _EVENT_MARKER_LEN <= len(data_section)
+            and data_section[pos : pos + 3] == b"\x00\x00\x00"
+            and data_section[pos + 3 : pos + 6].isalpha()
+        ):
+            pos += _EVENT_MARKER_LEN
+        elif pos + rec_bytes <= len(data_section):
+            for ch in range(n_channels):
+                offset = pos + ch * 3
+                val = int.from_bytes(data_section[offset : offset + 3], "big")
+                channel_data[ch].append(val)
+            pos += rec_bytes
+        else:
+            break
+
+    n_actual = len(channel_data[0])
+    if n_actual != n_samples:
+        import warnings
+
+        warnings.warn(
+            f"{file_path.name}: expected {n_samples} samples, decoded {n_actual}. "
+            "Time array built from decoded count.",
+            stacklevel=2,
+        )
+        n_samples = n_actual
+
+    # ------------------------------------------------------------------
+    # Build time coordinate
+    # ------------------------------------------------------------------
+    times = _build_time_array(n_samples, period_s, events, log_start)
+
+    # ------------------------------------------------------------------
+    # Build xarray Dataset
+    # ------------------------------------------------------------------
+    coords = {"time": times}
+    data_vars: Dict[str, xr.Variable] = {}
+
+    # Column names: prefer Channel[N].name (raw.txt format); fall back to column
+    # header line (hex format); final fallback to "Channel N".
+    col_names = meta.get("column_names", [])
+
+    for ch_idx in range(n_channels):
+        ch_num = ch_idx + 1
+        ch_name = (
+            meta["channel_names"].get(ch_num)
+            or (col_names[ch_idx] if ch_idx < len(col_names) else None)
+            or f"Channel {ch_num}"
+        )
+        ch_units = meta["channel_units"].get(ch_num, "")
+        cal = meta["channel_calibration"].get(ch_num, [])
+        raw_arr = np.array(channel_data[ch_idx], dtype=np.uint32)
+
+        # Raw counts (uint32) — always stored as channel_N
+        data_vars[f"channel_{ch_num}"] = xr.Variable(
+            "time",
+            raw_arr,
+            attrs={
+                "long_name": f"{ch_name} raw ADC count",
+                "comment": "Raw 24-bit unsigned integer from instrument.",
+                "calibration_coefficients": " ".join(str(c) for c in cal),
+                "units_after_calibration": ch_units,
+            },
+        )
+
+        # Calibrated engineering-units variable.
+        phys_name = re.sub(r"\W+", "_", ch_name.lower()).strip("_")
+        if phys_name == f"channel_{ch_num}":
+            phys_name = f"channel_{ch_num}_phys"  # avoid overwriting raw variable
+        if len(cal) == 4:
+            phys_data = _apply_rbr_cal(raw_arr, cal)
+            cal_method = (
+                "Steinhart-Hart: x=raw/16777215, R=(1-x)/x, "
+                "1/T_K=c0+c1*ln(R)+c2*ln(R)^2+c3*ln(R)^3, T=1/T_K-273.15"
+            )
+            cal_units = "degC"
+        else:
+            phys_data = raw_arr.astype(np.float64) / 16777215.0
+            cal_method = "raw / 16777215 (calibration not applied: unexpected number of coefficients)"
+            cal_units = ch_units
+        data_vars[phys_name] = xr.Variable(
+            "time",
+            phys_data,
+            attrs={
+                "long_name": ch_name,
+                "units": cal_units,
+                "calibration_method": cal_method,
+                "calibration_coefficients": " ".join(str(c) for c in cal),
+            },
+        )
+
+    global_attrs: Dict = {
+        "instrument_model": meta.get("model", "UNK"),
+        "instrument_firmware": meta.get("firmware", "UNK"),
+        "serial_number": meta.get("serial", "UNK"),
+        "logging_start": str(log_start),
+        "logging_end": str(log_end),
+        "sample_period_seconds": period_s,
+        "n_channels": n_channels,
+        "source_file": file_path.name,
+        "reader": "oceanarray.read_rbr_hex",
+    }
+
+    ds = xr.Dataset(data_vars, coords=coords, attrs=global_attrs)
+    return ds

--- a/oceanarray/report/_grid.py
+++ b/oceanarray/report/_grid.py
@@ -34,12 +34,17 @@ _GRID_HTML_TEMPLATE = """\
   * { box-sizing:border-box; }
   body { font-family:system-ui,-apple-system,"Segoe UI",sans-serif; font-size:14px;
          color:var(--text); max-width:1200px; margin:0 auto; padding:1.5rem 2rem 4rem; }
-  .masthead { background:var(--ocean); color:#fff; padding:1.4rem 2rem;
+  .masthead { background:#8e44ad; color:#fff; padding:1.6rem 2rem;
               border-radius:8px; margin-bottom:2rem; }
-  .masthead h1 { margin:0 0 0.25rem; font-size:1.6rem; font-weight:700; }
-  .masthead .sub { font-size:0.88rem; opacity:0.82; margin:0 0 0.7rem; }
-  .masthead .back { font-size:0.82rem; opacity:0.8; margin:0; }
-  .masthead .back a { color:#fff; }
+  .masthead h1 { margin:0 0 0.3rem; font-size:1.75rem; font-weight:700; letter-spacing:0.02em; }
+  .masthead .sub { font-size:0.9rem; opacity:0.88; margin:0 0 0.15rem; }
+  .masthead .sub a { color:#e8d5ff; font-weight:600; text-decoration:none; }
+  .masthead .sub a:hover { text-decoration:underline; }
+  .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(160px,1fr));
+               gap:0.5rem 2rem; font-size:0.84rem; margin-top:0.9rem; }
+  .meta-grid dt { opacity:0.7; text-transform:uppercase; font-size:0.7rem;
+                  letter-spacing:0.06em; margin-bottom:0.1rem; }
+  .meta-grid dd { margin:0; font-weight:600; }
   h2 { color:var(--ocean); font-size:1rem; border-bottom:2px solid var(--seafoam);
        padding-bottom:0.3rem; margin:2.5rem 0 1rem;
        display:flex; justify-content:space-between; align-items:baseline; }
@@ -77,11 +82,19 @@ _GRID_HTML_TEMPLATE = """\
 
 <div id="top" class="masthead">
   <h1>{{ mooring_name }} &mdash; Gridded data</h1>
-  <p class="sub">{{ deploy_time }} &ndash; {{ recover_time }} &bull; {{ n_levels }} pressure levels &bull; {{ n_time }} time steps</p>
-  <p class="back">
-    <a href="{{ mooring_report_link }}">&#8592; {{ mooring_name }} summary</a>
-    {% if stack_exists %} &bull; <a href="{{ mooring_name }}_stack_report.html">Stack report &#8596;</a>{% endif %}
+  <p class="sub">{{ n_levels }} pressure levels &bull; {{ p_range }} &bull; {{ n_time }} time steps &bull; generated {{ generated }}</p>
+  <p class="sub">
+    <a href="{{ mooring_report_link }}">&#8592; Mooring summary</a>
+    {% if stack_exists %} &bull; <a href="{{ mooring_name }}_stack_report.html">&#8592; Stack report</a>{% endif %}
   </p>
+  <dl class="meta-grid">
+    <div><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
+    <div><dt>Ship</dt><dd>{{ ship }}</dd></div>
+    <div><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>
+    <div><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>
+    <div><dt>Duration</dt><dd>{{ duration }}</dd></div>
+    <div><dt>Water depth</dt><dd>{{ waterdepth }}&thinsp;m</dd></div>
+  </dl>
 </div>
 
 <nav class="jump-nav">
@@ -128,12 +141,7 @@ _GRID_HTML_TEMPLATE = """\
 <h2 {% if loop.first %}id="density" {% endif %}>{{ sec.label }}</h2>
 <p class="note">{{ p_range }} &bull; colour range: {{ sec.plow }}–{{ sec.phigh }} {{ sec.units }} (5th–95th percentile) &bull; 20 discrete levels</p>
 {% if sec.fig_b64 %}
-<p class="style-label">pcolormesh</p>
 <img class="fig" src="data:image/png;base64,{{ sec.fig_b64 }}" alt="{{ sec.label }} pcolormesh">
-{% endif %}
-{% if sec.fig_cf_b64 %}
-<p class="style-label">contourf</p>
-<img class="fig" src="data:image/png;base64,{{ sec.fig_cf_b64 }}" alt="{{ sec.label }} contourf">
 {% endif %}
 {% if sec.isopycnal_zoom_b64 %}
 <h2>Isopycnal depths &mdash; {{ sec.name }} (3-day zoom, unfiltered)</h2>
@@ -183,13 +191,14 @@ _GRID_HTML_TEMPLATE = """\
 <h3 style="font-size:0.88rem;color:var(--ocean);margin:1rem 0 0.4rem;">Variables</h3>
 <table class="var-table">
   <thead>
-    <tr><th>Variable</th><th>Dims</th><th class="num">N</th><th class="num">Valid</th><th class="num">Min / Max</th><th>Units</th><th>Long name</th><th>Standard name</th><th>QC&nbsp;flag</th></tr>
+    <tr><th>Variable</th><th>Type</th><th>Dims</th><th class="num">N</th><th class="num">Valid</th><th class="num">Min / Max</th><th>Units</th><th>Long name</th><th>Standard name</th><th>QC&nbsp;flag</th></tr>
   </thead>
   <tbody>
     {% for v in nc_meta.time_vars %}
     {% if not v.is_qc %}
     <tr>
       <td class="mono">{{ v.name }}</td>
+      <td class="mono" style="font-size:0.75rem">{{ v.dtype }}</td>
       <td class="mono" style="font-size:0.75rem">{{ v.dims }}</td>
       <td class="num">{{ "{:,}".format(v.n) }}</td>
       <td class="num" {% if v.n_valid is defined and v.n_valid < v.n %}style="color:#c0392b;font-weight:600"{% endif %}>{{ "{:,}".format(v.n_valid) if v.n_valid is defined else "&mdash;" }}</td>
@@ -446,9 +455,6 @@ def generate_grid_page(
                     "fig_b64": _make_grid_fig_b64(
                         da, label, units_s, P.DENSITY_COLORMAP
                     ),
-                    "fig_cf_b64": _make_grid_fig_b64(
-                        da, label, units_s, P.DENSITY_COLORMAP, style="contourf"
-                    ),
                     "isopycnal_zoom_b64": _make_isopycnal_fig_b64(
                         da,
                         P.SIGMA_CONTOUR_LEVELS,
@@ -493,8 +499,12 @@ def generate_grid_page(
         env = Environment(autoescape=True)
         html = env.from_string(_GRID_HTML_TEMPLATE).render(
             mooring_name=mooring_name,
+            cruise=ctx.get("cruise", "—"),
+            ship=ctx.get("ship", "—"),
             deploy_time=ctx["deploy_time"],
             recover_time=ctx["recover_time"],
+            duration=ctx.get("duration", "—"),
+            waterdepth=ctx.get("waterdepth", "—"),
             n_levels=n_levels,
             n_time=n_time,
             p_range=p_range,

--- a/oceanarray/report/_html_helpers.py
+++ b/oceanarray/report/_html_helpers.py
@@ -254,6 +254,7 @@ def _read_nc_metadata(nc_path: Path) -> Dict[str, Any]:
                 "v_max": None,
             }
             if v.dims == ():
+                info["dtype"] = str(v.dtype)
                 try:
                     raw = v.values.item()
                     info["value"] = str(raw)[:120]
@@ -262,6 +263,7 @@ def _read_nc_metadata(nc_path: Path) -> Dict[str, Any]:
                 scalar_vars.append(info)
             else:
                 info["dims"] = ", ".join(str(d) for d in v.dims)
+                info["dtype"] = str(v.dtype)
                 info["n"] = int(np.prod(v.shape)) if v.shape else 0
                 arr = v.values
                 if arr.dtype.kind in ("f", "c"):
@@ -433,3 +435,42 @@ def _stage_files(
         "stage2": Path(str(base) + "_stage2.nc").exists(),
         "stage3": Path(str(base) + "_stage3.nc").exists(),
     }
+
+
+def _fmt_size(n_bytes: int) -> str:
+    """Return a human-readable file size string."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if n_bytes < 1024:
+            return f"{n_bytes:.0f} {unit}"
+        n_bytes /= 1024  # type: ignore[assignment]
+    return f"{n_bytes:.1f} GB"
+
+
+def _file_info(path: Path) -> Dict[str, str]:
+    """Return size and mtime for a file path, or empty strings if it doesn't exist."""
+    if not path.exists():
+        return {"exists": False, "name": path.name, "size": "", "mtime": ""}
+    import datetime as _dt
+
+    st = path.stat()
+    mtime = _dt.datetime.fromtimestamp(st.st_mtime, tz=_dt.timezone.utc)
+    return {
+        "exists": True,
+        "name": path.name,
+        "size": _fmt_size(st.st_size),
+        "mtime": mtime.strftime("%Y-%m-%d %H:%M UTC"),
+    }
+
+
+def _stage_file_details(
+    proc_dir: Path, instr_type: str, mooring: str, serial: str
+) -> list:
+    """Return per-stage file info dicts for template rendering."""
+    base = proc_dir / instr_type / f"{mooring}_{serial}"
+    rows = []
+    for stage in ("stage1", "stage2", "stage3"):
+        p = Path(str(base) + f"_{stage}.nc")
+        info = _file_info(p)
+        info["label"] = stage.capitalize()
+        rows.append(info)
+    return rows

--- a/oceanarray/report/_instrument.py
+++ b/oceanarray/report/_instrument.py
@@ -13,6 +13,8 @@ from ._html_helpers import (
     _parse_history,
     _read_qc_summary,
     _read_nc_metadata,
+    _stage_file_details,
+    _file_info,
 )
 from ._plots import (
     _make_instrument_fig,
@@ -46,16 +48,24 @@ _INSTRUMENT_HTML_TEMPLATE = """\
   * { box-sizing: border-box; }
   body { font-family: system-ui,-apple-system,"Segoe UI",sans-serif; font-size:14px;
          color:var(--text); max-width:1150px; margin:0 auto; padding:1.5rem 2rem 4rem; line-height:1.5; }
-  .masthead { background:var(--ocean); color:#fff; padding:1.4rem 2rem;
+  .masthead { background:#27ae60; color:#fff; padding:1.6rem 2rem;
               border-radius:8px; margin-bottom:2rem; }
-  .masthead h1 { margin:0 0 0.25rem; font-size:1.5rem; font-weight:700; }
-  .masthead .back { font-size:0.82rem; opacity:0.8; margin:0 0 0.9rem; }
-  .masthead .back a { color:#fff; }
+  .masthead h1 { margin:0 0 0.3rem; font-size:1.75rem; font-weight:700; letter-spacing:0.02em; }
+  .masthead .sub { font-size:0.9rem; opacity:0.88; margin:0 0 0.15rem; }
+  .masthead .sub a { color:#d5f5e3; font-weight:600; text-decoration:none; }
+  .masthead .sub a:hover { text-decoration:underline; }
   .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(170px,1fr));
-               gap:0.45rem 2rem; font-size:0.83rem; }
-  .meta-grid dt { opacity:0.65; text-transform:uppercase; font-size:0.68rem;
+               gap:0.45rem 2rem; font-size:0.83rem; margin-top:0.9rem; }
+  .meta-grid dt { opacity:0.7; text-transform:uppercase; font-size:0.68rem;
                   letter-spacing:0.06em; margin-bottom:0.1rem; }
   .meta-grid dd { margin:0; font-weight:600; }
+  .file-table { width:100%; border-collapse:collapse; font-size:0.81rem; margin-bottom:1.2rem; }
+  .file-table th { background:var(--seafoam); text-align:left; padding:0.35rem 0.65rem;
+                   border-bottom:2px solid #cde; font-weight:600; }
+  .file-table td { padding:0.3rem 0.65rem; border-bottom:1px solid #eef; vertical-align:middle; }
+  .file-table tr:nth-child(even) td { background:#f4f9fc; }
+  .file-table .ok { color:var(--good); font-weight:700; }
+  .file-table .miss { color:#bbb; }
   h2 { color:var(--ocean); font-size:1rem; border-bottom:2px solid var(--seafoam);
        padding-bottom:0.3rem; margin:2.2rem 0 0.9rem;
        display:flex; justify-content:space-between; align-items:baseline; }
@@ -106,22 +116,21 @@ _INSTRUMENT_HTML_TEMPLATE = """\
 
 <div id="top" class="masthead">
   <h1>{{ instr_type | title }}&ensp;&mdash;&ensp;s/n&nbsp;{{ serial }}</h1>
-  <p class="back"><a href="{{ mooring_report_link }}">&#8592; {{ mooring_name }} summary</a></p>
+  <p class="sub">{{ mooring_name }} &bull; {{ "%.1f"|format(hab) }}&thinsp;m hab{% if depth is not none %} &bull; ~{{ "%.0f"|format(depth) }}&thinsp;m depth{% endif %} &bull; generated {{ generated }}</p>
+  <p class="sub"><a href="{{ mooring_report_link }}">&#8592; Mooring summary</a></p>
   <dl class="meta-grid">
-    <div><dt>Mooring</dt><dd>{{ mooring_name }}</dd></div>
     <div><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
-    <div><dt>Hab</dt><dd>{{ "%.1f"|format(hab) }}&nbsp;m</dd></div>
-    <div><dt>Depth</dt><dd>{% if depth is not none %}{{ "%.0f"|format(depth) }}&nbsp;m{% else %}&mdash;{% endif %}</dd></div>
     <div><dt>Records</dt><dd>{{ n_records | default("&mdash;") }}</dd></div>
     <div><dt>Start</dt><dd>{{ t_start | default("&mdash;") }}</dd></div>
     <div><dt>End</dt><dd>{{ t_end | default("&mdash;") }}</dd></div>
-    <div><dt>Samp.&nbsp;&Delta;t&nbsp;(p90)</dt><dd>{{ median_dt | default("&mdash;") }}</dd></div>
+    <div><dt>Samp.&nbsp;&Delta;t</dt><dd>{{ median_dt | default("&mdash;") }}</dd></div>
     <div><dt>Source&nbsp;file</dt><dd>{{ nc_file }}</dd></div>
   </dl>
 </div>
 
 <nav class="jump-nav">
   Jump to:
+  <a href="#files">Files</a>
   <a href="#history">History</a>
   <a href="#timeseries">Time series</a>
   <a href="#start">Start/end windows</a>
@@ -134,6 +143,41 @@ _INSTRUMENT_HTML_TEMPLATE = """\
   {% if qc_summary %}<a href="#qc">QC flags</a>{% endif %}
   <a href="#vars">Variables</a>
 </nav>
+
+<!-- ══ Files ══ -->
+<h2 id="files">Files</h2>
+<table class="file-table">
+  <thead><tr><th>Stage</th><th>Filename</th><th>Size</th><th>Last modified</th></tr></thead>
+  <tbody>
+  {% if raw_file.exists %}
+  <tr>
+    <td>Raw</td>
+    <td class="mono">{{ raw_file.name }}</td>
+    <td class="num">{{ raw_file.size }}</td>
+    <td>{{ raw_file.mtime }}</td>
+  </tr>
+  {% else %}
+  <tr>
+    <td>Raw</td>
+    <td class="mono miss">{{ raw_file.name }}</td>
+    <td colspan="2" class="miss">&mdash; not found</td>
+  </tr>
+  {% endif %}
+  {% for f in stage_files %}
+  <tr>
+    <td>{{ f.label }}</td>
+    {% if f.exists %}
+    <td class="mono">{{ f.name }}</td>
+    <td class="num">{{ f.size }}</td>
+    <td>{{ f.mtime }}</td>
+    {% else %}
+    <td class="mono miss">{{ f.name }}</td>
+    <td colspan="2" class="miss">&mdash; not generated</td>
+    {% endif %}
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
 
 <!-- ══ Processing history ══ -->
 <h2 id="history">Processing history</h2>
@@ -298,13 +342,14 @@ _INSTRUMENT_HTML_TEMPLATE = """\
 <h3 style="font-size:0.88rem;color:var(--ocean);margin:1rem 0 0.4rem;">Time-series variables</h3>
 <table>
   <thead>
-    <tr><th>Variable</th><th>Dims</th><th class="num">N</th><th class="num">Valid</th><th class="num">Min / Max</th><th>Units</th><th>Long name</th><th>Standard name</th><th>QC&nbsp;flag</th></tr>
+    <tr><th>Variable</th><th>Type</th><th>Dims</th><th class="num">N</th><th class="num">Valid</th><th class="num">Min / Max</th><th>Units</th><th>Long name</th><th>Standard name</th><th>QC&nbsp;flag</th></tr>
   </thead>
   <tbody>
     {% for v in nc_meta.time_vars %}
     {% if not v.is_qc %}
     <tr>
       <td class="mono">{{ v.name }}</td>
+      <td class="mono" style="font-size:0.75rem">{{ v.dtype }}</td>
       <td class="mono" style="font-size:0.75rem">{{ v.dims }}</td>
       <td class="num">{{ "{:,}".format(v.n) }}</td>
       <td class="num" {% if v.n_valid is defined and v.n_valid < v.n %}style="color:#c0392b;font-weight:600"{% endif %}>{{ "{:,}".format(v.n_valid) if v.n_valid is defined else "&mdash;" }}</td>
@@ -323,12 +368,13 @@ _INSTRUMENT_HTML_TEMPLATE = """\
 <h3 style="font-size:0.88rem;color:var(--ocean);margin:1.4rem 0 0.4rem;">Scalar metadata variables</h3>
 <table>
   <thead>
-    <tr><th>Variable</th><th>Value</th><th>Units</th><th>Long name</th></tr>
+    <tr><th>Variable</th><th>Type</th><th>Value</th><th>Units</th><th>Long name</th></tr>
   </thead>
   <tbody>
     {% for v in nc_meta.scalar_vars %}
     <tr>
       <td class="mono">{{ v.name }}</td>
+      <td class="mono" style="font-size:0.75rem">{{ v.dtype }}</td>
       <td class="mono" style="font-size:0.78rem;word-break:break-all">{{ v.value }}</td>
       <td>{{ v.units }}</td>
       <td>{{ v.long_name }}</td>
@@ -433,6 +479,23 @@ def generate_instrument_pages(
             except Exception:
                 pass
 
+        # File listing — raw source and stage1/2/3 NC files
+        raw_filename = instr.get("filename", "")
+        raw_file_path = (
+            base_dir
+            / str(cfg.get("directory", "raw")).rstrip("/")
+            / instr_type
+            / raw_filename
+            if raw_filename
+            else Path("no_raw_file")
+        )
+        raw_file = (
+            _file_info(raw_file_path)
+            if raw_filename
+            else {"exists": False, "name": raw_filename or "—", "size": "", "mtime": ""}
+        )
+        stage_files = _stage_file_details(proc_dir, instr_type, mooring_name, serial)
+
         ctx = {
             "mooring_name": mooring_name,
             "cruise": cruise,
@@ -447,6 +510,8 @@ def generate_instrument_pages(
             "t_end": t_end,
             "median_dt": median_dt,
             "nc_file": nc_file,
+            "raw_file": raw_file,
+            "stage_files": stage_files,
             "mooring_report_link": mooring_report_link,
             "generated": generated,
             "proc_machine": proc_machine,
@@ -461,12 +526,12 @@ def generate_instrument_pages(
             "fig_rose_b64": _make_instrument_rose_b64(best_nc) if best_nc else None,
             "fig_trajectory_b64": (
                 _make_temperature_trajectory(best_nc)
-                if best_nc and "nortek" in instr_type.lower()
+                if best_nc and instr_type.lower() == "aquadopp"
                 else None
             ),
             "fig_speed_boxplot_b64": (
                 _make_speed_boxplot(best_nc)
-                if best_nc and "nortek" in instr_type.lower()
+                if best_nc and instr_type.lower() == "aquadopp"
                 else None
             ),
             "fig_dt_b64": _make_data_histogram(best_nc) if best_nc else None,
@@ -508,7 +573,7 @@ def generate_instrument_pages(
         ctx["analog_yaml_info"] = analog_yaml_info
         # Warn if magnetic declination was not applied (lat/lon missing from YAML)
         ctx["declination_warn"] = (
-            "nortek" in instr_type.lower()
+            instr_type.lower() == "aquadopp"
             and "magnetic_declination" not in ctx["nc_meta"].get("global_attrs", {})
         )
         # True when the NC contains instrument-frame XYZ velocities (rose has XYZ panel)

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -286,7 +286,7 @@ _HTML_TEMPLATE = """\
 </table>
 
 <!-- ════════════════════════════════════ 3. INSTRUMENT SUMMARY ══ -->
-<h2 id="instruments">3 &mdash; Instrument summary</h2>
+<h2 id="instruments">3 &mdash; Instrument summary (using stage3 files)</h2>
 <style>
   .vbadge {
     display: inline-block;

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -1400,7 +1400,7 @@ def _make_rose_grid_b64(
         east_all[qc >= 3] = np.nan
         north_all[qc >= 3] = np.nan
 
-    has_vel = [np.any(np.isfinite(east_all[i])) for i in range(east_all.shape[0])]
+    has_vel = [np.any(np.isfinite(east_all[:, i])) for i in range(east_all.shape[1])]
     aqd_idx = [i for i in range(len(serial_list)) if i < len(has_vel) and has_vel[i]]
     n = len(aqd_idx)
     if n == 0:
@@ -1427,7 +1427,9 @@ def _make_rose_grid_b64(
             title = f"{serial} ({hab_vals[instr_i]:.0f} m)"
         else:
             title = str(serial)
-        _rose_ax(axs_flat[plot_i], east_all[instr_i], north_all[instr_i], title=title)
+        _rose_ax(
+            axs_flat[plot_i], east_all[:, instr_i], north_all[:, instr_i], title=title
+        )
 
     for k in range(n, len(axs_flat)):
         axs_flat[k].set_visible(False)
@@ -1652,17 +1654,18 @@ def _make_analog_timeseries(nc_path: "Path", analog_vars: "List[str]") -> Option
             long_name = ds[vname].attrs.get("long_name", vname)
             ylabel = f"{long_name} ({units})" if units else long_name
 
-            # Stack NC: shape (N_LEVELS, time) — plot each level with finite data
+            # Stack NC: shape (time, N_LEVELS) — plot each level with finite data
             if raw.ndim == 2:
                 n_plotted = 0
-                for lvl_i in range(raw.shape[0]):
-                    row_data = raw[lvl_i]
+                for lvl_i in range(raw.shape[1]):
+                    row_data = raw[:, lvl_i]
                     if np.any(np.isfinite(row_data)):
                         label = None
                         if "serial" in ds.coords:
                             label = str(ds["serial"].values[lvl_i])
                         ax.plot(
-                            time, row_data,
+                            time,
+                            row_data,
                             linewidth=0.8,
                             color=colors[n_plotted % len(colors)],
                             label=label,

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -35,12 +35,17 @@ _STACK_HTML_TEMPLATE = """\
   * { box-sizing:border-box; }
   body { font-family:system-ui,-apple-system,"Segoe UI",sans-serif; font-size:14px;
          color:var(--text); max-width:1200px; margin:0 auto; padding:1.5rem 2rem 4rem; }
-  .masthead { background:var(--ocean); color:#fff; padding:1.4rem 2rem;
+  .masthead { background:#2980b9; color:#fff; padding:1.6rem 2rem;
               border-radius:8px; margin-bottom:2rem; }
-  .masthead h1 { margin:0 0 0.25rem; font-size:1.6rem; font-weight:700; }
-  .masthead .sub { font-size:0.88rem; opacity:0.82; margin:0 0 0.7rem; }
-  .masthead .back { font-size:0.82rem; opacity:0.8; margin:0; }
-  .masthead .back a { color:#fff; }
+  .masthead h1 { margin:0 0 0.3rem; font-size:1.75rem; font-weight:700; letter-spacing:0.02em; }
+  .masthead .sub { font-size:0.9rem; opacity:0.88; margin:0 0 0.15rem; }
+  .masthead .sub a { color:#cef; font-weight:600; text-decoration:none; }
+  .masthead .sub a:hover { text-decoration:underline; }
+  .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(160px,1fr));
+               gap:0.5rem 2rem; font-size:0.84rem; margin-top:0.9rem; }
+  .meta-grid dt { opacity:0.7; text-transform:uppercase; font-size:0.7rem;
+                  letter-spacing:0.06em; margin-bottom:0.1rem; }
+  .meta-grid dd { margin:0; font-weight:600; }
   h2 { color:var(--ocean); font-size:1rem; border-bottom:2px solid var(--seafoam);
        padding-bottom:0.3rem; margin:2.5rem 0 1rem;
        display:flex; justify-content:space-between; align-items:baseline; }
@@ -77,11 +82,19 @@ _STACK_HTML_TEMPLATE = """\
 
 <div id="top" class="masthead">
   <h1>{{ mooring_name }} &mdash; Stacked data</h1>
-  <p class="sub">{{ deploy_time }} &ndash; {{ recover_time }} &bull; {{ n_instr }} instruments &bull; {{ dt_seconds }}s grid &bull; {{ n_time }} time steps</p>
-  <p class="back">
-    <a href="{{ mooring_report_link }}">&#8592; {{ mooring_name }} summary</a>
-    {% if grid_exists %} &bull; <a href="{{ mooring_name }}_grid_report.html">Grid report &#8596;</a>{% endif %}
+  <p class="sub">{{ n_instr }} instruments &bull; {{ dt_seconds }}&thinsp;s grid &bull; {{ n_time }} time steps &bull; generated {{ generated }}</p>
+  <p class="sub">
+    <a href="{{ mooring_report_link }}">&#8592; Mooring summary</a>
+    {% if grid_exists %} &bull; <a href="{{ mooring_name }}_grid_report.html">&#8594; Grid report</a>{% endif %}
   </p>
+  <dl class="meta-grid">
+    <div><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
+    <div><dt>Ship</dt><dd>{{ ship }}</dd></div>
+    <div><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>
+    <div><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>
+    <div><dt>Duration</dt><dd>{{ duration }}</dd></div>
+    <div><dt>Water depth</dt><dd>{{ waterdepth }}&thinsp;m</dd></div>
+  </dl>
 </div>
 
 <nav class="jump-nav">
@@ -250,13 +263,14 @@ _STACK_HTML_TEMPLATE = """\
 <h3 style="font-size:0.88rem;color:var(--ocean);margin:1rem 0 0.4rem;">Variables</h3>
 <table class="var-table">
   <thead>
-    <tr><th>Variable</th><th>Dims</th><th class="num">N</th><th class="num">Valid</th><th class="num">Min / Max</th><th>Units</th><th>Long name</th><th>Standard name</th><th>QC&nbsp;flag</th></tr>
+    <tr><th>Variable</th><th>Type</th><th>Dims</th><th class="num">N</th><th class="num">Valid</th><th class="num">Min / Max</th><th>Units</th><th>Long name</th><th>Standard name</th><th>QC&nbsp;flag</th></tr>
   </thead>
   <tbody>
     {% for v in nc_meta.time_vars %}
     {% if not v.is_qc %}
     <tr>
       <td class="mono">{{ v.name }}</td>
+      <td class="mono" style="font-size:0.75rem">{{ v.dtype }}</td>
       <td class="mono" style="font-size:0.75rem">{{ v.dims }}</td>
       <td class="num">{{ "{:,}".format(v.n) }}</td>
       <td class="num" {% if v.n_valid is defined and v.n_valid < v.n %}style="color:#c0392b;font-weight:600"{% endif %}>{{ "{:,}".format(v.n_valid) if v.n_valid is defined else "&mdash;" }}</td>
@@ -275,12 +289,13 @@ _STACK_HTML_TEMPLATE = """\
 <h3 style="font-size:0.88rem;color:var(--ocean);margin:1.4rem 0 0.4rem;">Scalar metadata variables</h3>
 <table class="var-table">
   <thead>
-    <tr><th>Variable</th><th>Value</th><th>Units</th><th>Long name</th></tr>
+    <tr><th>Variable</th><th>Type</th><th>Value</th><th>Units</th><th>Long name</th></tr>
   </thead>
   <tbody>
     {% for v in nc_meta.scalar_vars %}
     <tr>
       <td class="mono">{{ v.name }}</td>
+      <td class="mono" style="font-size:0.75rem">{{ v.dtype }}</td>
       <td class="mono" style="font-size:0.78rem;word-break:break-all">{{ v.value }}</td>
       <td>{{ v.units }}</td>
       <td>{{ v.long_name }}</td>
@@ -356,7 +371,7 @@ def _make_aquadopp_tilt_panels(ds: Any, step: int = 1) -> Optional[str]:
         )
 
         aq_indices = [
-            i for i, t in enumerate(instr_types) if "nortek" in str(t).lower()
+            i for i, t in enumerate(instr_types) if str(t).lower() == "aquadopp"
         ]
         if not aq_indices:
             return None
@@ -386,17 +401,17 @@ def _make_aquadopp_tilt_panels(ds: Any, step: int = 1) -> Optional[str]:
 
             p_data = r_data = tp_data = None
             if has_pitch:
-                p_data = np.abs(ds["pitch"].values[i, ::step].astype(float))
+                p_data = np.abs(ds["pitch"].values[::step, i].astype(float))
                 if np.any(np.isfinite(p_data)):
                     ax_ts.plot(
                         time_ds, p_data, lw=0.7, color="#2980b9", label="|pitch|"
                     )
             if has_roll:
-                r_data = np.abs(ds["roll"].values[i, ::step].astype(float))
+                r_data = np.abs(ds["roll"].values[::step, i].astype(float))
                 if np.any(np.isfinite(r_data)):
                     ax_ts.plot(time_ds, r_data, lw=0.7, color="#27ae60", label="|roll|")
             if has_tilt_p:
-                tp_data = ds["tilt_from_pressure"].values[i, ::step].astype(float)
+                tp_data = ds["tilt_from_pressure"].values[::step, i].astype(float)
                 if np.any(np.isfinite(tp_data)):
                     ax_ts.plot(
                         time_ds,
@@ -417,7 +432,12 @@ def _make_aquadopp_tilt_panels(ds: Any, step: int = 1) -> Optional[str]:
                 _ref_s = str(ref_serials[i]) if ref_serials is not None else "?"
                 _ref_note = f"  [ref: s/n {_ref_s} @ {ref_habs[i]:.0f} m]"
             ax_ts.set_title(f"s/n {serial}  ({hab:.0f} m hab){_ref_note}")
-            ax_ts.legend(loc="upper right", framealpha=0.8, ncol=3)
+            ax_ts.legend(
+                loc="upper left",
+                bbox_to_anchor=(1.01, 1.0),
+                borderaxespad=0,
+                framealpha=0.8,
+            )
 
             if row < n_panels - 1:
                 ax_ts.tick_params(labelbottom=False)
@@ -469,7 +489,13 @@ def _make_aquadopp_tilt_panels(ds: Any, step: int = 1) -> Optional[str]:
                 ax_sc.set_ylim(bottom=0.0)
                 ax_sc.set_xlabel("tilt (pressure) [°]")
                 ax_sc.set_ylabel("|pitch|, |roll| [°]")
-                ax_sc.legend(loc="upper left", framealpha=0.8, markerscale=3)
+                ax_sc.legend(
+                    loc="upper left",
+                    bbox_to_anchor=(1.01, 1.0),
+                    borderaxespad=0,
+                    framealpha=0.8,
+                    markerscale=3,
+                )
             else:
                 ax_sc.text(
                     0.5,
@@ -566,7 +592,7 @@ def generate_stack_page(
             for i in range(n_instr):
                 serial = _serial_list[i]
                 color = _serial_colors[serial]
-                y = arr[i, ::step]
+                y = arr[::step, i]
                 if not np.any(np.isfinite(y)):
                     continue
                 plotted = True
@@ -590,9 +616,14 @@ def generate_stack_page(
                 except Exception:
                     pass
             n_plotted = sum(
-                1 for i in range(n_instr) if np.any(np.isfinite(arr[i, ::step]))
+                1 for i in range(n_instr) if np.any(np.isfinite(arr[::step, i]))
             )
-            ax.legend(loc="upper right", framealpha=0.8, ncol=max(1, n_plotted // 8))
+            ax.legend(
+                loc="upper left",
+                bbox_to_anchor=(1.01, 1.0),
+                borderaxespad=0,
+                framealpha=0.8,
+            )
             plt.tight_layout()
             b64 = _fig_to_base64(fig)
             plt.close(fig)
@@ -636,7 +667,7 @@ def generate_stack_page(
         _n_rose = 0
         if "east_velocity" in ds.data_vars:
             _ev = ds["east_velocity"].values
-            _n_rose = sum(np.any(np.isfinite(_ev[i])) for i in range(_ev.shape[0]))
+            _n_rose = sum(np.any(np.isfinite(_ev[:, i])) for i in range(_ev.shape[1]))
         _rose_w_map = {1: "33", 2: "50", 3: "66", 4: "83"}
         rose_img_width = _rose_w_map.get(_n_rose, "100")
 
@@ -648,9 +679,9 @@ def generate_stack_page(
                 {round(float(v), 2) for v in _dv if np.isfinite(float(v))}
             )
             if "instrument_type" in ds:
-                # instrument_type is a coord (N_LEVELS); YAML key is "nortek-aqd"
+                # instrument_type is a coord (N_LEVELS); allowed value is "aquadopp"
                 _aqd_mask = np.array(
-                    ["nortek" in str(t).lower() for t in ds["instrument_type"].values]
+                    [str(t).lower() == "aquadopp" for t in ds["instrument_type"].values]
                 )
                 _decl_missing = bool(
                     _aqd_mask.any() and np.any(~np.isfinite(_dv[_aqd_mask]))
@@ -658,7 +689,7 @@ def generate_stack_page(
             # no else — if instrument_type absent, don't warn (can't identify Aquadopps)
         elif "instrument_type" in ds:
             _aqd_mask = np.array(
-                ["nortek" in str(t).lower() for t in ds["instrument_type"].values]
+                [str(t).lower() == "aquadopp" for t in ds["instrument_type"].values]
             )
             _decl_missing = bool(_aqd_mask.any())
         rose_declination_note = (
@@ -671,13 +702,13 @@ def generate_stack_page(
         fig_spacing_b64: Optional[str] = None
         if "pressure" in ds.data_vars and n_instr > 1:
             try:
-                pres_arr = ds["pressure"].values
-                med_p = np.nanmedian(pres_arr, axis=1)
+                pres_arr = ds["pressure"].values  # (time, N_LEVELS)
+                med_p = np.nanmedian(pres_arr, axis=0)  # one value per N_LEVELS
                 sort_idx = np.argsort(med_p)
-                pres_sorted = pres_arr[sort_idx, :]
+                pres_sorted = pres_arr[:, sort_idx]
                 all_spacings: list = []
                 for i in range(1, n_instr):
-                    spacing = pres_sorted[i, :] - pres_sorted[i - 1, :]
+                    spacing = pres_sorted[:, i] - pres_sorted[:, i - 1]
                     valid = spacing[np.isfinite(spacing) & (spacing >= 2.0)]
                     all_spacings.extend(valid.tolist())
                 if all_spacings:
@@ -713,8 +744,12 @@ def generate_stack_page(
         env = Environment(autoescape=True)
         html = env.from_string(_STACK_HTML_TEMPLATE).render(
             mooring_name=mooring_name,
+            cruise=ctx.get("cruise", "—"),
+            ship=ctx.get("ship", "—"),
             deploy_time=ctx["deploy_time"],
             recover_time=ctx["recover_time"],
+            duration=ctx.get("duration", "—"),
+            waterdepth=ctx.get("waterdepth", "—"),
             n_instr=n_instr,
             dt_seconds=dt_seconds,
             n_time=n_time,

--- a/oceanarray/stage1.py
+++ b/oceanarray/stage1.py
@@ -12,7 +12,7 @@ import xarray as xr
 import yaml
 import seasenselib
 from seasenselib.writers import NetCdfWriter
-from .utilities import _status
+from .utilities import _status, cast_output_dtypes
 
 # Suppress noisy INFO/WARNING messages from seasenselib/pycnv.
 logging.getLogger("seasenselib").setLevel(logging.WARNING)
@@ -193,6 +193,7 @@ class MooringProcessor:
         "rbr-rsk",
         "rbr-matlab-legacy",
         "rbr-dat",
+        "rbr-hex-oa",  # internal oceanarray hex reader for TR-1050; use rbr-hex once seasenselib supports it
         "sbe-hex",
     }
 
@@ -324,6 +325,23 @@ class MooringProcessor:
                 )
                 coord_system = "UNK"
             return self._normalize_nortek_variables(ds, coord_system=coord_system)
+
+        if file_type == "rbr-hex-oa":
+            from .read_rbr_hex import read_rbr_hex
+
+            ds = read_rbr_hex(file_path)
+            # Rename column-derived physical variables to canonical oceanarray names.
+            # read_rbr_hex uses the column header as the variable name (e.g. "temp");
+            # raw ADC count variables are always named "channel_N" and kept as-is.
+            rename_map = {}
+            for v in list(ds.data_vars):
+                if v.startswith("channel_"):
+                    continue
+                if "temp" in v.lower():
+                    rename_map[v] = "temperature"
+            if rename_map:
+                ds = ds.rename(rename_map)
+            return ds
 
         kwargs = {}
         if file_type in ("nortek-aqd", "nortek-ascii") and header_path:
@@ -701,7 +719,8 @@ class MooringProcessor:
 
         def _coeff_str(coeffs: Dict[str, Any]) -> str:
             return ", ".join(
-                f"{k}={v}" for k, v in coeffs.items()
+                f"{k}={v}"
+                for k, v in coeffs.items()
                 if k not in ("serialnum", "caldate")
             )
 
@@ -710,6 +729,7 @@ class MooringProcessor:
 
         def _iso_date(raw: str) -> str:
             import datetime
+
             for fmt in ("%d-%b-%y", "%d-%b-%Y"):
                 try:
                     return datetime.datetime.strptime(raw, fmt).strftime("%Y-%m-%d")
@@ -722,48 +742,54 @@ class MooringProcessor:
             tc = cal_coeffs["temperature"]["coefficients"]
             sn = tc.get("serialnum", instr_serial)
             cal_date = _iso_date(tc.get("caldate", "—"))
-            dataset[f"SENSOR_TEMP_{instr_serial}"] = _make_sensor_var({
-                "long_name": "Sea-Bird SBE temperature sensor metadata",
-                "sensor_type": "TEMPERATURE",
-                "sensor_serial_number": sn,
-                "sensor_model": "Sea-Bird SBE temperature sensor",
-                "sensor_calibration_date": cal_date,
-                "TEMPERATURE_calibration_coefficients": _coeff_str(tc),
-                "cf_role": "sensor_id",
-                "coverage_content_type": "auxiliaryInformation",
-            })
+            dataset[f"SENSOR_TEMP_{instr_serial}"] = _make_sensor_var(
+                {
+                    "long_name": "Sea-Bird SBE temperature sensor metadata",
+                    "sensor_type": "TEMPERATURE",
+                    "sensor_serial_number": sn,
+                    "sensor_model": "Sea-Bird SBE temperature sensor",
+                    "sensor_calibration_date": cal_date,
+                    "TEMPERATURE_calibration_coefficients": _coeff_str(tc),
+                    "cf_role": "sensor_id",
+                    "coverage_content_type": "auxiliaryInformation",
+                }
+            )
 
         # Conductivity
         if "conductivity" in cal_coeffs:
             cc = cal_coeffs["conductivity"]["coefficients"]
             sn = cc.get("serialnum", instr_serial)
             cal_date = _iso_date(cc.get("caldate", "—"))
-            dataset[f"SENSOR_CNDC_{instr_serial}"] = _make_sensor_var({
-                "long_name": "Sea-Bird SBE conductivity sensor metadata",
-                "sensor_type": "CONDUCTIVITY",
-                "sensor_serial_number": sn,
-                "sensor_model": "Sea-Bird SBE conductivity sensor",
-                "sensor_calibration_date": cal_date,
-                "CONDUCTIVITY_calibration_coefficients": _coeff_str(cc),
-                "cf_role": "sensor_id",
-                "coverage_content_type": "auxiliaryInformation",
-            })
+            dataset[f"SENSOR_CNDC_{instr_serial}"] = _make_sensor_var(
+                {
+                    "long_name": "Sea-Bird SBE conductivity sensor metadata",
+                    "sensor_type": "CONDUCTIVITY",
+                    "sensor_serial_number": sn,
+                    "sensor_model": "Sea-Bird SBE conductivity sensor",
+                    "sensor_calibration_date": cal_date,
+                    "CONDUCTIVITY_calibration_coefficients": _coeff_str(cc),
+                    "cf_role": "sensor_id",
+                    "coverage_content_type": "auxiliaryInformation",
+                }
+            )
 
         # Pressure
         if "pressure" in cal_coeffs:
             pc = cal_coeffs["pressure"]["coefficients"]
             sn = pc.get("serialnum", instr_serial)
             cal_date = _iso_date(pc.get("caldate", "—"))
-            dataset[f"SENSOR_PRES_{instr_serial}"] = _make_sensor_var({
-                "long_name": "Sea-Bird pressure sensor metadata",
-                "sensor_type": "PRESSURE",
-                "sensor_serial_number": sn,
-                "sensor_model": "Sea-Bird pressure sensor",
-                "sensor_calibration_date": cal_date,
-                "PRESSURE_calibration_coefficients": _coeff_str(pc),
-                "cf_role": "sensor_id",
-                "coverage_content_type": "auxiliaryInformation",
-            })
+            dataset[f"SENSOR_PRES_{instr_serial}"] = _make_sensor_var(
+                {
+                    "long_name": "Sea-Bird pressure sensor metadata",
+                    "sensor_type": "PRESSURE",
+                    "sensor_serial_number": sn,
+                    "sensor_model": "Sea-Bird pressure sensor",
+                    "sensor_calibration_date": cal_date,
+                    "PRESSURE_calibration_coefficients": _coeff_str(pc),
+                    "cf_role": "sensor_id",
+                    "coverage_content_type": "auxiliaryInformation",
+                }
+            )
 
         return dataset
 
@@ -926,7 +952,7 @@ class MooringProcessor:
         return ""
 
     @staticmethod
-    def _safe_serial(serial) -> str:
+    def _safe_serial(serial: str) -> str:
         """Strip characters that are illegal in filenames (e.g. '*' used as a YAML marker)."""
         import re
 
@@ -1231,7 +1257,7 @@ class MooringProcessor:
 
         # Write to NetCDF
         _status("file", str(relative_output))
-        writer = NetCdfWriter(dataset)
+        writer = NetCdfWriter(cast_output_dtypes(dataset))
         writer_params = self._get_netcdf_writer_params()
         writer.write(str(output_file), **writer_params)
 
@@ -1250,6 +1276,7 @@ class MooringProcessor:
             mooring_name: Name of the mooring to process
             output_path: Optional custom output path. If None, uses default structure.
             serials: Optional list of serial numbers to process; if None, process all.
+            force: Re-process even if output already exists.
 
         Returns:
             bool: True if processing completed successfully, False otherwise

--- a/oceanarray/stage2.py
+++ b/oceanarray/stage2.py
@@ -47,7 +47,7 @@ import xarray as xr
 import yaml
 from seasenselib.writers import NetCdfWriter
 
-from .utilities import _status
+from .utilities import _status, cast_output_dtypes, drop_all_zero_vars
 
 
 def _parse_clock_str(s: str) -> Optional[pd.Timestamp]:
@@ -550,7 +550,8 @@ class Stage2Processor:
                 use_filepath.unlink()
 
             # Write the processed dataset
-            writer = NetCdfWriter(dataset)
+            dataset = drop_all_zero_vars(dataset, ["amplitude_beam", "analog_input_"])
+            writer = NetCdfWriter(cast_output_dtypes(dataset))
             writer_params = self._get_netcdf_writer_params()
             writer.write(str(use_filepath), **writer_params)
 

--- a/oceanarray/stage3.py
+++ b/oceanarray/stage3.py
@@ -51,6 +51,8 @@ import numpy as np
 import xarray as xr
 import yaml
 
+from .utilities import cast_output_dtypes, drop_all_zero_vars
+
 
 HAB_THRESHOLD = 2.0  # metres — use near-neighbour below this Δhab
 
@@ -1262,7 +1264,8 @@ class Stage3Processor:
             existing = ds.attrs.get("history", "")
             ds.attrs["history"] = f"{existing}; {entry}" if existing else entry
 
-            ds.to_netcdf(l3_path)
+            ds = drop_all_zero_vars(ds, ["amplitude_beam", "analog_input_"])
+            cast_output_dtypes(ds).to_netcdf(l3_path)
             ds.close()
             self._log(
                 f"  Creating output file: {l3_path.name}  ({'; '.join(qc_summary)})"

--- a/oceanarray/utilities.py
+++ b/oceanarray/utilities.py
@@ -355,3 +355,114 @@ def _nice_colorbar_bounds(vmin: float, vmax: float, n: int = 20) -> np.ndarray:
     mid_aligned = round(mid / nice_step) * nice_step
     lo = mid_aligned - (n / 2) * nice_step
     return np.array([lo + i * nice_step for i in range(n + 1)])
+
+
+# ---------------------------------------------------------------------------
+# Output dtype helpers
+# ---------------------------------------------------------------------------
+
+
+def find_best_dtype(var_name: str, da: xr.DataArray) -> type:
+    """Determine the optimal storage dtype for a variable.
+
+    Parameters
+    ----------
+    var_name : str
+        Variable name.
+    da : xr.DataArray
+        Data array to inspect.
+
+    Returns
+    -------
+    type
+        Recommended numpy dtype.
+
+    Notes
+    -----
+    Rules applied in order:
+
+    - String / datetime / object variables: unchanged.
+    - ``time`` in name: unchanged (preserve datetime64 / float encoding).
+    - ``*_qc`` suffix or ``flag`` in name: ``int8``.
+    - ``serial_number`` or ``serial``: ``int32``.
+    - ``latitude`` / ``longitude`` in name: ``float64``.
+    - Integer input: downsize to ``int32`` if stored as ``int64``, else unchanged.
+    - ``float64`` input: ``float32``.
+    - Anything else: unchanged.
+
+    """
+    input_dtype = da.dtype.type
+    if da.dtype.kind in ("U", "S", "O", "M"):
+        return input_dtype
+    if "time" in var_name.lower():
+        return input_dtype
+    if var_name.endswith("_qc") or "flag" in var_name:
+        return np.int8
+    if var_name in ("serial_number", "serial"):
+        return np.int32
+    if "latitude" in var_name.lower() or "longitude" in var_name.lower():
+        return np.float64
+    if da.dtype.kind in ("i", "u") and da.dtype.itemsize == 8:
+        return np.int32
+    if input_dtype == np.float64:
+        return np.float32
+    return input_dtype
+
+
+def drop_all_zero_vars(ds: xr.Dataset, prefixes: list[str]) -> xr.Dataset:
+    """Drop variables whose finite values are all zero.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset to filter.
+    prefixes : list of str
+        Variable name prefixes to check (e.g. ``["amplitude_beam", "analog_input_"]``).
+        Any variable whose name starts with one of these prefixes and whose
+        finite values are all zero (or has no finite values) is dropped.
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset with all-zero prefix-matched variables removed.
+
+    """
+    to_drop = []
+    for vname in ds.data_vars:
+        if not any(vname.startswith(p) for p in prefixes):
+            continue
+        arr = ds[vname].values
+        finite = arr[np.isfinite(arr)] if np.issubdtype(arr.dtype, np.floating) else arr
+        if finite.size == 0 or np.all(finite == 0):
+            to_drop.append(vname)
+    return ds.drop_vars(to_drop) if to_drop else ds
+
+
+def cast_output_dtypes(ds: xr.Dataset) -> xr.Dataset:
+    """Cast every variable in *ds* to its optimal storage dtype.
+
+    Calls :func:`find_best_dtype` per variable and rebuilds only those that
+    change.  Attributes are preserved.  The input dataset is not modified.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset to cast.
+
+    Returns
+    -------
+    xr.Dataset
+        New dataset with optimised dtypes, ready for NetCDF output.
+
+    """
+    updates: dict[str, xr.Variable] = {}
+    for vname in ds.data_vars:
+        var = ds[vname]
+        target = find_best_dtype(vname, var)
+        if np.dtype(target) != var.dtype:
+            updates[vname] = xr.Variable(
+                var.dims, var.values.astype(target), attrs=var.attrs
+            )
+    if not updates:
+        return ds
+    return ds.assign(updates)


### PR DESCRIPTION
  ## Summary
  
  - New RBR HEX reader (`read_rbr_hex.py`): reads TR-1050 binary-hex files from Ruskin, parses BCD-encoded timestamps, applies Steinhart-Hart calibration polynomial from header coefficients; exposed via CLI and wired into stage1.  **will be incorporated into seasenselib**
  - Output dtype optimisation (`utilities.py`): find_best_dtype / cast_output_dtypes applied at every write site in stage1/2/3, mooring_level.py.  QC flags → int8, physics → float32, lat/lon → float64, serial numbers → int32.  drop_all_zero_vars removes uninstrumented amplitude_beam* and analog_input_* channels from stage2/3 and stacked output; velocity_beam* always dropped from the stacked file.
  - Stacked file dimension order (`mooring_level.py`): flipped from (N_LEVELS, time) to (time, N_LEVELS) per OceanSITES convention. Grid step, all report/plot code updated to match.  Both _stack.nc and _grid.nc now written with zlib compression (complevel=5).
  - Report header cards: colour-coded mastheads matching pipeline badge colours — stack reports blue (#2980b9), grid reports purple  (#8e44ad), per-instrument reports green (#27ae60). All three now include a rich meta-grid (cruise, ship, deployment/recovery dates, duration, water depth) and cross-navigation links.
  - Per-instrument report: new Files section (before Processing history) listing raw source file and stage1/2/3 NC files with size and last-modified timestamp.
  - Grid report: density sections now show pcolormesh only (contourf panel removed).
  - Aquadopp plot attribution (`plotters/_current.py`): plot_multi_aquadopp_trajectories and plot_aquadopp_speed_profile docstrings note adaptation from 02_aqdp_ploter.py by L. Moscatel (lmoscat), Universitat de Barcelona.

  Test plan

  - [x] Run stage1 on a TR-1050 HEX file; verify temp variable, calibration_method attr, and correct temperature values
  - [x] Re-run stack + grid on a mooring; confirm _stack.nc dims are (time, N_LEVELS), files are compressed, beam/zero-channel vars absent
  - [x] Regenerate all four report types; verify header card colours, meta-grid fields, file table in instrument report, no contourf in grid
  density section
  - [x] ruff check . passes *(mostly)* clean