### PR TITLE
[FIX/FEAT] Bug fixes and report header cards

### DIFF
--- a/oceanarray/plotters/_current.py
+++ b/oceanarray/plotters/_current.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 from typing import Optional
 
+import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from matplotlib.collections import LineCollection
 
 from oceanarray.plotters._primitives import plot_trajectory
+from oceanarray.utilities import _nice_colorbar_bounds
 
 
 def plot_temperature_trajectory(
@@ -217,11 +219,12 @@ def plot_multi_aquadopp_trajectories(
     cmap = plt.get_cmap("coolwarm")
     if has_temp and all_temps:
         flat = np.concatenate(all_temps)
-        norm: plt.Normalize = plt.Normalize(
-            vmin=float(np.nanmin(flat)), vmax=float(np.nanmax(flat))
+        _bounds = _nice_colorbar_bounds(
+            float(np.nanmin(flat)), float(np.nanmax(flat)), n=20
         )
     else:
-        norm = plt.Normalize(vmin=0, vmax=1)
+        _bounds = _nice_colorbar_bounds(0.0, 1.0, n=20)
+    norm: mcolors.BoundaryNorm = mcolors.BoundaryNorm(_bounds, ncolors=256)
 
     fig, ax = plt.subplots(figsize=(6, 5))
 
@@ -235,7 +238,7 @@ def plot_multi_aquadopp_trajectories(
             lc = LineCollection(
                 segments, cmap=cmap, norm=norm, linewidth=1.5, alpha=0.85
             )
-            lc.set_array(temp)
+            lc.set_array(temp[:-1])
             ax.add_collection(lc)
             end_color = cmap(
                 norm(float(np.nanmedian(temp[-max(1, len(temp) // 20) :])))
@@ -275,7 +278,9 @@ def plot_multi_aquadopp_trajectories(
         sm.set_array([])
         units = ds[temp_var].attrs.get("units", "°C")
         long_name = ds[temp_var].attrs.get("long_name", "Temperature")
-        fig.colorbar(sm, ax=ax, label=f"{long_name} ({units})", shrink=0.75)
+        fig.colorbar(
+            sm, ax=ax, label=f"{long_name} ({units})", shrink=0.75, ticks=_bounds
+        )
 
     ax.autoscale_view()
     ax.set_xlabel("East displacement (m)")

--- a/oceanarray/plotters/_primitives.py
+++ b/oceanarray/plotters/_primitives.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 from typing import Optional
 
+import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import LineCollection
+
+from ..utilities import _nice_colorbar_bounds
 
 
 def plot_trajectory(
@@ -64,11 +67,12 @@ def plot_trajectory(
         segments = np.concatenate([points[:-1], points[1:]], axis=1)
         vmin = np.nanmin(color_data)
         vmax = np.nanmax(color_data)
-        norm = plt.Normalize(vmin=vmin, vmax=vmax)
+        bounds = _nice_colorbar_bounds(vmin, vmax, n=20)
+        norm = mcolors.BoundaryNorm(bounds, ncolors=256)
         lc = LineCollection(segments, cmap=cmap, norm=norm, linewidth=1.5)
-        lc.set_array(color_data)
+        lc.set_array(color_data[:-1])
         ax.add_collection(lc)
-        fig.colorbar(lc, ax=ax, label=colorbar_label, shrink=0.8)
+        fig.colorbar(lc, ax=ax, label=colorbar_label, shrink=0.8, ticks=bounds)
         ax.set_xlim(
             np.nanmin(x) - 0.05 * (np.nanmax(x) - np.nanmin(x) + 1),
             np.nanmax(x) + 0.05 * (np.nanmax(x) - np.nanmin(x) + 1),

--- a/oceanarray/rapid_interp.py
+++ b/oceanarray/rapid_interp.py
@@ -599,8 +599,8 @@ def interpolate_profiles(
 
     """
     # Check if the climatology dataset has the required variables
-    utilities._check_necessary_variables(clim_ds, vars=["dTdp", "dSdp"])
-    utilities._check_necessary_variables(
+    utilities.check_necessary_variables(clim_ds, vars=["dTdp", "dSdp"])
+    utilities.check_necessary_variables(
         ds, vars=[temp_key, salt_key, "LATITUDE", "LONGITUDE"]
     )
 

--- a/oceanarray/report/_grid.py
+++ b/oceanarray/report/_grid.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from ._html_helpers import _parse_history, _read_nc_metadata, _status
+from ._html_helpers import _nav_buttons_html, _parse_history, _read_nc_metadata, _status
 from ._plots import (
     _make_grid_fig_b64,
     _make_grid_ts_diagram,
@@ -40,11 +40,12 @@ _GRID_HTML_TEMPLATE = """\
   .masthead .sub { font-size:0.9rem; opacity:0.88; margin:0 0 0.15rem; }
   .masthead .sub a { color:#e8d5ff; font-weight:600; text-decoration:none; }
   .masthead .sub a:hover { text-decoration:underline; }
-  .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(160px,1fr));
+  .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr));
                gap:0.5rem 2rem; font-size:0.84rem; margin-top:0.9rem; }
   .meta-grid dt { opacity:0.7; text-transform:uppercase; font-size:0.7rem;
                   letter-spacing:0.06em; margin-bottom:0.1rem; }
   .meta-grid dd { margin:0; font-weight:600; }
+  .meta-miss dd { color:#e67e22; opacity:1; }
   h2 { color:var(--ocean); font-size:1rem; border-bottom:2px solid var(--seafoam);
        padding-bottom:0.3rem; margin:2.5rem 0 1rem;
        display:flex; justify-content:space-between; align-items:baseline; }
@@ -81,19 +82,25 @@ _GRID_HTML_TEMPLATE = """\
 <body>
 
 <div id="top" class="masthead">
-  <h1>{{ mooring_name }} &mdash; Gridded data</h1>
-  <p class="sub">{{ n_levels }} pressure levels &bull; {{ p_range }} &bull; {{ n_time }} time steps &bull; generated {{ generated }}</p>
-  <p class="sub">
-    <a href="{{ mooring_report_link }}">&#8592; Mooring summary</a>
-    {% if stack_exists %} &bull; <a href="{{ mooring_name }}_stack_report.html">&#8592; Stack report</a>{% endif %}
-  </p>
+  <h1 style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem"><span>{{ mooring_name }}</span><span style="font-size:1.2rem;opacity:0.8;white-space:nowrap">Gridded</span></h1>
+  <p class="sub" style="text-align:right">generated {{ generated }}</p>
+  {{ nav_buttons | safe }}
   <dl class="meta-grid">
-    <div><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
-    <div><dt>Ship</dt><dd>{{ ship }}</dd></div>
-    <div><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>
-    <div><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>
-    <div><dt>Duration</dt><dd>{{ duration }}</dd></div>
-    <div><dt>Water depth</dt><dd>{{ waterdepth }}&thinsp;m</dd></div>
+    <div{% if cruise == '—' %} class="meta-miss"{% endif %}><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
+    <div{% if ship == '—' %} class="meta-miss"{% endif %}><dt>Ship</dt><dd>{{ ship }}</dd></div>
+    <div{% if latitude == '—' %} class="meta-miss"{% endif %}><dt>Latitude</dt><dd>{{ latitude }}</dd></div>
+    <div{% if longitude == '—' %} class="meta-miss"{% endif %}><dt>Longitude</dt><dd>{{ longitude }}</dd></div>
+    <div{% if waterdepth == '—' %} class="meta-miss"{% endif %}><dt>Water depth</dt><dd>{{ waterdepth }}{% if waterdepth != '—' %}&thinsp;m{% endif %}</dd></div>
+    <div{% if deploy_time == '—' %} class="meta-miss"{% endif %}><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>
+    <div{% if recover_time == '—' %} class="meta-miss"{% endif %}><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>
+    <div{% if duration == '—' %} class="meta-miss"{% endif %}><dt>Duration</dt><dd>{{ duration }}</dd></div>
+    <div{% if grid_dt_s == '—' %} class="meta-miss"{% endif %}><dt>Samp.&nbsp;&Delta;t</dt><dd>{{ grid_dt_s }}{% if grid_dt_s != '—' %}&thinsp;s{% endif %}</dd></div>
+    <div><dt>Records</dt><dd>{{ n_time }}</dd></div>
+    <div{% if grid_dp == '—' %} class="meta-miss"{% endif %}><dt>Grid&nbsp;&Delta;P</dt><dd>{{ grid_dp }}</dd></div>
+    <div><dt>Pressure&nbsp;levels</dt><dd>{{ n_levels }}</dd></div>
+    <div><dt>Pressure&nbsp;range</dt><dd>{{ p_range }}</dd></div>
+    <div><dt>Instruments</dt><dd>{{ n_instr }}</dd></div>
+    <div><dt>Source&nbsp;file</dt><dd>{{ nc_file }}</dd></div>
   </dl>
 </div>
 
@@ -290,6 +297,17 @@ def generate_grid_page(
         n_time = ds.sizes["time"]
         p_min, p_max = int(pressure.min()), int(pressure.max())
         p_range = f"{p_min}–{p_max} dbar"
+        grid_dp = (
+            f"{int(round(float(np.median(np.diff(pressure)))))} dbar"
+            if len(pressure) > 1
+            else "—"
+        )
+        if n_time > 1:
+            dt_arr = np.diff(ds["time"].values) / np.timedelta64(1, "s")
+            grid_dt_s = str(int(np.median(dt_arr)))
+        else:
+            grid_dt_s = "—"
+        n_instr = ctx.get("n_instruments", "—")
         grid_history = _parse_history(ds.attrs.get("history", ""))
 
         # Temperature
@@ -499,6 +517,13 @@ def generate_grid_page(
         env = Environment(autoescape=True)
         html = env.from_string(_GRID_HTML_TEMPLATE).render(
             mooring_name=mooring_name,
+            nav_buttons=_nav_buttons_html(
+                mooring_name,
+                ctx.get("instruments", []),
+                stack_exists=stack_exists,
+                grid_exists=True,
+                current_report="grid",
+            ),
             cruise=ctx.get("cruise", "—"),
             ship=ctx.get("ship", "—"),
             deploy_time=ctx["deploy_time"],
@@ -527,6 +552,11 @@ def generate_grid_page(
             fig_spectrum_b64=fig_spectrum_b64,
             fig_ts_grid_b64=fig_ts_grid_b64,
             fig_n2_b64=fig_n2_b64,
+            latitude=ctx.get("latitude", "—"),
+            longitude=ctx.get("longitude", "—"),
+            n_instr=n_instr,
+            grid_dt_s=grid_dt_s,
+            grid_dp=grid_dp,
             generated=ctx["generated"],
             proc_machine=ctx.get("proc_machine", ""),
         )

--- a/oceanarray/report/_html_helpers.py
+++ b/oceanarray/report/_html_helpers.py
@@ -474,3 +474,116 @@ def _stage_file_details(
         info["label"] = stage.capitalize()
         rows.append(info)
     return rows
+
+
+def _nav_buttons_html(
+    mooring_name: str,
+    instruments: List[Dict[str, Any]],
+    stack_exists: bool = True,
+    grid_exists: bool = True,
+    current_report: str = "",
+) -> str:
+    """Return an HTML navigation snippet for injection into report masthead cards.
+
+    Parameters
+    ----------
+    mooring_name : str
+        Mooring identifier used to build sibling report filenames.
+    instruments : list of dict
+        Each dict must have ``serial`` and ``instr_type`` keys (the format
+        produced by ``MooringReport._build_context()``).
+    stack_exists : bool
+        Whether the stack report is available.
+    grid_exists : bool
+        Whether the grid report is available.
+    current_report : str
+        Which report this snippet is rendered in — ``"summary"``, ``"stack"``,
+        ``"grid"``, or a serial number string for per-instrument reports.
+        The matching pill is shown as a non-clickable chip (greyed out).
+
+    Returns
+    -------
+    str
+        HTML fragment safe for ``{{ nav_buttons | safe }}`` in Jinja2 templates.
+
+    """
+    import html as _html
+
+    mn = _html.escape(mooring_name)
+
+    _BTN = (
+        "display:inline-block;padding:0.2em 0.65em;border-radius:4px;"
+        "font-size:0.78rem;font-weight:700;text-decoration:none;"
+        "color:#fff;margin:0 0.2rem 0.25rem 0;white-space:nowrap;"
+    )
+    _CHIP = (
+        "display:inline-block;padding:0.2em 0.65em;border-radius:4px;"
+        "font-size:0.78rem;font-weight:700;color:#fff;"
+        "margin:0 0.2rem 0.25rem 0;white-space:nowrap;opacity:0.45;"
+    )
+    _LABEL = (
+        "font-size:0.72rem;opacity:0.75;margin-right:0.3rem;"
+        "white-space:nowrap;vertical-align:middle;"
+    )
+
+    def _pill(label: str, href: str, bg: str, is_current: bool) -> str:
+        esc = _html.escape(label)
+        if is_current:
+            return f'<span style="{_CHIP}background:{bg}">{esc}</span>'
+        return f'<a href="{href}" style="{_BTN}background:{bg}">{esc}</a>'
+
+    parts = ['<div style="margin-top:0.65rem">']
+
+    # Row 1: report-level navigation (Summary / Stack / Grid)
+    parts.append('<div style="margin-bottom:0.25rem">')
+    parts.append(f'<span style="{_LABEL}">Reports:</span>')
+    parts.append(
+        _pill("Summary", f"{mn}_report.html", "#1a3a5c", current_report == "summary")
+    )
+    if stack_exists:
+        parts.append(
+            _pill(
+                "Stack",
+                f"{mn}_stack_report.html",
+                "#2980b9",
+                current_report == "stack",
+            )
+        )
+    if grid_exists:
+        parts.append(
+            _pill(
+                "Grid",
+                f"{mn}_grid_report.html",
+                "#8e44ad",
+                current_report == "grid",
+            )
+        )
+    parts.append("</div>")
+
+    # Row 2: per-instrument buttons grouped by instrument type
+    by_type: Dict[str, List[str]] = {}
+    for instr in instruments:
+        itype = str(instr.get("instr_type", instr.get("instrument", "other"))).lower()
+        ser = str(instr.get("serial", ""))
+        if itype not in by_type:
+            by_type[itype] = []
+        by_type[itype].append(ser)
+
+    for itype, serials_of_type in by_type.items():
+        parts.append('<div style="margin-bottom:0.1rem">')
+        parts.append(
+            f'<span style="{_LABEL}">{_html.escape(itype.capitalize())}:</span>'
+        )
+        for ser in serials_of_type:
+            parts.append(
+                _pill(
+                    ser,
+                    f"{mn}_{_html.escape(ser)}_report.html",
+                    "#27ae60",
+                    current_report == ser,
+                )
+            )
+        parts.append("</div>")
+
+    parts.append("</div>")
+    return "".join(parts)

--- a/oceanarray/report/_instrument.py
+++ b/oceanarray/report/_instrument.py
@@ -9,12 +9,15 @@ from typing import Any, Dict, List, Optional
 
 
 from ._html_helpers import (
-    _safe_serial,
-    _parse_history,
-    _read_qc_summary,
-    _read_nc_metadata,
-    _stage_file_details,
+    _duration_str,
     _file_info,
+    _nav_buttons_html,
+    _parse_dt,
+    _parse_history,
+    _read_nc_metadata,
+    _read_qc_summary,
+    _safe_serial,
+    _stage_file_details,
 )
 from ._plots import (
     _make_instrument_fig,
@@ -48,17 +51,18 @@ _INSTRUMENT_HTML_TEMPLATE = """\
   * { box-sizing: border-box; }
   body { font-family: system-ui,-apple-system,"Segoe UI",sans-serif; font-size:14px;
          color:var(--text); max-width:1150px; margin:0 auto; padding:1.5rem 2rem 4rem; line-height:1.5; }
-  .masthead { background:#27ae60; color:#fff; padding:1.6rem 2rem;
+  .masthead { background:#1e8449; color:#fff; padding:1.6rem 2rem;
               border-radius:8px; margin-bottom:2rem; }
   .masthead h1 { margin:0 0 0.3rem; font-size:1.75rem; font-weight:700; letter-spacing:0.02em; }
   .masthead .sub { font-size:0.9rem; opacity:0.88; margin:0 0 0.15rem; }
   .masthead .sub a { color:#d5f5e3; font-weight:600; text-decoration:none; }
   .masthead .sub a:hover { text-decoration:underline; }
-  .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(170px,1fr));
+  .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr));
                gap:0.45rem 2rem; font-size:0.83rem; margin-top:0.9rem; }
   .meta-grid dt { opacity:0.7; text-transform:uppercase; font-size:0.68rem;
                   letter-spacing:0.06em; margin-bottom:0.1rem; }
   .meta-grid dd { margin:0; font-weight:600; }
+  .meta-miss dd { color:#e67e22; opacity:1; }
   .file-table { width:100%; border-collapse:collapse; font-size:0.81rem; margin-bottom:1.2rem; }
   .file-table th { background:var(--seafoam); text-align:left; padding:0.35rem 0.65rem;
                    border-bottom:2px solid #cde; font-weight:600; }
@@ -116,14 +120,17 @@ _INSTRUMENT_HTML_TEMPLATE = """\
 
 <div id="top" class="masthead">
   <h1>{{ instr_type | title }}&ensp;&mdash;&ensp;s/n&nbsp;{{ serial }}</h1>
-  <p class="sub">{{ mooring_name }} &bull; {{ "%.1f"|format(hab) }}&thinsp;m hab{% if depth is not none %} &bull; ~{{ "%.0f"|format(depth) }}&thinsp;m depth{% endif %} &bull; generated {{ generated }}</p>
-  <p class="sub"><a href="{{ mooring_report_link }}">&#8592; Mooring summary</a></p>
+  <p class="sub" style="display:flex;justify-content:space-between"><span>{{ mooring_name }}</span><span>generated {{ generated }}</span></p>
+  {{ nav_buttons | safe }}
   <dl class="meta-grid">
-    <div><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
-    <div><dt>Records</dt><dd>{{ n_records | default("&mdash;") }}</dd></div>
-    <div><dt>Start</dt><dd>{{ t_start | default("&mdash;") }}</dd></div>
-    <div><dt>End</dt><dd>{{ t_end | default("&mdash;") }}</dd></div>
-    <div><dt>Samp.&nbsp;&Delta;t</dt><dd>{{ median_dt | default("&mdash;") }}</dd></div>
+    <div{% if cruise == '—' %} class="meta-miss"{% endif %}><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
+    <div><dt>HAB</dt><dd>{{ "%.1f"|format(hab) }}&thinsp;m</dd></div>
+    <div{% if depth is none %} class="meta-miss"{% endif %}><dt>Depth</dt><dd>{% if depth is not none %}~{{ "%.0f"|format(depth) }}&thinsp;m{% else %}&mdash;{% endif %}</dd></div>
+    <div{% if t_start is none or t_start == '—' %} class="meta-miss"{% endif %}><dt>Start</dt><dd>{{ t_start | default("—") }}</dd></div>
+    <div{% if t_end is none or t_end == '—' %} class="meta-miss"{% endif %}><dt>End</dt><dd>{{ t_end | default("—") }}</dd></div>
+    <div{% if duration == '—' %} class="meta-miss"{% endif %}><dt>Duration</dt><dd>{{ duration }}</dd></div>
+    <div{% if median_dt is none or median_dt == '—' %} class="meta-miss"{% endif %}><dt>Samp.&nbsp;&Delta;t</dt><dd>{{ median_dt | default("—") }}</dd></div>
+    <div{% if n_records is none or n_records == '—' %} class="meta-miss"{% endif %}><dt>Records</dt><dd>{{ n_records | default("—") }}</dd></div>
     <div><dt>Source&nbsp;file</dt><dd>{{ nc_file }}</dd></div>
   </dl>
 </div>
@@ -433,6 +440,8 @@ def generate_instrument_pages(
     mooring_report_link = f"{mooring_name}_report.html"
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     proc_machine = socket.gethostname().split(".")[0]
+    stack_exists = (proc_dir / f"{mooring_name}_stack.nc").exists()
+    grid_exists = (proc_dir / f"{mooring_name}_grid.nc").exists()
     _d = cfg.get("deployment_cruise") or cfg.get("cruise", "—")
     _r = cfg.get("recovery_cruise") or cfg.get("cruise") or _d
     cruise = _d if _d == _r else f"{_d} / {_r}"
@@ -468,6 +477,7 @@ def generate_instrument_pages(
         t_end = nc_info.get("t_end", "—")
         dt_s = nc_info.get("dt_s")
         median_dt = f"{dt_s:.0f} s" if dt_s and dt_s == dt_s else "—"
+        duration = _duration_str(_parse_dt(t_start), _parse_dt(t_end))
 
         history_entries: List[Dict[str, str]] = []
         if best_nc:
@@ -508,11 +518,19 @@ def generate_instrument_pages(
             ),
             "t_start": t_start,
             "t_end": t_end,
+            "duration": duration,
             "median_dt": median_dt,
             "nc_file": nc_file,
             "raw_file": raw_file,
             "stage_files": stage_files,
             "mooring_report_link": mooring_report_link,
+            "nav_buttons": _nav_buttons_html(
+                mooring_name,
+                instruments,
+                stack_exists=stack_exists,
+                grid_exists=grid_exists,
+                current_report=serial,
+            ),
             "generated": generated,
             "proc_machine": proc_machine,
             "history_entries": history_entries,

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -16,6 +16,7 @@ from ._html_helpers import (
     _fmt_dt,
     _get_proc_dir,
     _load_pdf_b64,
+    _nav_buttons_html,
     _parse_dt,
     _raw_file_path,
     _read_instrument_info,
@@ -81,6 +82,7 @@ _HTML_TEMPLATE = """\
   }
   .meta-grid dt { opacity: 0.68; text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.06em; margin-bottom: 0.1rem; }
   .meta-grid dd { margin: 0; font-weight: 600; }
+  .meta-miss dd { color: #e67e22; opacity: 1; }
   /* section headings */
   h2 {
     color: var(--ocean);
@@ -157,21 +159,18 @@ _HTML_TEMPLATE = """\
 
 <!-- ══════════════════════════════════════════════ 1. HEADER ══ -->
 <div id="top" class="masthead">
-  <h1>{{ mooring_name }}</h1>
-  <p class="sub">Mooring recovery report &mdash; generated {{ generated }}</p>
-  {% if stack_exists or grid_exists %}<p class="sub" style="margin-top:0.2rem">
-    {% if stack_exists %}<a href="{{ mooring_name }}_stack_report.html" style="color:#aee;font-weight:600">&#8594; Stack report</a>{% endif %}
-    {% if stack_exists and grid_exists %} &bull; {% endif %}
-    {% if grid_exists %}<a href="{{ mooring_name }}_grid_report.html" style="color:#aee;font-weight:600">&#8594; Grid report</a>{% endif %}
-  </p>{% endif %}
+  <h1 style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem"><span>{{ mooring_name }}</span><span style="font-size:1.2rem;opacity:0.8;white-space:nowrap">Summary</span></h1>
+  <p class="sub" style="display:flex;justify-content:space-between"><span>Mooring recovery report</span><span>generated {{ generated }}</span></p>
+  {{ nav_buttons | safe }}
   <dl class="meta-grid">
-    <div><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
-    <div><dt>Ship</dt><dd>{{ ship }}</dd></div>
-    <div><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>
-    <div><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>
-    <div><dt>Duration</dt><dd>{{ duration }}</dd></div>
-    <div><dt>Water depth</dt><dd>{{ waterdepth }} m</dd></div>
-    <div><dt>Location</dt><dd>{{ latitude }}, {{ longitude }}</dd></div>
+    <div{% if cruise == '—' %} class="meta-miss"{% endif %}><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
+    <div{% if ship == '—' %} class="meta-miss"{% endif %}><dt>Ship</dt><dd>{{ ship }}</dd></div>
+    <div{% if latitude == '—' %} class="meta-miss"{% endif %}><dt>Latitude</dt><dd>{{ latitude }}</dd></div>
+    <div{% if longitude == '—' %} class="meta-miss"{% endif %}><dt>Longitude</dt><dd>{{ longitude }}</dd></div>
+    <div{% if waterdepth == '—' %} class="meta-miss"{% endif %}><dt>Water depth</dt><dd>{{ waterdepth }}{% if waterdepth != '—' %}&thinsp;m{% endif %}</dd></div>
+    <div{% if deploy_time == '—' %} class="meta-miss"{% endif %}><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>
+    <div{% if recover_time == '—' %} class="meta-miss"{% endif %}><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>
+    <div{% if duration == '—' %} class="meta-miss"{% endif %}><dt>Duration</dt><dd>{{ duration }}</dd></div>
     <div><dt>Instruments</dt><dd>{{ n_instruments }}</dd></div>
   </dl>
 </div>
@@ -804,6 +803,13 @@ class MooringReport:
             "stack_exists": stack_exists,
             "grid_exists": grid_exists,
             "any_clock_correction": any_clock,
+            "nav_buttons": _nav_buttons_html(
+                mooring_name,
+                instruments,
+                stack_exists=stack_exists,
+                grid_exists=grid_exists,
+                current_report="summary",
+            ),
             "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
             "proc_machine": socket.gethostname().split(".")[0],
             "yaml_path": str(yaml_path.relative_to(self.base_dir)),

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -7,7 +7,13 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from ._html_helpers import _fig_to_base64, _parse_history, _read_nc_metadata, _status
+from ._html_helpers import (
+    _fig_to_base64,
+    _nav_buttons_html,
+    _parse_history,
+    _read_nc_metadata,
+    _status,
+)
 from ._plots import (
     _make_rose_grid_b64,
     _make_stack_ts_diagram,
@@ -41,11 +47,12 @@ _STACK_HTML_TEMPLATE = """\
   .masthead .sub { font-size:0.9rem; opacity:0.88; margin:0 0 0.15rem; }
   .masthead .sub a { color:#cef; font-weight:600; text-decoration:none; }
   .masthead .sub a:hover { text-decoration:underline; }
-  .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(160px,1fr));
+  .meta-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr));
                gap:0.5rem 2rem; font-size:0.84rem; margin-top:0.9rem; }
   .meta-grid dt { opacity:0.7; text-transform:uppercase; font-size:0.7rem;
                   letter-spacing:0.06em; margin-bottom:0.1rem; }
   .meta-grid dd { margin:0; font-weight:600; }
+  .meta-miss dd { color:#e67e22; opacity:1; }
   h2 { color:var(--ocean); font-size:1rem; border-bottom:2px solid var(--seafoam);
        padding-bottom:0.3rem; margin:2.5rem 0 1rem;
        display:flex; justify-content:space-between; align-items:baseline; }
@@ -81,19 +88,22 @@ _STACK_HTML_TEMPLATE = """\
 <body>
 
 <div id="top" class="masthead">
-  <h1>{{ mooring_name }} &mdash; Stacked data</h1>
-  <p class="sub">{{ n_instr }} instruments &bull; {{ dt_seconds }}&thinsp;s grid &bull; {{ n_time }} time steps &bull; generated {{ generated }}</p>
-  <p class="sub">
-    <a href="{{ mooring_report_link }}">&#8592; Mooring summary</a>
-    {% if grid_exists %} &bull; <a href="{{ mooring_name }}_grid_report.html">&#8594; Grid report</a>{% endif %}
-  </p>
+  <h1 style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem"><span>{{ mooring_name }}</span><span style="font-size:1.2rem;opacity:0.8;white-space:nowrap">Stacked</span></h1>
+  <p class="sub" style="text-align:right">generated {{ generated }}</p>
+  {{ nav_buttons | safe }}
   <dl class="meta-grid">
-    <div><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
-    <div><dt>Ship</dt><dd>{{ ship }}</dd></div>
-    <div><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>
-    <div><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>
-    <div><dt>Duration</dt><dd>{{ duration }}</dd></div>
-    <div><dt>Water depth</dt><dd>{{ waterdepth }}&thinsp;m</dd></div>
+    <div{% if cruise == '—' %} class="meta-miss"{% endif %}><dt>Cruise</dt><dd>{{ cruise }}</dd></div>
+    <div{% if ship == '—' %} class="meta-miss"{% endif %}><dt>Ship</dt><dd>{{ ship }}</dd></div>
+    <div{% if latitude == '—' %} class="meta-miss"{% endif %}><dt>Latitude</dt><dd>{{ latitude }}</dd></div>
+    <div{% if longitude == '—' %} class="meta-miss"{% endif %}><dt>Longitude</dt><dd>{{ longitude }}</dd></div>
+    <div{% if waterdepth == '—' %} class="meta-miss"{% endif %}><dt>Water depth</dt><dd>{{ waterdepth }}{% if waterdepth != '—' %}&thinsp;m{% endif %}</dd></div>
+    <div{% if deploy_time == '—' %} class="meta-miss"{% endif %}><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>
+    <div{% if recover_time == '—' %} class="meta-miss"{% endif %}><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>
+    <div{% if duration == '—' %} class="meta-miss"{% endif %}><dt>Duration</dt><dd>{{ duration }}</dd></div>
+    <div{% if dt_seconds == '—' %} class="meta-miss"{% endif %}><dt>Samp.&nbsp;&Delta;t</dt><dd>{{ dt_seconds }}{% if dt_seconds != '—' %}&thinsp;s{% endif %}</dd></div>
+    <div><dt>Records</dt><dd>{{ n_time }}</dd></div>
+    <div><dt>Instruments</dt><dd>{{ n_instr }}</dd></div>
+    <div><dt>Source&nbsp;file</dt><dd>{{ nc_file }}</dd></div>
   </dl>
 </div>
 
@@ -744,6 +754,13 @@ def generate_stack_page(
         env = Environment(autoescape=True)
         html = env.from_string(_STACK_HTML_TEMPLATE).render(
             mooring_name=mooring_name,
+            nav_buttons=_nav_buttons_html(
+                mooring_name,
+                ctx.get("instruments", []),
+                stack_exists=True,
+                grid_exists=grid_exists,
+                current_report="stack",
+            ),
             cruise=ctx.get("cruise", "—"),
             ship=ctx.get("ship", "—"),
             deploy_time=ctx["deploy_time"],
@@ -755,6 +772,8 @@ def generate_stack_page(
             n_time=n_time,
             mooring_report_link=f"{mooring_name}_report.html",
             grid_exists=grid_exists,
+            latitude=ctx.get("latitude", "—"),
+            longitude=ctx.get("longitude", "—"),
             history_entries=stack_history,
             instr_rows=instr_rows,
             nc_meta=nc_meta,

--- a/oceanarray/stage3.py
+++ b/oceanarray/stage3.py
@@ -149,31 +149,44 @@ def _apply_beam_to_enu(
 
     # Magnetic declination via ppigrf
     declination = 0.0
-    try:
-        import ppigrf
-        import datetime as _dt
-
-        time_vals = ds["time"].values
-        t_mid = time_vals[len(time_vals) // 2]
-        t_mid_s = int(t_mid.astype("datetime64[s]").astype("int64"))
-        t_mid_dt = _dt.datetime.utcfromtimestamp(t_mid_s)
-        Be, Bn, _ = ppigrf.igrf(float(lon), float(lat), 0.0, t_mid_dt)
-        declination = float(
-            np.degrees(
-                np.arctan2(float(np.atleast_1d(Be)[0]), float(np.atleast_1d(Bn)[0]))
-            )
+    if lat == 0.0 and lon == 0.0 and "unknown" in latlon_source.lower():
+        _warn(
+            f"  WARNING: BEAM→ENU — lat/lon unknown for serial {entry.get('serial', '?')}. "
+            "Skipping magnetic declination to avoid silently applying the Gulf of Guinea value. "
+            "Set lat/lon in the mooring YAML to get a correct declination correction."
         )
-        ds.attrs["magnetic_declination"] = declination
-        ds.attrs["magnetic_declination_units"] = "degrees_east"
-        ds.attrs["magnetic_declination_method"] = "ppigrf IGRF at deployment midpoint"
-        ds.attrs["magnetic_declination_lat"] = lat
-        ds.attrs["magnetic_declination_lon"] = lon
+        ds.attrs["magnetic_declination"] = "UNK"
         ds.attrs["magnetic_declination_latlon_source"] = (
             f"mooring YAML ({latlon_source})"
         )
-        _warn(f"  BEAM→ENU: magnetic declination = {declination:.2f}°")
-    except Exception as e:  # noqa: BLE001  — ppigrf optional; proceed with 0° declination
-        _warn(f"  WARNING: magnetic declination unavailable ({e}) — using 0°")
+    else:
+        try:
+            import ppigrf
+            import datetime as _dt
+
+            time_vals = ds["time"].values
+            t_mid = time_vals[len(time_vals) // 2]
+            t_mid_s = int(t_mid.astype("datetime64[s]").astype("int64"))
+            t_mid_dt = _dt.datetime.utcfromtimestamp(t_mid_s)
+            Be, Bn, _ = ppigrf.igrf(float(lon), float(lat), 0.0, t_mid_dt)
+            declination = float(
+                np.degrees(
+                    np.arctan2(float(np.atleast_1d(Be)[0]), float(np.atleast_1d(Bn)[0]))
+                )
+            )
+            ds.attrs["magnetic_declination"] = declination
+            ds.attrs["magnetic_declination_units"] = "degrees_east"
+            ds.attrs["magnetic_declination_method"] = (
+                "ppigrf IGRF at deployment midpoint"
+            )
+            ds.attrs["magnetic_declination_lat"] = lat
+            ds.attrs["magnetic_declination_lon"] = lon
+            ds.attrs["magnetic_declination_latlon_source"] = (
+                f"mooring YAML ({latlon_source})"
+            )
+            _warn(f"  BEAM→ENU: magnetic declination = {declination:.2f}°")
+        except Exception as e:  # noqa: BLE001  — ppigrf optional; proceed with 0° declination
+            _warn(f"  WARNING: magnetic declination unavailable ({e}) — using 0°")
 
     if coord_sys == "BEAM":
         # Stage1 could not apply the T matrix (header file missing or unparseable).
@@ -324,6 +337,18 @@ def _apply_declination_to_enu(
         return ds  # already applied
 
     if "east_velocity" not in ds.data_vars or "north_velocity" not in ds.data_vars:
+        return ds
+
+    if lat == 0.0 and lon == 0.0 and "unknown" in latlon_source.lower():
+        _warn(
+            "  WARNING: ENU declination correction skipped — lat/lon unknown. "
+            "Applying declination from (0°N, 0°E) would silently rotate velocities by "
+            "the Gulf of Guinea value. Set lat/lon in the mooring YAML."
+        )
+        ds.attrs["magnetic_declination"] = "UNK"
+        ds.attrs["magnetic_declination_latlon_source"] = (
+            f"mooring YAML ({latlon_source})"
+        )
         return ds
 
     try:

--- a/oceanarray/utilities.py
+++ b/oceanarray/utilities.py
@@ -67,7 +67,7 @@ def concat_with_scalar_vars(
     return combined
 
 
-def _check_necessary_variables(ds: xr.Dataset, vars: list) -> None:
+def check_necessary_variables(ds: xr.Dataset, vars: list) -> None:
     """Check that all required variables are present in a dataset.
 
     Parameters

--- a/tests/test_plotters.py
+++ b/tests/test_plotters.py
@@ -201,3 +201,26 @@ def test_show_attributes_from_dataset():
     df = plotters.show_attributes(ds)
     assert "Attribute" in df.columns
     assert "Value" in df.columns
+
+
+def test_plot_trajectory_lc_array_length():
+    """LineCollection colour array must have N-1 entries for N trajectory points."""
+    import matplotlib.pyplot as plt
+    from matplotlib.collections import LineCollection
+
+    from oceanarray.plotters._primitives import plot_trajectory
+
+    x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    y = np.array([0.0, 1.0, 0.0, -1.0, 0.0])
+    color = np.linspace(5.0, 25.0, 5)  # N=5 values → N-1=4 segments
+
+    fig = plot_trajectory(x, y, color_data=color)
+    ax = fig.axes[0]
+    lcs = [c for c in ax.collections if isinstance(c, LineCollection)]
+    assert lcs, "expected a LineCollection in the trajectory figure"
+    arr = lcs[0].get_array()
+    assert len(arr) == len(x) - 1, (
+        f"LineCollection has {len(arr)} colour values for {len(x)} points; "
+        f"expected {len(x) - 1} (one per segment)"
+    )
+    plt.close(fig)

--- a/tests/test_stage3.py
+++ b/tests/test_stage3.py
@@ -1,0 +1,70 @@
+"""Tests for stage3 processing functions."""
+
+import numpy as np
+import xarray as xr
+
+from oceanarray.stage3 import _apply_declination_to_enu
+
+
+def _make_enu_dataset():
+    """Minimal dataset with east/north velocity and a time coordinate."""
+    time = np.array(["2020-06-15T12:00:00"], dtype="datetime64[ns]")
+    return xr.Dataset(
+        {
+            "east_velocity": ("time", np.array([0.1])),
+            "north_velocity": ("time", np.array([0.05])),
+        },
+        coords={"time": time},
+    )
+
+
+def test_declination_guard_unknown_position():
+    """When lat/lon are (0, 0) with unknown source, skip declination and store 'UNK'."""
+    ds = _make_enu_dataset()
+    result = _apply_declination_to_enu(
+        ds,
+        lat=0.0,
+        lon=0.0,
+        latlon_source="unknown (defaulting to 0, 0)",
+    )
+    assert result.attrs.get("magnetic_declination") == "UNK"
+    # Velocities must be unmodified
+    np.testing.assert_array_equal(result["east_velocity"].values, [0.1])
+    np.testing.assert_array_equal(result["north_velocity"].values, [0.05])
+
+
+def test_declination_guard_only_triggers_on_unknown_source():
+    """A real (0, 0) position with a non-'unknown' source should not be blocked."""
+    ds = _make_enu_dataset()
+    # source doesn't contain 'unknown' → guard must NOT fire
+    # (ppigrf may or may not be installed; we only check the guard path here)
+    result = _apply_declination_to_enu(
+        ds,
+        lat=0.0,
+        lon=0.0,
+        latlon_source="seabed GPS fix",  # not 'unknown'
+    )
+    # Guard did not fire → magnetic_declination is numeric (or missing if ppigrf absent)
+    decl = result.attrs.get("magnetic_declination")
+    assert decl != "UNK", "guard should not fire for a non-unknown source string"
+
+
+def test_declination_skipped_if_already_applied():
+    """If magnetic_declination attr already exists, _apply_declination_to_enu is a no-op."""
+    ds = _make_enu_dataset()
+    ds.attrs["magnetic_declination"] = 5.0
+    ds["east_velocity"].values[0] = 0.1
+    result = _apply_declination_to_enu(ds, lat=55.0, lon=-20.0)
+    # No change — already applied
+    np.testing.assert_array_equal(result["east_velocity"].values, [0.1])
+
+
+def test_declination_skipped_if_no_velocity():
+    """Dataset without east/north velocity is returned unchanged."""
+    time = np.array(["2020-06-15T12:00:00"], dtype="datetime64[ns]")
+    ds = xr.Dataset(
+        {"temperature": ("time", np.array([5.0]))},
+        coords={"time": time},
+    )
+    result = _apply_declination_to_enu(ds, lat=55.0, lon=-20.0)
+    assert "magnetic_declination" not in result.attrs

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,19 +1,13 @@
-from oceanarray import logger, utilities
-
-# Sample data
-VALID_URL = "https://rapid.ac.uk/sites/default/files/rapid_data/"
-INVALID_URL = "ftdp://invalid-url.com/data.nc"
-INVALID_STRING = "not_a_valid_source"
-
-logger.disable_logging()
-
 from datetime import datetime
 
 import numpy as np
 import pytest
 import xarray as xr
 
-from oceanarray.utilities import iso8601_duration_from_seconds
+from oceanarray import logger, utilities
+from oceanarray.utilities import drop_all_zero_vars, iso8601_duration_from_seconds
+
+logger.disable_logging()
 
 
 def test_concat_with_scalar_vars_preserves_scalars():
@@ -27,13 +21,13 @@ def test_concat_with_scalar_vars_preserves_scalars():
 
 def test_check_necessary_variables_pass():
     ds = xr.Dataset({"TEMP": ("TIME", [1, 2, 3]), "PRES": ("TIME", [10, 20, 30])})
-    utilities._check_necessary_variables(ds, ["TEMP", "PRES"])  # Should not raise
+    utilities.check_necessary_variables(ds, ["TEMP", "PRES"])
 
 
 def test_check_necessary_variables_fail():
     ds = xr.Dataset({"TEMP": ("TIME", [1, 2, 3])})
     with pytest.raises(KeyError):
-        utilities._check_necessary_variables(ds, ["TEMP", "PRES"])
+        utilities.check_necessary_variables(ds, ["TEMP", "PRES"])
 
 
 def test_get_time_key_standard():
@@ -62,13 +56,6 @@ def test_get_dims_basic():
     assert time_key == "TIME"
     assert pres_dim == "DEPTH"
     assert time_dim == "TIME"
-
-
-def test_iso8601_duration_from_seconds():
-    assert utilities.iso8601_duration_from_seconds(3600) == "PT1H"
-    assert utilities.iso8601_duration_from_seconds(65) == "PT1M"
-    assert utilities.iso8601_duration_from_seconds(5) == "PT5S"
-    assert utilities.iso8601_duration_from_seconds(86400) == "P1D"
 
 
 def test_is_iso8601_utc_valid_formats():
@@ -116,3 +103,60 @@ def test_is_iso8601_utc():
     assert utilities.is_iso8601_utc("2023-06-09T12:00:00Z")
     assert utilities.is_iso8601_utc("2023/06/09T12:00:00Z")
     assert not utilities.is_iso8601_utc("2023-06-09 12:00:00")
+
+
+# ---------------------------------------------------------------------------
+# drop_all_zero_vars
+# ---------------------------------------------------------------------------
+
+
+def test_drop_all_zero_vars_drops_all_zero_float():
+    ds = xr.Dataset(
+        {
+            "amplitude_beam1": ("time", np.zeros(5, dtype=float)),
+            "temperature": ("time", np.ones(5)),
+        }
+    )
+    out = drop_all_zero_vars(ds, ["amplitude_beam"])
+    assert "amplitude_beam1" not in out.data_vars
+    assert "temperature" in out.data_vars
+
+
+def test_drop_all_zero_vars_keeps_mixed_float():
+    ds = xr.Dataset(
+        {
+            "amplitude_beam1": ("time", np.array([0.0, 1.0, 0.0])),
+        }
+    )
+    out = drop_all_zero_vars(ds, ["amplitude_beam"])
+    assert "amplitude_beam1" in out.data_vars
+
+
+def test_drop_all_zero_vars_all_nan_dropped():
+    ds = xr.Dataset(
+        {
+            "amplitude_beam1": ("time", np.array([np.nan, np.nan, np.nan])),
+        }
+    )
+    out = drop_all_zero_vars(ds, ["amplitude_beam"])
+    assert "amplitude_beam1" not in out.data_vars
+
+
+def test_drop_all_zero_vars_integer_zero_dropped():
+    ds = xr.Dataset(
+        {
+            "amplitude_beam1": ("time", np.zeros(5, dtype=np.int16)),
+        }
+    )
+    out = drop_all_zero_vars(ds, ["amplitude_beam"])
+    assert "amplitude_beam1" not in out.data_vars
+
+
+def test_drop_all_zero_vars_nonmatching_prefix_kept():
+    ds = xr.Dataset(
+        {
+            "temperature": ("time", np.zeros(5)),
+        }
+    )
+    out = drop_all_zero_vars(ds, ["amplitude_beam"])
+    assert "temperature" in out.data_vars


### PR DESCRIPTION
### Bug fixes
  - `plotters/_current.py`, `plotters/_primitives.py`: replace continuous plt.Normalize colorbars with BoundaryNorm(_nice_colorbar_bounds(..., n=20)) for discrete-colorbar rule; fix LineCollection.set_array() receiving N colours for N−1 segments (off-by-one  that caused a matplotlib warning and clipped the last segment colour)
  - `stage3.py`: guard `_apply_beam_to_enu` and `_apply_declination_to_enu` against silently applying the Gulf of Guinea declination (~−1°) when lat/lon are unknown; stores magnetic_declination = "UNK" and skips rotation with a loud warning instead
  - `report/_grid.py`: fix grid sample-interval computation (timedelta64 was cast to datetime64[s] giving nanosecond values instead of seconds)
  - `utilities.py`: rename `_check_necessary_variables` → `check_necessary_variables` (make public); update callers in rapid_interp.py

### Report header card overhaul (all four report types — summary, stack, grid,
  per-instrument)
  - Shared `_nav_buttons_html()` helper in report/_html_helpers.py: generates cross-report navigation pill buttons (Summary / Stack / Grid in report colours; per-instrument pills grouped by type, one row per instrument type)
  - Canonical meta-grid entry order across all reports: Cruise → Ship → Lat → Lon → Water depth → Deployment/Start → Recovery/End → Duration → Δt → Records → [Grid: ΔP / Levels / Range] → Instruments → Source file
  - Missing-value indicator: entries where the value is "—" or None get class="meta-miss"; CSS colours the <dd> amber (#e67e22); unit suffixes suppressed when missing to avoid "— m" artefacts
  - Instrument: masthead darkened #27ae60 → #1e8449 so serial-number pills remain visible; Duration added (computed from Start/End); HAB and Depth moved from sub-line into meta-grid

###  Test plan

  - [x] Regenerate a summary, stack, grid, and at least one per-instrument report; verify nav buttons link correctly between reports
  - [x] Confirm meta-grid entries appear in canonical order and column count is ~4 at normal browser width
  - [x] Run pytest tests/test_stage3.py tests/test_plotters.py tests/test_utilities.py -v — all pass
  - [x] Run ruff check . — clean