### PR TITLE
[FEAT] ADCP integration to pipeline + reports

### DIFF
--- a/oceanarray/mooring_level.py
+++ b/oceanarray/mooring_level.py
@@ -45,17 +45,14 @@ STACK_VARS = [
     "velocity_beam1",
     "velocity_beam2",
     "velocity_beam3",
-    "amplitude_beam1",
-    "amplitude_beam2",
-    "amplitude_beam3",
-    "correlation_beam1",
-    "correlation_beam2",
-    "correlation_beam3",
     "heading",
     "pitch",
     "roll",
     "analog_input_1",
     "analog_input_2",
+    "percent_good_qc",
+    "error_velocity_qc",
+    "seabed_qc",
 ]
 
 # Variables passed through without QC masking at the stack step.
@@ -72,12 +69,6 @@ _STACK_RAW: frozenset = frozenset(
         "velocity_beam1",
         "velocity_beam2",
         "velocity_beam3",
-        "amplitude_beam1",
-        "amplitude_beam2",
-        "amplitude_beam3",
-        "correlation_beam1",
-        "correlation_beam2",
-        "correlation_beam3",
         "heading",
         "pitch",
         "roll",
@@ -86,12 +77,22 @@ _STACK_RAW: frozenset = frozenset(
         "up_velocity_qc",
         "pitch_qc",
         "roll_qc",
+        "percent_good_qc",
+        "error_velocity_qc",
+        "seabed_qc",
     }
 )
 
 
 def _safe_serial(serial: Any) -> str:
-    return re.sub(r"[^\w\-]", "", str(serial))
+    """Sanitise a serial number string for use in filenames.
+
+    If the raw YAML value contains a comma (e.g. ``16430, R01-024``), only
+    the first comma-separated token is used — the remainder is a beacon ID
+    or annotation and is not part of the filename.
+    """
+    s = str(serial).split(",")[0]
+    return re.sub(r"[^\w\-]", "", s)
 
 
 def _dms_to_deg(s: str) -> float:
@@ -248,6 +249,102 @@ def _detect_interval_s(time_vals: np.ndarray) -> float:
     return float(np.median(dt))
 
 
+# Variables measured at the ADCP transducer head (point measurements, not per-bin).
+# These must NOT appear in per-bin datasets — they belong only in the head entry.
+_ADCP_HEAD_VARS: frozenset = frozenset(
+    {
+        "temperature",
+        "temperature_qc",
+        "heading",
+        "pitch",
+        "roll",
+        "battery_voltage",
+        "speed_of_sound",
+        "analog_input_1",
+        "analog_input_2",
+    }
+)
+
+
+def _make_adcp_head_ds(ds_parent: xr.Dataset) -> xr.Dataset:
+    """Create a 1-D point-instrument view of the ADCP transducer head.
+
+    Keeps only time-series variables that are measured at the instrument head
+    (temperature, heading, pitch, roll, transducer pressure) — NOT the per-bin
+    velocity or bin_pressure arrays.  This entry represents the instrument's
+    physical location in the stack alongside the velocity bin entries.
+    """
+    keep = [
+        v
+        for v in ds_parent.data_vars
+        if v in _ADCP_HEAD_VARS and ds_parent[v].dims == ("time",)
+    ]
+    # Also keep the instrument-head pressure if present (1-D, not bin_pressure)
+    if "pressure" in ds_parent.data_vars and ds_parent["pressure"].dims == ("time",):
+        if "pressure" not in keep:
+            keep.append("pressure")
+    return ds_parent[keep]
+
+
+def _make_adcp_bin_ds(ds_parent: xr.Dataset, bin_idx: int) -> xr.Dataset:
+    """Create a 1-D point-instrument view of ADCP data for one range bin.
+
+    Slices the parent dataset at *bin_idx* along ``P.ADCP_BIN_DIM``, replaces
+    the transducer ``pressure`` with ``bin_pressure[:, bin_idx]``, computes
+    ``current_speed`` and ``current_direction``, and drops any remaining
+    variables that still have non-time dimensions (e.g. beam-dimension arrays
+    ``amplitude``, ``correlation``, ``percent_good``).
+
+    Instrument-head variables (temperature, heading, pitch, roll — see
+    ``_ADCP_HEAD_VARS``) are dropped here; they belong only in the separate
+    head entry added to the stack by the expansion loop.
+
+    The result is compatible with ``_nearest_subsample`` and ``_linear_interp``
+    because every data variable has dimension ``("time",)`` or is scalar.
+    """
+    bin_dim = P.ADCP_BIN_DIM
+    ds_bin = ds_parent.isel({bin_dim: bin_idx}, drop=True)
+
+    # Drop head-only variables — these belong in the separate head entry
+    head_to_drop = [v for v in _ADCP_HEAD_VARS if v in ds_bin.data_vars]
+    if head_to_drop:
+        ds_bin = ds_bin.drop_vars(head_to_drop)
+
+    if "bin_pressure" in ds_bin.data_vars:
+        ds_bin = ds_bin.assign(
+            pressure=xr.Variable(
+                "time",
+                ds_bin["bin_pressure"].values.astype(np.float32),
+                {"units": "dbar", "long_name": "Pressure at ADCP bin"},
+            )
+        ).drop_vars("bin_pressure")
+
+    if "east_velocity" in ds_bin.data_vars and "north_velocity" in ds_bin.data_vars:
+        e = ds_bin["east_velocity"].values.astype(float)
+        n = ds_bin["north_velocity"].values.astype(float)
+        ds_bin = ds_bin.assign(
+            current_speed=xr.Variable(
+                "time",
+                np.hypot(e, n).astype(np.float32),
+                {"units": "m s-1", "long_name": "Current speed"},
+            ),
+            current_direction=xr.Variable(
+                "time",
+                (np.degrees(np.arctan2(e, n)) % 360.0).astype(np.float32),
+                {
+                    "units": "degrees",
+                    "long_name": "Current direction (oceanographic, 0=N clockwise)",
+                },
+            ),
+        )
+
+    to_drop = [v for v in ds_bin.data_vars if any(d != "time" for d in ds_bin[v].dims)]
+    if to_drop:
+        ds_bin = ds_bin.drop_vars(to_drop)
+
+    return ds_bin
+
+
 def _nearest_subsample(
     ds: xr.Dataset,
     common_time: np.ndarray,
@@ -376,9 +473,12 @@ class MooringStacker:
         ).astype("datetime64[ns]")
         n_time = len(common_time)
 
-        instrument_list = mooring_config.get(
-            "clamp", mooring_config.get("instruments", [])
+        from .utilities import extract_inline_instruments
+
+        instrument_list = list(
+            mooring_config.get("clamp", mooring_config.get("instruments", []))
         )
+        instrument_list += extract_inline_instruments(mooring_config.get("inline", []))
 
         # Collect instruments with known hab and an available stage2/stage3 file
         instruments = []
@@ -418,6 +518,103 @@ class MooringStacker:
 
         # Sort deep-first (ascending hab: smallest hab = nearest bottom = deepest)
         instruments.sort(key=lambda x: x["hab"])
+
+        # ── Expand ADCP instruments into per-bin pseudo-instruments ───────
+        # Each ADCP bin becomes a separate row in the stack, with its own
+        # bin_pressure, velocity, and QC time series sliced from the 2-D
+        # (time, N_BINS) arrays in the parent stage3 file.
+        # The parent file is loaded once and cached; _make_adcp_bin_ds slices it.
+        _adcp_parent_datasets: Dict[str, xr.Dataset] = {}
+        expanded: List[Dict] = []
+        for info in instruments:
+            if info["instrument"].lower() != "adcp":
+                expanded.append(info)
+                continue
+            nc_key = str(info["nc_path"])
+            if nc_key not in _adcp_parent_datasets:
+                try:
+                    _adcp_parent_datasets[nc_key] = xr.open_dataset(
+                        info["nc_path"], decode_timedelta=False
+                    ).load()
+                except Exception as e:  # noqa: BLE001  — bad ADCP file must not abort stack
+                    print(f"  WARNING: Could not load ADCP {info['nc_path'].name}: {e}")
+                    expanded.append(info)
+                    continue
+            ds_adcp = _adcp_parent_datasets[nc_key]
+            bin_dim = P.ADCP_BIN_DIM
+            if bin_dim not in ds_adcp.dims:
+                print(
+                    f"  WARNING: ADCP s/n {info['serial']} has no {bin_dim} dim "
+                    "— treating as point instrument"
+                )
+                expanded.append(info)
+                continue
+            n_bins = ds_adcp.dims[bin_dim]
+            range_vals = (
+                ds_adcp["range"].values
+                if "range" in ds_adcp.coords
+                else np.arange(n_bins, dtype=float)
+            )
+            orientation = ds_adcp.attrs.get("orientation_yaml") or ds_adcp.attrs.get(
+                "orientation_instrument", "down"
+            )
+            looking_down = str(orientation).lower() == "down"
+            # Pre-compute seabed mask so always-submerged bins can be skipped.
+            # seabed_qc has dims (time, N_BINS); a bin is permanently below the
+            # seabed when every time step is flagged suspect or worse (>= 3).
+            _seabed_qc_vals = (
+                ds_adcp["seabed_qc"].values
+                if "seabed_qc" in ds_adcp.data_vars
+                else None
+            )
+
+            n_skipped = 0
+            valid_bins = []
+            for i in range(n_bins):
+                if _seabed_qc_vals is not None and np.all(_seabed_qc_vals[:, i] >= 3):
+                    n_skipped += 1
+                else:
+                    valid_bins.append(i)
+
+            print(
+                f"  ADCP s/n {info['serial']}: expanding {len(valid_bins)} of {n_bins} bins "
+                f"({orientation}-looking) into stack + head entry"
+                + (
+                    f" [{n_skipped} bins always below seabed, skipped]"
+                    if n_skipped
+                    else ""
+                )
+            )
+
+            # Head entry — transducer location carries temperature and orientation.
+            # Uses the instrument HAB directly (range = 0 from the transducer).
+            expanded.append(
+                {
+                    **info,
+                    "serial": f"{info['serial']}_hd",
+                    "hab": float(info["hab"]),
+                    "_adcp_head": True,
+                    "_adcp_nc_key": nc_key,
+                }
+            )
+            for i in valid_bins:
+                r = float(range_vals[i])
+                bin_hab = (
+                    float(info["hab"]) - r if looking_down else float(info["hab"]) + r
+                )
+                expanded.append(
+                    {
+                        **info,
+                        "serial": f"{info['serial']}_b{i:02d}",
+                        "hab": bin_hab,
+                        "_adcp_bin_idx": i,
+                        "_adcp_nc_key": nc_key,
+                    }
+                )
+        instruments = expanded
+        # Re-sort after expansion so ADCP bins interleave with other instruments by depth
+        instruments.sort(key=lambda x: x["hab"])
+
         n_instr = len(instruments)
 
         print(
@@ -444,8 +641,15 @@ class MooringStacker:
             stage_labels.append(info["nc_path"].stem.split("_")[-1])
 
             try:
-                ds = xr.open_dataset(info["nc_path"], decode_timedelta=False).load()
-                ds.close()
+                if "_adcp_bin_idx" in info:
+                    ds_parent = _adcp_parent_datasets[info["_adcp_nc_key"]]
+                    ds = _make_adcp_bin_ds(ds_parent, info["_adcp_bin_idx"])
+                elif "_adcp_head" in info:
+                    ds_parent = _adcp_parent_datasets[info["_adcp_nc_key"]]
+                    ds = _make_adcp_head_ds(ds_parent)
+                else:
+                    ds = xr.open_dataset(info["nc_path"], decode_timedelta=False).load()
+                    ds.close()
             except Exception as e:  # noqa: BLE001  — one bad instrument must not abort the stack
                 print(f"  WARNING: Could not load {info['nc_path'].name}: {e}")
                 # Ensure scalar_meta lists stay length-consistent
@@ -505,6 +709,10 @@ class MooringStacker:
             for vname in scalar_meta:
                 if len(scalar_meta[vname]) < i + 1:
                     scalar_meta[vname].append(None)
+
+        # Release cached ADCP parent datasets
+        for _ds_adcp in _adcp_parent_datasets.values():
+            _ds_adcp.close()
 
         # Build output dataset; skip physics variables that are entirely NaN
         data_vars: Dict = {}
@@ -758,8 +966,8 @@ class MooringStacker:
                 "Conventions": "CF-1.13",
                 "history": (
                     f"Step 1 stack: {n_instr} instruments onto {dt_seconds}s grid; "
-                    f"fast instruments (dt<={dt_seconds}s) subsampled (nearest), "
-                    f"slow instruments interpolated (linear)"
+                    f"fast instruments (dt<={dt_seconds}s) subsampled (nearest-neighbour in time), "
+                    f"slow instruments interpolated (linear in time)"
                 ),
             }
         )
@@ -862,12 +1070,8 @@ class MooringGridder:
                 "velocity_beam1",
                 "velocity_beam2",
                 "velocity_beam3",
-                "amplitude_beam1",
-                "amplitude_beam2",
-                "amplitude_beam3",
-                "correlation_beam1",
-                "correlation_beam2",
-                "correlation_beam3",
+                "amplitude",
+                "correlation",
                 "battery_voltage",
                 "velocity_flag",  # flag array, not a gridded physics variable
                 "tilt_from_pressure",  # per-instrument diagnostic, not gridded
@@ -917,6 +1121,20 @@ class MooringGridder:
             for _v in _vel_vars:
                 if _v in var_data:
                     var_data[_v][~np.isfinite(var_data[_v])] = np.nan
+
+        # ADCP standalone QC variables — mask velocity before gridding.
+        # seabed_qc removes bins at/below the seafloor; percent_good_qc and
+        # error_velocity_qc remove poor-quality pings.  All three use flag >= 3
+        # (suspect or worse) as the NaN threshold, consistent with how the
+        # rose diagram and stack report mask these variables.
+        for _adcp_qc in ("seabed_qc", "percent_good_qc", "error_velocity_qc"):
+            if _adcp_qc not in ds.data_vars:
+                continue
+            _qc = ds[_adcp_qc].values  # (time, N_LEVELS) after stack transpose
+            _bad = np.isin(np.round(_qc).astype(np.int8), [3, 4, 9])
+            for _v in _vel_vars:
+                if _v in var_data:
+                    var_data[_v][_bad] = np.nan
 
         for t in range(n_time):
             p_col = pressure[t, :]
@@ -979,7 +1197,7 @@ class MooringGridder:
                 "dp_dbar": dp,
                 "history": (
                     prior_history
-                    + f"; Step 2 grid: linear interpolation onto {dp:.0f} dbar pressure grid "
+                    + f"; Step 2 grid: linear interpolation in pressure onto {dp:.0f} dbar pressure grid "
                     f"({p_start:.0f}–{p_end:.0f} dbar); no extrapolation"
                 ),
             }

--- a/oceanarray/mooring_level.py
+++ b/oceanarray/mooring_level.py
@@ -267,12 +267,33 @@ _ADCP_HEAD_VARS: frozenset = frozenset(
 
 
 def _make_adcp_head_ds(ds_parent: xr.Dataset) -> xr.Dataset:
-    """Create a 1-D point-instrument view of the ADCP transducer head.
+    """Create a 1-D (time-only) view of the ADCP transducer head for stack insertion.
 
-    Keeps only time-series variables that are measured at the instrument head
-    (temperature, heading, pitch, roll, transducer pressure) — NOT the per-bin
-    velocity or bin_pressure arrays.  This entry represents the instrument's
-    physical location in the stack alongside the velocity bin entries.
+    The ADCP transducer head is treated as a distinct instrument position in the mooring
+    stack.  It carries instrument-diagnostic variables that describe the sensor, not the
+    water column:
+
+    - ``temperature`` (°C) — internal electronics temperature; useful for diagnosing
+      warm-up drift but not a reliable water temperature measurement.
+    - ``heading``, ``pitch``, ``roll`` (°) — instrument orientation.
+    - ``pressure`` (dbar) — pressure at the transducer face, i.e. the instrument depth.
+
+    Per-bin velocity and ``bin_pressure`` are deliberately excluded.  Each velocity bin
+    gets its own stack entry at the pressure appropriate to that bin
+    (see ``_make_adcp_bin_ds``), rather than the transducer pressure.
+
+    Parameters
+    ----------
+    ds_parent : xr.Dataset
+        Full ADCP stage-3 dataset, including 2-D ``(time, N_BINS)`` variables.
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset containing only time-series (1-D) variables from ``_ADCP_HEAD_VARS``
+        plus the transducer ``pressure``.  Suitable for merging into a point-instrument
+        stack.
+
     """
     keep = [
         v
@@ -287,20 +308,43 @@ def _make_adcp_head_ds(ds_parent: xr.Dataset) -> xr.Dataset:
 
 
 def _make_adcp_bin_ds(ds_parent: xr.Dataset, bin_idx: int) -> xr.Dataset:
-    """Create a 1-D point-instrument view of ADCP data for one range bin.
+    """Create a 1-D (time-only) point-instrument view of one ADCP range bin.
 
-    Slices the parent dataset at *bin_idx* along ``P.ADCP_BIN_DIM``, replaces
-    the transducer ``pressure`` with ``bin_pressure[:, bin_idx]``, computes
-    ``current_speed`` and ``current_direction``, and drops any remaining
-    variables that still have non-time dimensions (e.g. beam-dimension arrays
-    ``amplitude``, ``correlation``, ``percent_good``).
+    Slices the parent dataset at *bin_idx* along ``P.ADCP_BIN_DIM`` and replaces the
+    transducer ``pressure`` with ``bin_pressure[:, bin_idx]`` so that this entry sits at
+    the correct depth in the stack.  Computes derived scalar velocity quantities::
 
-    Instrument-head variables (temperature, heading, pitch, roll — see
-    ``_ADCP_HEAD_VARS``) are dropped here; they belong only in the separate
-    head entry added to the stack by the expansion loop.
+        current_speed      = sqrt(east_velocity² + north_velocity²)  [m s⁻¹, always ≥ 0]
+        current_direction  = atan2(east, north) mod 360               [degrees, 0 = N CW]
 
-    The result is compatible with ``_nearest_subsample`` and ``_linear_interp``
-    because every data variable has dimension ``("time",)`` or is scalar.
+    **Direction convention**: the direction *toward which* the water flows, clockwise
+    from True North.  This is the oceanographic convention (opposite to meteorological
+    "wind from").  0° = northward flow, 90° = eastward flow.
+
+    Instrument-head variables (``temperature``, ``heading``, ``pitch``, ``roll`` — see
+    ``_ADCP_HEAD_VARS``) are dropped because they belong to the transducer location, not
+    to an individual velocity bin.  Variables retaining non-time dimensions (e.g.
+    beam-dimension arrays ``amplitude``, ``correlation``, ``percent_good``) are also
+    dropped; they cannot be represented as point-instrument time series without
+    ambiguity about which beam to keep.
+
+    The result is compatible with ``_nearest_subsample`` and ``_linear_interp`` because
+    every remaining data variable has dimension ``("time",)`` or is scalar.
+
+    Parameters
+    ----------
+    ds_parent : xr.Dataset
+        Full ADCP stage-3 dataset.
+    bin_idx : int
+        Zero-based index along the bin dimension (``P.ADCP_BIN_DIM``).  Index 0 is
+        the bin nearest the transducer face.
+
+    Returns
+    -------
+    xr.Dataset
+        Single-bin time-series dataset with ``pressure`` set to ``bin_pressure``
+        at this bin and ``current_speed`` / ``current_direction`` added.
+
     """
     bin_dim = P.ADCP_BIN_DIM
     ds_bin = ds_parent.isel({bin_dim: bin_idx}, drop=True)
@@ -556,8 +600,15 @@ class MooringStacker:
                 else np.arange(n_bins, dtype=float)
             )
             orientation = ds_adcp.attrs.get("orientation_yaml") or ds_adcp.attrs.get(
-                "orientation_instrument", "down"
+                "orientation_instrument"
             )
+            if not orientation:
+                orientation = "down"
+                print(
+                    f"  WARNING: ADCP {info['serial']} has no orientation attr — "
+                    "assuming downward-looking. HAB offsets may be wrong for "
+                    "upward-looking instruments."
+                )
             looking_down = str(orientation).lower() == "down"
             # Pre-compute seabed mask so always-submerged bins can be skipped.
             # seabed_qc has dims (time, N_BINS); a bin is permanently below the

--- a/oceanarray/parameters.py
+++ b/oceanarray/parameters.py
@@ -154,6 +154,29 @@ QC_TILT: dict = {
     "fail_threshold": 50.0,
 }
 
+# ---------------------------------------------------------------------------
+# ADCP-specific QC thresholds.
+#
+# percent_good_bad     : bins whose mean (across beams) percent_good falls
+#                        below this threshold are flagged bad (4).
+# percent_good_suspect : bins between percent_good_bad and this threshold
+#                        are flagged suspect (3).
+# error_velocity_threshold : bins where |error_velocity| exceeds this value
+#                        are flagged bad (4). m/s.
+# ---------------------------------------------------------------------------
+QC_ADCP: dict = {
+    "percent_good_bad": 25.0,
+    "percent_good_suspect": 50.0,
+    "error_velocity_threshold": 0.3,
+}
+
+# ---------------------------------------------------------------------------
+# ADCP bin dimension name.
+# Never hard-code "N_BINS" — reference this constant everywhere so the
+# dimension can be renamed to "N_LEVELS" later by changing one line.
+# ---------------------------------------------------------------------------
+ADCP_BIN_DIM: str = "N_BINS"
+
 INSTRUMENT_ABBREV = {
     "microcat": "MC",
     "aquadopp": "AQ",
@@ -188,11 +211,12 @@ INSTRUMENT_FILE_TYPES: dict = {
     "rbrsolo": ["rbr-rsk", "rbr-dat"],  # RBR Solo/Duet single-channel T or T+P
     "seapoint": ["rbr-rsk", "rbr-dat"],  # Seapoint turbidity sensor via RBR logger
     "ADCP": [
+        "rdi-raw",  # RDI Workhorse / Sentinel via dolfyn (mhkit[dolfyn] required)
         "nortek-aqd",
         "nortek-ascii",
         "adcp-matlab-rdadcp",
         "adcp-matlab-uhhds",
-    ],  # Generic ADCP
+    ],  # Generic ADCP (instrument: ADCP in YAML — note uppercase)
 }
 
 # Derived: set of allowed ``instrument:`` values in mooring YAML files.

--- a/oceanarray/parameters.py
+++ b/oceanarray/parameters.py
@@ -157,8 +157,10 @@ QC_TILT: dict = {
 # ---------------------------------------------------------------------------
 # ADCP-specific QC thresholds.
 #
-# percent_good_bad     : bins whose mean (across beams) percent_good falls
-#                        below this threshold are flagged bad (4).
+# percent_good_bad     : bins where percent_good column 3 (fraction of 4-beam
+#                        solutions) falls below this threshold are flagged bad (4).
+#                        Column 3 is used — NOT the mean across beams — because
+#                        a cross-beam mean would give ~25 % even for perfect data.
 # percent_good_suspect : bins between percent_good_bad and this threshold
 #                        are flagged suspect (3).
 # error_velocity_threshold : bins where |error_velocity| exceeds this value

--- a/oceanarray/plotters/_current.py
+++ b/oceanarray/plotters/_current.py
@@ -575,3 +575,117 @@ def plot_aquadopp_speed_profile(
     ax.grid(True, axis="x", linestyle="--", linewidth=0.5, alpha=0.5)
     fig.tight_layout()
     return fig
+
+
+def plot_adcp_trajectories(
+    ds: xr.Dataset,
+    u_var: str = "east_velocity",
+    v_var: str = "north_velocity",
+    instr_type_var: str = "instrument_type",
+    hab_var: str = "hab",
+    seabed_qc_var: str = "seabed_qc",
+    percent_good_qc_var: str = "percent_good_qc",
+) -> Optional[plt.Figure]:
+    """Lagrangian per-bin trajectories for ADCP data, coloured by HAB.
+
+    Each depth bin integrated by Euler-forward from the origin.  Bins that are
+    entirely below the seabed (all seabed_qc >= 3) are silently omitted.  QC
+    masking is applied before integration so bad pings are treated as zero
+    velocity (do not accumulate spurious displacement).
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Stacked mooring dataset.  ADCP bins are identified by
+        ``instrument_type == "ADCP"``.
+    u_var, v_var : str
+        Eastward and northward velocity variable names (m s⁻¹).
+    instr_type_var, hab_var : str
+        Coordinate variable names.
+    seabed_qc_var : str
+        QC variable for seabed proximity; bins with all values >= 3 are skipped.
+    percent_good_qc_var : str
+        Ping-quality QC; timesteps flagged >= 3 are zeroed before integration.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or None
+        None if no ADCP bins are found.
+    """
+    if u_var not in ds.data_vars or v_var not in ds.data_vars:
+        return None
+
+    instr_types = ds[instr_type_var].values
+    habs = ds[hab_var].values
+    adcp_idx = [i for i, t in enumerate(instr_types) if str(t).upper() == "ADCP"]
+
+    if not adcp_idx:
+        return None
+
+    time = ds["time"].values
+    dt = np.array(
+        [(time[j] - time[j - 1]) / np.timedelta64(1, "s") for j in range(1, len(time))],
+        dtype=float,
+    )
+
+    # Build per-bin trajectories with seabed + percent_good masking
+    trajs: list = []  # (hab, x, y)
+    hab_all: list = []
+    for i in adcp_idx:
+        u = ds[u_var].values[:, i].copy().astype(float)
+        v = ds[v_var].values[:, i].copy().astype(float)
+
+        # Mask by seabed proximity
+        if seabed_qc_var in ds.data_vars:
+            sqc = ds[seabed_qc_var].values[:, i]
+            # Skip bins that are always below the seabed
+            if np.all(sqc >= 3):
+                continue
+            u[sqc >= 3] = np.nan
+            v[sqc >= 3] = np.nan
+
+        # Mask by ping quality
+        if percent_good_qc_var in ds.data_vars:
+            pqc = ds[percent_good_qc_var].values[:, i]
+            u[pqc >= 3] = np.nan
+            v[pqc >= 3] = np.nan
+
+        # NaN → 0 for integration (no displacement during missing pings)
+        x = np.concatenate([[0.0], np.cumsum(np.nan_to_num(u[:-1], nan=0.0) * dt)])
+        y = np.concatenate([[0.0], np.cumsum(np.nan_to_num(v[:-1], nan=0.0) * dt)])
+        trajs.append((float(habs[i]), x, y))
+        hab_all.append(float(habs[i]))
+
+    if not trajs:
+        return None
+
+    hab_min, hab_max = min(hab_all), max(hab_all)
+    cmap = plt.get_cmap("viridis")
+    _bounds = _nice_colorbar_bounds(hab_min, hab_max, n=20)
+    norm: mcolors.BoundaryNorm = mcolors.BoundaryNorm(_bounds, ncolors=256)
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+
+    for hab, x, y in trajs:
+        points = np.array([x, y]).T.reshape(-1, 1, 2)
+        segments = np.concatenate([points[:-1], points[1:]], axis=1)
+        lc = LineCollection(segments, cmap=cmap, norm=norm, linewidth=1.0, alpha=0.6)
+        lc.set_array(np.full(len(segments), hab))
+        ax.add_collection(lc)
+
+    sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+    sm.set_array([])
+    fig.colorbar(sm, ax=ax, label="HAB (m)", shrink=0.75, ticks=_bounds)
+
+    ax.plot(0, 0, "o", color="black", markersize=7, zorder=6, label="Start")
+    ax.legend(fontsize=8, loc="upper left")
+    ax.autoscale_view()
+    ax.set_xlabel("East displacement (m)")
+    ax.set_ylabel("North displacement (m)")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
+    ax.axvline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
+    ax.set_aspect("equal", adjustable="datalim")
+    ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.4)
+    ax.set_title("ADCP bins coloured by HAB")
+    fig.tight_layout()
+    return fig

--- a/oceanarray/report/_grid.py
+++ b/oceanarray/report/_grid.py
@@ -9,11 +9,13 @@ import numpy as np
 
 from ._html_helpers import _nav_buttons_html, _parse_history, _read_nc_metadata, _status
 from ._plots import (
-    _make_grid_fig_b64,
+    _make_grid_hydro_b64,
+    _make_grid_sigma_b64,
     _make_grid_timeseries_b64,
     _make_grid_trajectory_b64,
     _make_grid_ts_diagram,
     _make_grid_n2_b64,
+    _make_grid_velocity_stacked_b64,
     _make_isopycnal_fig_b64,
     _make_spectrum_fig_b64,
     _make_velocity_iqr_profile_b64,
@@ -114,16 +116,13 @@ _GRID_HTML_TEMPLATE = """\
 <nav class="jump-nav">
   Jump to:
   {% if history_entries %}<a href="#history">History</a>{% endif %}
-  {% if fig_temp_b64 or fig_temp_cf_b64 %}<a href="#temp">Temperature</a>{% endif %}
-  {% if fig_sal_b64 or fig_sal_cf_b64 %}<a href="#sal">Salinity</a>{% endif %}
-  {% if sigma_sections %}<a href="#density">Potential density</a>{% endif %}
-  {% if vel_sections %}<a href="#vel">Velocities</a>{% endif %}
+  {% if fig_hydro_b64 %}<a href="#hydro">Hydrography</a>{% endif %}
+  {% if fig_vel_stacked_b64 %}<a href="#vel">Velocity</a>{% endif %}
+  {% if fig_ts_grid_b64 %}<a href="#ts">T-S diagram</a>{% endif %}
   {% if fig_vel_iqr_b64 %}<a href="#vel-iqr">Velocity profiles</a>{% endif %}
   {% if fig_grid_traj_b64 %}<a href="#grid-traj">Particle trajectory</a>{% endif %}
-  {% if fig_n2_b64 %}<a href="#n2">N²</a>{% endif %}
-  {% if sigma_sections %}<a href="#isopycnal">Isopycnal depths</a>{% endif %}
   {% if fig_grid_ts_b64 %}<a href="#grid-ts">Velocity time series</a>{% endif %}
-  {% if fig_ts_grid_b64 %}<a href="#ts">T-S diagram</a>{% endif %}
+  {% if fig_sigma_b64 or fig_n2_b64 %}<a href="#strat">Stratification</a>{% endif %}
   {% if fig_spectrum_b64 %}<a href="#spectrum">Power spectrum</a>{% endif %}
   <a href="#vars">Variables</a>
 </nav>
@@ -140,96 +139,25 @@ _GRID_HTML_TEMPLATE = """\
 </ul>
 {% endif %}
 
-<!-- Temperature -->
-{% if fig_temp_b64 %}
-<h2 id="temp">Temperature</h2>
-<p class="note">{{ p_range }} &bull; colour range: {{ temp_plow }}–{{ temp_phigh }} °C (5th–95th percentile) &bull; 20 discrete levels</p>
+<!-- ══ Hydrography: T and S ══ -->
+{% if fig_hydro_b64 %}
+<h2 id="hydro">Hydrography</h2>
+<p class="note">Temperature and salinity. Vertically interpolated to regular pressure grid &bull; 20 discrete colour levels.</p>
 <details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" src="data:image/png;base64,{{ fig_temp_b64 }}" alt="Temperature pcolormesh">
+<img class="fig" src="data:image/png;base64,{{ fig_hydro_b64 }}" alt="Temperature and salinity">
 </details>
 {% endif %}
 
-<!-- Salinity -->
-{% if fig_sal_b64 %}
-<h2 id="sal">Practical Salinity</h2>
-<p class="note">{{ sal_source }} &bull; colour range: {{ sal_plow }}–{{ sal_phigh }} (5th–95th percentile) &bull; 20 discrete levels</p>
+<!-- ══ Velocity: E / N / Up ══ -->
+{% if fig_vel_stacked_b64 %}
+<h2 id="vel">Velocity</h2>
+<p class="note">East, north, and up velocity. QC-flagged samples excluded before interpolation. Shared symmetric Spectral_r colormap for east/north; separate bounds for up. No temporal gap fill — NaN where no data.</p>
 <details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" src="data:image/png;base64,{{ fig_sal_b64 }}" alt="Salinity pcolormesh">
+<img class="fig" src="data:image/png;base64,{{ fig_vel_stacked_b64 }}" alt="Velocity pcolormesh">
 </details>
 {% endif %}
 
-<!-- Potential density (pcolormesh only — isopycnal time series rendered below N²) -->
-{% for sec in sigma_sections %}
-<h2 {% if loop.first %}id="density" {% endif %}>{{ sec.label }}</h2>
-<p class="note">{{ p_range }} &bull; colour range: {{ sec.plow }}–{{ sec.phigh }} {{ sec.units }} (5th–95th percentile) &bull; 20 discrete levels</p>
-{% if sec.fig_b64 %}
-<details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" src="data:image/png;base64,{{ sec.fig_b64 }}" alt="{{ sec.label }} pcolormesh">
-</details>
-{% endif %}
-{% endfor %}
-
-<!-- Velocity grids (speed, direction, W) -->
-{% for sec in vel_sections %}
-<h2 {% if loop.first %}id="vel" {% endif %}>{{ sec.label }}</h2>
-<p class="note">Vertically interpolated to regular pressure grid. QC-flagged samples excluded before interpolation. No temporal gap fill — NaN where no data.</p>
-{% if sec.fig_b64 %}
-<details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" src="data:image/png;base64,{{ sec.fig_b64 }}" alt="{{ sec.label }} grid">
-</details>
-{% endif %}
-{% endfor %}
-
-{% if fig_vel_iqr_b64 %}
-<h2 id="vel-iqr">Velocity IQR profiles <a class="top-link" href="#top">↑ top</a></h2>
-<p class="note">Median (solid line) and interquartile range (shaded, 25–75 %) across the full deployment at each pressure level. 2.5–97.5 % outer envelope for speed. Built from the gridded data.</p>
-<details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" style="max-width:85%" src="data:image/png;base64,{{ fig_vel_iqr_b64 }}" alt="Velocity IQR profiles">
-</details>
-{% endif %}
-
-{% if fig_grid_traj_b64 %}
-<h2 id="grid-traj">Particle trajectory (gridded pressure levels) <a class="top-link" href="#top">↑ top</a></h2>
-<p class="note">Pseudo-Lagrangian trajectories at each gridded pressure level, integrated from east and north velocity (Euler forward). All start at the origin. Coloured by pressure (dbar).</p>
-<details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" style="max-width:55%" src="data:image/png;base64,{{ fig_grid_traj_b64 }}" alt="Grid particle trajectory">
-</details>
-{% endif %}
-
-{% if fig_n2_b64 %}
-<h2 id="n2">Buoyancy frequency squared (N²)</h2>
-<p class="note">log₁₀(N²) in s⁻². Purple = strongly stratified (high N²); yellow = weakly stratified. Computed from T and S via GSW; one pressure mid-point between each adjacent pair of grid levels.</p>
-<details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" src="data:image/png;base64,{{ fig_n2_b64 }}" alt="N² pcolormesh">
-</details>
-{% endif %}
-
-<!-- Isopycnal depth time series (moved below N²) -->
-{% for sec in sigma_sections %}
-{% if sec.isopycnal_zoom_b64 %}
-<h2 {% if loop.first %}id="isopycnal" {% endif %}>Isopycnal depths &mdash; {{ sec.name }} (3-day zoom, unfiltered)</h2>
-<p class="note">3-day window centred on deployment midpoint &bull; raw gridded data &bull; no temporal filter applied.</p>
-<details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" src="data:image/png;base64,{{ sec.isopycnal_zoom_b64 }}" alt="Isopycnal depths zoom {{ sec.label }}">
-</details>
-{% endif %}
-{% if sec.isopycnal_b64 %}
-<h2>Isopycnal depths &mdash; {{ sec.name }} (full record, 24 h Tukey filtered)</h2>
-<p class="note">Full deployment &bull; 24 h Tukey (α=0.5) moving-average applied before contouring to reduce tidal noise.</p>
-<details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" src="data:image/png;base64,{{ sec.isopycnal_b64 }}" alt="Isopycnal depths {{ sec.label }}">
-</details>
-{% endif %}
-{% endfor %}
-
-{% if fig_grid_ts_b64 %}
-<h2 id="grid-ts">Velocity time series at depth of maximum mean speed</h2>
-<p class="note">Depth chosen as the pressure level with the highest time-mean current speed. Speed, east, and north velocity at that level.</p>
-<details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" src="data:image/png;base64,{{ fig_grid_ts_b64 }}" alt="Velocity time series at max-speed depth">
-</details>
-{% endif %}
-
+<!-- ══ T-S diagram (before derived quantities) ══ -->
 {% if fig_ts_grid_b64 %}
 <h2 id="ts">T-S diagram</h2>
 <p class="note">All (pressure, time) grid points. Colour = log₁₀(count+1). QC-bad data excluded at the stack step before gridding.</p>
@@ -238,8 +166,72 @@ _GRID_HTML_TEMPLATE = """\
 </details>
 {% endif %}
 
+<!-- ══ Velocity IQR profiles ══ -->
+{% if fig_vel_iqr_b64 %}
+<h2 id="vel-iqr">Velocity IQR profiles</h2>
+<p class="note">Median (solid line) and interquartile range (shaded, 25–75 %) across the full deployment at each pressure level. 2.5–97.5 % outer envelope for speed. Right panel: count of non-NaN values per depth.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" style="max-width:85%" src="data:image/png;base64,{{ fig_vel_iqr_b64 }}" alt="Velocity IQR profiles">
+</details>
+{% endif %}
+
+<!-- ══ Particle trajectory ══ -->
+{% if fig_grid_traj_b64 %}
+<h2 id="grid-traj">Particle trajectory</h2>
+<p class="note">Pseudo-Lagrangian trajectories at each gridded pressure level, integrated from east and north velocity (Euler forward). All start at the origin. Coloured by pressure (dbar).</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" style="max-width:55%" src="data:image/png;base64,{{ fig_grid_traj_b64 }}" alt="Grid particle trajectory">
+</details>
+{% endif %}
+
+<!-- ══ Velocity time series at depth of max speed ══ -->
+{% if fig_grid_ts_b64 %}
+<h2 id="grid-ts">Velocity time series at depth of maximum mean speed</h2>
+<p class="note">Depth chosen as the pressure level with the highest time-mean current speed. Speed, east, and north velocity at that level.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" src="data:image/png;base64,{{ fig_grid_ts_b64 }}" alt="Velocity time series at max-speed depth">
+</details>
+{% endif %}
+
+<!-- ══ Stratification: sigma0 + N² + isopycnal depths + spectrum ══ -->
+{% if fig_sigma_b64 or fig_n2_b64 %}
+<h2 id="strat">Stratification</h2>
+{% endif %}
+
+{% if fig_sigma_b64 %}
+<p class="note">Potential density. 20 discrete colour levels.</p>
+<details open><summary class="collapse-toggle">show / hide sigma0</summary>
+<img class="fig" src="data:image/png;base64,{{ fig_sigma_b64 }}" alt="Potential density pcolormesh">
+</details>
+{% endif %}
+
+{% if fig_n2_b64 %}
+<h3 style="font-size:0.9rem;color:var(--ocean);margin:1.5rem 0 0.4rem;">Buoyancy frequency squared (N²)</h3>
+<p class="note">log₁₀(N²) in s⁻². Purple = strongly stratified; yellow = weakly stratified. Computed from T and S via GSW.</p>
+<details open><summary class="collapse-toggle">show / hide N²</summary>
+<img class="fig" src="data:image/png;base64,{{ fig_n2_b64 }}" alt="N² pcolormesh">
+</details>
+{% endif %}
+
+{% for sec in sigma_sections %}
+{% if sec.isopycnal_zoom_b64 %}
+<h3 style="font-size:0.9rem;color:var(--ocean);margin:1.5rem 0 0.4rem;">Isopycnal depths &mdash; {{ sec.name }} (3-day zoom, unfiltered)</h3>
+<p class="note">3-day window centred on deployment midpoint &bull; raw gridded data.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" src="data:image/png;base64,{{ sec.isopycnal_zoom_b64 }}" alt="Isopycnal depths zoom">
+</details>
+{% endif %}
+{% if sec.isopycnal_b64 %}
+<h3 style="font-size:0.9rem;color:var(--ocean);margin:1.5rem 0 0.4rem;">Isopycnal depths &mdash; {{ sec.name }} (full record, 24 h Tukey filtered)</h3>
+<p class="note">Full deployment &bull; 24 h Tukey (α=0.5) moving-average applied before contouring.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" src="data:image/png;base64,{{ sec.isopycnal_b64 }}" alt="Isopycnal depths">
+</details>
+{% endif %}
+{% endfor %}
+
 {% if fig_spectrum_b64 %}
-<h2 id="spectrum">Temperature power spectrum</h2>
+<h3 style="font-size:0.9rem;color:var(--ocean);margin:1.5rem 0 0.4rem;" id="spectrum">Temperature power spectrum</h3>
 <p class="note">Welch PSD (Hann window, 14-day segments, 50% overlap). One line per depth level; colour indicates pressure (shallow = light blue, deep = dark blue). Dashed vertical lines mark tidal and inertial frequencies. Dashed black line: &minus;2 spectral slope reference.</p>
 <details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" src="data:image/png;base64,{{ fig_spectrum_b64 }}" alt="Temperature power spectrum">
@@ -367,126 +359,11 @@ def generate_grid_page(
         n_instr = ctx.get("n_instruments", "—")
         grid_history = _parse_history(ds.attrs.get("history", ""))
 
-        # Temperature
-        fig_temp_b64 = fig_temp_cf_b64 = temp_plow = temp_phigh = None
-        if "temperature" in ds:
-            T_da = ds["temperature"]
-            T_units = T_da.attrs.get("units", "degC")
-            T_vals = T_da.values
-            temp_plow = f"{np.nanpercentile(T_vals, P.COLORBAR_PLOW):.2f}"
-            temp_phigh = f"{np.nanpercentile(T_vals, P.COLORBAR_PHIGH):.2f}"
-            fig_temp_b64 = _make_grid_fig_b64(T_da, "Temperature", T_units, "RdYlBu_r")
-            fig_temp_cf_b64 = None
+        # Hydrography: stacked T + S
+        fig_hydro_b64 = _make_grid_hydro_b64(ds)
 
-        # Salinity — use stored variable or derive from T/C via GSW
-        fig_sal_b64 = sal_plow = sal_phigh = None
-        sal_source = ""
-        SP_da = None
-        if "salinity" in ds:
-            SP_da = ds["salinity"]
-            sal_units = SP_da.attrs.get("units", "1")
-            sal_source = "practical salinity from _grid.nc"
-        elif "conductivity" in ds and "temperature" in ds:
-            import gsw
-
-            T_tp = ds["temperature"].transpose("time", "pressure").values
-            C_tp = ds["conductivity"].transpose("time", "pressure").values
-            SP_vals = gsw.SP_from_C(C_tp, T_tp, pressure[np.newaxis, :])
-            SP_da = xr.DataArray(
-                SP_vals,
-                dims=("time", "pressure"),
-                coords={"time": ds["time"], "pressure": ds["pressure"]},
-            )
-            sal_units = "1"
-            sal_source = "practical salinity computed from T, C via GSW"
-        fig_sal_cf_b64 = None
-        if SP_da is not None:
-            sal_plow = f"{np.nanpercentile(SP_da.values, P.COLORBAR_PLOW):.3f}"
-            sal_phigh = f"{np.nanpercentile(SP_da.values, P.COLORBAR_PHIGH):.3f}"
-            fig_sal_b64 = _make_grid_fig_b64(
-                SP_da, "Practical Salinity", sal_units, "YlGnBu_r"
-            )
-
-        # Velocity grids (ENU)
-        vel_sections = []
-
-        def _qc_masked_vel(ds: "xr.Dataset", vel_var: str) -> "xr.DataArray | None":  # noqa: ANN202
-            import xarray as _xr
-
-            if vel_var not in ds.data_vars:
-                return None
-            da = ds[vel_var]
-            qc_var = f"{vel_var}_qc"
-            if qc_var in ds.data_vars:
-                data = da.values.copy()
-                data[ds[qc_var].values >= 3] = np.nan
-                da = _xr.DataArray(data, dims=da.dims, coords=da.coords, attrs=da.attrs)
-            return da
-
-        da_east = _qc_masked_vel(ds, "east_velocity")
-        da_north = _qc_masked_vel(ds, "north_velocity")
-
-        if da_east is not None and da_north is not None:
-            import xarray as _xr
-
-            spd_vals = np.sqrt(da_east.values**2 + da_north.values**2)
-            dir_vals = (
-                90.0 - np.degrees(np.arctan2(da_north.values, da_east.values))
-            ) % 360.0
-            spd_da = _xr.DataArray(
-                spd_vals,
-                dims=da_east.dims,
-                coords=da_east.coords,
-                attrs={"units": "m s-1", "long_name": "Current speed"},
-            )
-            dir_da = _xr.DataArray(
-                dir_vals,
-                dims=da_east.dims,
-                coords=da_east.coords,
-                attrs={
-                    "units": "degrees",
-                    "long_name": "Current direction (toward, °T)",
-                },
-            )
-            vel_sections.append(
-                {
-                    "label": "Current speed",
-                    "units": "m s-1",
-                    "fig_b64": _make_grid_fig_b64(
-                        spd_da, "Current speed", "m s⁻¹", "plasma"
-                    ),
-                }
-            )
-            vel_sections.append(
-                {
-                    "label": "Current direction (toward, °T)",
-                    "units": "°",
-                    "fig_b64": _make_grid_fig_b64(
-                        dir_da,
-                        "Current direction (toward, °T)",
-                        "°",
-                        "hsv",
-                        vmin=0.0,
-                        vmax=360.0,
-                    ),
-                }
-            )
-
-        da_up = _qc_masked_vel(ds, "up_velocity")
-        if da_up is not None:
-            vel_sections.append(
-                {
-                    "label": "Up velocity (W)",
-                    "units": da_up.attrs.get("units", "m s-1"),
-                    "fig_b64": _make_grid_fig_b64(
-                        da_up,
-                        "Up velocity (W)",
-                        da_up.attrs.get("units", "m s-1"),
-                        "RdBu_r",
-                        symmetric=True,
-                    ),
-                }
-            )
+        # Velocity: stacked E / N / Up
+        fig_vel_stacked_b64 = _make_grid_velocity_stacked_b64(ds)
 
         fig_vel_iqr_b64 = _make_velocity_iqr_profile_b64(ds)
         fig_grid_traj_b64 = _make_grid_trajectory_b64(ds)
@@ -506,6 +383,8 @@ def generate_grid_page(
                     pass
         fig_n2_b64 = _make_grid_n2_b64(ds, lat=_lat_n2)
 
+        # Stratification: sigma0 stacked panel + isopycnal time series
+        fig_sigma_b64 = _make_grid_sigma_b64(ds)
         sigma_sections = []
         for sv in [
             v
@@ -514,10 +393,6 @@ def generate_grid_page(
         ]:
             da = ds[sv]
             label = da.attrs.get("long_name", sv)
-            units_s = da.attrs.get("units", "kg m-3")
-            vals = da.values
-            sig_plow = f"{np.nanpercentile(vals, P.COLORBAR_PLOW):.4f}"
-            sig_phigh = f"{np.nanpercentile(vals, P.COLORBAR_PHIGH):.4f}"
             _dt_s = float(ds.attrs.get("dt_seconds", 60))
             _filter_s = max(3, int(24 * 3600 / _dt_s))
             _n_t = da.sizes["time"]
@@ -527,12 +402,6 @@ def generate_grid_page(
                 {
                     "name": sv,
                     "label": label,
-                    "units": units_s,
-                    "plow": sig_plow,
-                    "phigh": sig_phigh,
-                    "fig_b64": _make_grid_fig_b64(
-                        da, label, units_s, P.DENSITY_COLORMAP
-                    ),
                     "isopycnal_zoom_b64": _make_isopycnal_fig_b64(
                         da,
                         P.SIGMA_CONTOUR_LEVELS,
@@ -598,17 +467,10 @@ def generate_grid_page(
             history_entries=grid_history,
             nc_meta=nc_meta,
             nc_file=grid_path.name,
-            fig_temp_b64=fig_temp_b64,
-            fig_temp_cf_b64=fig_temp_cf_b64,
-            temp_plow=temp_plow,
-            temp_phigh=temp_phigh,
-            fig_sal_b64=fig_sal_b64,
-            fig_sal_cf_b64=fig_sal_cf_b64,
-            sal_plow=sal_plow,
-            sal_phigh=sal_phigh,
-            sal_source=sal_source,
+            fig_hydro_b64=fig_hydro_b64,
+            fig_vel_stacked_b64=fig_vel_stacked_b64,
             sigma_sections=sigma_sections,
-            vel_sections=vel_sections,
+            fig_sigma_b64=fig_sigma_b64,
             fig_vel_iqr_b64=fig_vel_iqr_b64,
             fig_grid_traj_b64=fig_grid_traj_b64,
             fig_grid_ts_b64=fig_grid_ts_b64,

--- a/oceanarray/report/_grid.py
+++ b/oceanarray/report/_grid.py
@@ -10,10 +10,13 @@ import numpy as np
 from ._html_helpers import _nav_buttons_html, _parse_history, _read_nc_metadata, _status
 from ._plots import (
     _make_grid_fig_b64,
+    _make_grid_timeseries_b64,
+    _make_grid_trajectory_b64,
     _make_grid_ts_diagram,
     _make_grid_n2_b64,
     _make_isopycnal_fig_b64,
     _make_spectrum_fig_b64,
+    _make_velocity_iqr_profile_b64,
 )
 from .. import parameters as P
 
@@ -76,6 +79,10 @@ _GRID_HTML_TEMPLATE = """\
   td.mono { font-family:monospace; font-size:0.8rem; }
   .none-note { color:var(--muted); font-style:italic; }
   .var-qc { color:var(--good); font-size:0.78rem; }
+  details summary.collapse-toggle { color:var(--muted); font-size:0.76rem; cursor:pointer;
+    list-style:none; padding:0.15rem 0 0.4rem; user-select:none; }
+  details summary.collapse-toggle::before { content:"▾ "; }
+  details[open] summary.collapse-toggle::before { content:"▴ "; }
   @media print { .masthead { -webkit-print-color-adjust:exact; print-color-adjust:exact; } }
 </style>
 </head>
@@ -111,7 +118,11 @@ _GRID_HTML_TEMPLATE = """\
   {% if fig_sal_b64 or fig_sal_cf_b64 %}<a href="#sal">Salinity</a>{% endif %}
   {% if sigma_sections %}<a href="#density">Potential density</a>{% endif %}
   {% if vel_sections %}<a href="#vel">Velocities</a>{% endif %}
+  {% if fig_vel_iqr_b64 %}<a href="#vel-iqr">Velocity profiles</a>{% endif %}
+  {% if fig_grid_traj_b64 %}<a href="#grid-traj">Particle trajectory</a>{% endif %}
   {% if fig_n2_b64 %}<a href="#n2">N²</a>{% endif %}
+  {% if sigma_sections %}<a href="#isopycnal">Isopycnal depths</a>{% endif %}
+  {% if fig_grid_ts_b64 %}<a href="#grid-ts">Velocity time series</a>{% endif %}
   {% if fig_ts_grid_b64 %}<a href="#ts">T-S diagram</a>{% endif %}
   {% if fig_spectrum_b64 %}<a href="#spectrum">Power spectrum</a>{% endif %}
   <a href="#vars">Variables</a>
@@ -133,32 +144,28 @@ _GRID_HTML_TEMPLATE = """\
 {% if fig_temp_b64 %}
 <h2 id="temp">Temperature</h2>
 <p class="note">{{ p_range }} &bull; colour range: {{ temp_plow }}–{{ temp_phigh }} °C (5th–95th percentile) &bull; 20 discrete levels</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" src="data:image/png;base64,{{ fig_temp_b64 }}" alt="Temperature pcolormesh">
+</details>
 {% endif %}
 
 <!-- Salinity -->
 {% if fig_sal_b64 %}
 <h2 id="sal">Practical Salinity</h2>
 <p class="note">{{ sal_source }} &bull; colour range: {{ sal_plow }}–{{ sal_phigh }} (5th–95th percentile) &bull; 20 discrete levels</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" src="data:image/png;base64,{{ fig_sal_b64 }}" alt="Salinity pcolormesh">
+</details>
 {% endif %}
 
-<!-- Potential density -->
+<!-- Potential density (pcolormesh only — isopycnal time series rendered below N²) -->
 {% for sec in sigma_sections %}
 <h2 {% if loop.first %}id="density" {% endif %}>{{ sec.label }}</h2>
 <p class="note">{{ p_range }} &bull; colour range: {{ sec.plow }}–{{ sec.phigh }} {{ sec.units }} (5th–95th percentile) &bull; 20 discrete levels</p>
 {% if sec.fig_b64 %}
+<details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" src="data:image/png;base64,{{ sec.fig_b64 }}" alt="{{ sec.label }} pcolormesh">
-{% endif %}
-{% if sec.isopycnal_zoom_b64 %}
-<h2>Isopycnal depths &mdash; {{ sec.name }} (3-day zoom, unfiltered)</h2>
-<p class="note">3-day window centred on deployment midpoint &bull; raw gridded data &bull; no temporal filter applied.</p>
-<img class="fig" src="data:image/png;base64,{{ sec.isopycnal_zoom_b64 }}" alt="Isopycnal depths zoom {{ sec.label }}">
-{% endif %}
-{% if sec.isopycnal_b64 %}
-<h2>Isopycnal depths &mdash; {{ sec.name }} (full record, 24 h Tukey filtered)</h2>
-<p class="note">Full deployment &bull; 24 h Tukey (α=0.5) moving-average applied before contouring to reduce tidal noise.</p>
-<img class="fig" src="data:image/png;base64,{{ sec.isopycnal_b64 }}" alt="Isopycnal depths {{ sec.label }}">
+</details>
 {% endif %}
 {% endfor %}
 
@@ -167,26 +174,76 @@ _GRID_HTML_TEMPLATE = """\
 <h2 {% if loop.first %}id="vel" {% endif %}>{{ sec.label }}</h2>
 <p class="note">Vertically interpolated to regular pressure grid. QC-flagged samples excluded before interpolation. No temporal gap fill — NaN where no data.</p>
 {% if sec.fig_b64 %}
+<details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" src="data:image/png;base64,{{ sec.fig_b64 }}" alt="{{ sec.label }} grid">
+</details>
 {% endif %}
 {% endfor %}
+
+{% if fig_vel_iqr_b64 %}
+<h2 id="vel-iqr">Velocity IQR profiles <a class="top-link" href="#top">↑ top</a></h2>
+<p class="note">Median (solid line) and interquartile range (shaded, 25–75 %) across the full deployment at each pressure level. 2.5–97.5 % outer envelope for speed. Built from the gridded data.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" style="max-width:85%" src="data:image/png;base64,{{ fig_vel_iqr_b64 }}" alt="Velocity IQR profiles">
+</details>
+{% endif %}
+
+{% if fig_grid_traj_b64 %}
+<h2 id="grid-traj">Particle trajectory (gridded pressure levels) <a class="top-link" href="#top">↑ top</a></h2>
+<p class="note">Pseudo-Lagrangian trajectories at each gridded pressure level, integrated from east and north velocity (Euler forward). All start at the origin. Coloured by pressure (dbar).</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" style="max-width:55%" src="data:image/png;base64,{{ fig_grid_traj_b64 }}" alt="Grid particle trajectory">
+</details>
+{% endif %}
 
 {% if fig_n2_b64 %}
 <h2 id="n2">Buoyancy frequency squared (N²)</h2>
 <p class="note">log₁₀(N²) in s⁻². Purple = strongly stratified (high N²); yellow = weakly stratified. Computed from T and S via GSW; one pressure mid-point between each adjacent pair of grid levels.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" src="data:image/png;base64,{{ fig_n2_b64 }}" alt="N² pcolormesh">
+</details>
+{% endif %}
+
+<!-- Isopycnal depth time series (moved below N²) -->
+{% for sec in sigma_sections %}
+{% if sec.isopycnal_zoom_b64 %}
+<h2 {% if loop.first %}id="isopycnal" {% endif %}>Isopycnal depths &mdash; {{ sec.name }} (3-day zoom, unfiltered)</h2>
+<p class="note">3-day window centred on deployment midpoint &bull; raw gridded data &bull; no temporal filter applied.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" src="data:image/png;base64,{{ sec.isopycnal_zoom_b64 }}" alt="Isopycnal depths zoom {{ sec.label }}">
+</details>
+{% endif %}
+{% if sec.isopycnal_b64 %}
+<h2>Isopycnal depths &mdash; {{ sec.name }} (full record, 24 h Tukey filtered)</h2>
+<p class="note">Full deployment &bull; 24 h Tukey (α=0.5) moving-average applied before contouring to reduce tidal noise.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" src="data:image/png;base64,{{ sec.isopycnal_b64 }}" alt="Isopycnal depths {{ sec.label }}">
+</details>
+{% endif %}
+{% endfor %}
+
+{% if fig_grid_ts_b64 %}
+<h2 id="grid-ts">Velocity time series at depth of maximum mean speed</h2>
+<p class="note">Depth chosen as the pressure level with the highest time-mean current speed. Speed, east, and north velocity at that level.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
+<img class="fig" src="data:image/png;base64,{{ fig_grid_ts_b64 }}" alt="Velocity time series at max-speed depth">
+</details>
 {% endif %}
 
 {% if fig_ts_grid_b64 %}
 <h2 id="ts">T-S diagram</h2>
 <p class="note">All (pressure, time) grid points. Colour = log₁₀(count+1). QC-bad data excluded at the stack step before gridding.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" style="width:45%;max-width:45%;" src="data:image/png;base64,{{ fig_ts_grid_b64 }}" alt="T-S diagram">
+</details>
 {% endif %}
 
 {% if fig_spectrum_b64 %}
 <h2 id="spectrum">Temperature power spectrum</h2>
 <p class="note">Welch PSD (Hann window, 14-day segments, 50% overlap). One line per depth level; colour indicates pressure (shallow = light blue, deep = dark blue). Dashed vertical lines mark tidal and inertial frequencies. Dashed black line: &minus;2 spectral slope reference.</p>
+<details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" src="data:image/png;base64,{{ fig_spectrum_b64 }}" alt="Temperature power spectrum">
+</details>
 {% endif %}
 
 <!-- ══ NetCDF variables ══ -->
@@ -353,7 +410,7 @@ def generate_grid_page(
         # Velocity grids (ENU)
         vel_sections = []
 
-        def _qc_masked_vel(ds, vel_var):
+        def _qc_masked_vel(ds: "xr.Dataset", vel_var: str) -> "xr.DataArray | None":  # noqa: ANN202
             import xarray as _xr
 
             if vel_var not in ds.data_vars:
@@ -431,6 +488,9 @@ def generate_grid_page(
                 }
             )
 
+        fig_vel_iqr_b64 = _make_velocity_iqr_profile_b64(ds)
+        fig_grid_traj_b64 = _make_grid_trajectory_b64(ds)
+        fig_grid_ts_b64 = _make_grid_timeseries_b64(ds)
         fig_ts_grid_b64 = _make_grid_ts_diagram(ds)
 
         _lat_n2 = 0.0
@@ -549,6 +609,9 @@ def generate_grid_page(
             sal_source=sal_source,
             sigma_sections=sigma_sections,
             vel_sections=vel_sections,
+            fig_vel_iqr_b64=fig_vel_iqr_b64,
+            fig_grid_traj_b64=fig_grid_traj_b64,
+            fig_grid_ts_b64=fig_grid_ts_b64,
             fig_spectrum_b64=fig_spectrum_b64,
             fig_ts_grid_b64=fig_ts_grid_b64,
             fig_n2_b64=fig_n2_b64,

--- a/oceanarray/report/_html_helpers.py
+++ b/oceanarray/report/_html_helpers.py
@@ -281,12 +281,14 @@ def _read_nc_metadata(nc_path: Path) -> Dict[str, Any]:
                 time_vars.append(info)
 
         global_attrs = {k: str(val) for k, val in ds.attrs.items() if k != "history"}
+        dims = {str(d): int(s) for d, s in ds.sizes.items()}
         ds.close()
         return {
             "time_vars": time_vars,
             "scalar_vars": scalar_vars,
             "global_attrs": global_attrs,
             "analog_vars": analog_vars,
+            "dims": dims,
         }
     except Exception as exc:
         return {

--- a/oceanarray/report/_instrument.py
+++ b/oceanarray/report/_instrument.py
@@ -30,6 +30,8 @@ from ._plots import (
     _make_speed_boxplot,
     _make_temperature_trajectory,
     _make_analog_timeseries,
+    _make_adcp_velocity_b64,
+    _make_adcp_rose_b64,
 )
 
 
@@ -133,7 +135,7 @@ _INSTRUMENT_HTML_TEMPLATE = """\
     <div{% if duration == '—' %} class="meta-miss"{% endif %}><dt>Duration</dt><dd>{{ duration }}</dd></div>
     <div{% if median_dt is none or median_dt == '—' %} class="meta-miss"{% endif %}><dt>Samp.&nbsp;&Delta;t</dt><dd>{{ median_dt | default("—") }}</dd></div>
     <div{% if n_records is none or n_records == '—' %} class="meta-miss"{% endif %}><dt>Records</dt><dd>{{ n_records | default("—") }}</dd></div>
-    <div><dt>Source&nbsp;file</dt><dd>{{ nc_file }}</dd></div>
+    <div><dt>Source&nbsp;file</dt><dd>{{ nc_file }}{% if data_stage and data_stage != 'stage3' %} <span style="color:#e67e22;font-weight:bold">({{ data_stage }} — QC not applied)</span>{% endif %}</dd></div>
   </dl>
 </div>
 
@@ -141,9 +143,11 @@ _INSTRUMENT_HTML_TEMPLATE = """\
   Jump to:
   <a href="#files">Files</a>
   <a href="#history">History</a>
+  {% if fig_adcp_velocity_b64 %}<a href="#adcp-velocity">Velocity</a>{% endif %}
   <a href="#timeseries">Time series</a>
   <a href="#start">Start/end windows</a>
   {% if fig_tsd_b64 %}<a href="#ts">T-S diagram</a>{% endif %}
+  {% if fig_adcp_rose_b64 %}<a href="#adcp-rose">Current roses</a>{% endif %}
   {% if fig_rose_b64 %}<a href="#rose">Current roses</a>{% endif %}
   {% if fig_trajectory_b64 %}<a href="#trajectory">Trajectory</a>{% endif %}
   {% if fig_hodograph_b64 %}<a href="#hodograph">Hodograph</a>{% endif %}
@@ -151,6 +155,7 @@ _INSTRUMENT_HTML_TEMPLATE = """\
   {% if fig_analog_b64 %}<a href="#analog">Analog channels</a>{% endif %}
   <a href="#dist">Distributions</a>
   {% if qc_summary %}<a href="#qc">QC thresholds &amp; flags</a>{% endif %}
+  {% if nc_meta.dims %}<a href="#dims">Dimensions</a>{% endif %}
   <a href="#vars">Variables</a>
 </nav>
 
@@ -204,6 +209,18 @@ _INSTRUMENT_HTML_TEMPLATE = """\
 <p class="none-note">No history attribute found.</p>
 {% endif %}
 
+<!-- ══ ADCP velocity colour plots ══ -->
+{% if fig_adcp_velocity_b64 %}
+<h2 id="adcp-velocity">Velocity</h2>
+<p style="font-size:0.8rem;color:#555;margin-top:-0.5rem;">
+  Time&ndash;range colour plots of the four velocity components (east, north, up, error).
+  Y-axis: range from transducer (m).
+  Colour scale: symmetric about zero; percentile&nbsp;2/98 of all components combined.
+  {% if data_stage and data_stage != 'stage3' %}Magnetic declination has <b>not</b> been applied ({{ data_stage }} data).{% endif %}
+</p>
+<img class="fig" src="data:image/png;base64,{{ fig_adcp_velocity_b64 }}">
+{% endif %}
+
 <!-- ══ Full time series ══ -->
 <h2 id="timeseries">Time series (full deployment)</h2>
 {% if fig_ts_b64 %}
@@ -229,6 +246,18 @@ _INSTRUMENT_HTML_TEMPLATE = """\
   Coloured by pressure (or sample index). &times; = suspect &nbsp;|&nbsp; &times; = bad (QC flags).
 </p>
 <img class="fig" src="data:image/png;base64,{{ fig_tsd_b64 }}">
+{% endif %}
+
+<!-- ══ ADCP current roses ══ -->
+{% if fig_adcp_rose_b64 %}
+<h2 id="adcp-rose">Current roses</h2>
+<p style="font-size:0.8rem;color:#555;margin-top:-0.5rem;">
+  Depth-average followed by bins nearest 100, 200, 300 and 400&nbsp;m from the transducer.
+  Bins with fewer than two valid samples are omitted.
+  Direction toward which the current flows; 0°&nbsp;=&nbsp;N, clockwise.
+  {% if data_stage and data_stage != 'stage3' %}Magnetic declination not yet applied ({{ data_stage }} data).{% endif %}
+</p>
+<img class="fig" src="data:image/png;base64,{{ fig_adcp_rose_b64 }}">
 {% endif %}
 
 <!-- ══ Current roses ══ -->
@@ -380,6 +409,19 @@ _INSTRUMENT_HTML_TEMPLATE = """\
 </table>
 {% endif %}
 
+<!-- ══ NetCDF dimensions ══ -->
+{% if nc_meta.dims %}
+<h2 id="dims">NetCDF dimensions &mdash; {{ nc_file }}</h2>
+<table class="var-table" style="max-width:28rem">
+  <thead><tr><th>Dimension</th><th class="num">Size</th></tr></thead>
+  <tbody>
+    {% for dim, size in nc_meta.dims.items() %}
+    <tr><td class="mono">{{ dim }}</td><td class="num">{{ "{:,}".format(size) }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
 <!-- ══ NetCDF variables ══ -->
 <h2 id="vars">NetCDF variables &mdash; {{ nc_file }}</h2>
 {% if nc_meta.get("error") %}
@@ -403,7 +445,7 @@ _INSTRUMENT_HTML_TEMPLATE = """\
       <td class="num" style="font-size:0.76rem;white-space:nowrap">{% if v.v_min is not none %}{{ v.v_min }} / {{ v.v_max }}{% else %}&mdash;{% endif %}</td>
       <td>{{ v.units }}</td>
       <td>{{ v.long_name }}</td>
-      <td style="font-size:0.78rem;color:var(--muted)">{{ v.standard_name }}</td>
+      <td style="font-size:0.78rem;color:var(--muted);max-width:18rem;word-break:break-all">{{ v.standard_name }}</td>
       <td style="text-align:center">{% if v.has_qc %}<span class="var-qc">✓</span>{% else %}&ndash;{% endif %}</td>
     </tr>
     {% endif %}
@@ -509,10 +551,21 @@ def generate_instrument_pages(
         _base = proc_dir / instr_type / f"{mooring_name}_{serial}"
         stage3_nc = Path(str(_base) + "_stage3.nc")
         stage3_nc = stage3_nc if stage3_nc.exists() else None
-        best_nc = stage3_nc or (
-            Path(str(_base) + "_stage2.nc")
-            if Path(str(_base) + "_stage2.nc").exists()
-            else None
+        _stage2_nc = Path(str(_base) + "_stage2.nc")
+        _stage1_nc = Path(str(_base) + "_stage1.nc")
+        best_nc = (
+            stage3_nc
+            or (_stage2_nc if _stage2_nc.exists() else None)
+            or (_stage1_nc if _stage1_nc.exists() else None)
+        )
+        data_stage = (
+            "stage3"
+            if stage3_nc
+            else (
+                "stage2"
+                if _stage2_nc.exists()
+                else ("stage1" if _stage1_nc.exists() else None)
+            )
         )
         nc_file = best_nc.name if best_nc else "—"
 
@@ -586,7 +639,21 @@ def generate_instrument_pages(
                 _make_windows_fig(best_nc, instr_type) if best_nc else None
             ),
             "fig_tsd_b64": _make_ts_diagram(best_nc) if best_nc else None,
-            "fig_rose_b64": _make_instrument_rose_b64(best_nc) if best_nc else None,
+            "fig_rose_b64": (
+                _make_instrument_rose_b64(best_nc)
+                if best_nc and instr_type.lower() != "adcp"
+                else None
+            ),
+            "fig_adcp_velocity_b64": (
+                _make_adcp_velocity_b64(best_nc)
+                if best_nc and instr_type.lower() == "adcp"
+                else None
+            ),
+            "fig_adcp_rose_b64": (
+                _make_adcp_rose_b64(best_nc)
+                if best_nc and instr_type.lower() == "adcp"
+                else None
+            ),
             "fig_trajectory_b64": (
                 _make_temperature_trajectory(best_nc)
                 if best_nc and instr_type.lower() == "aquadopp"
@@ -606,6 +673,7 @@ def generate_instrument_pages(
             "qc_summary": _read_qc_summary(stage3_nc) if stage3_nc else [],
             "qc_thresholds": _read_qc_thresholds(stage3_nc) if stage3_nc else [],
             "nc_meta": _read_nc_metadata(best_nc) if best_nc else {},
+            "data_stage": data_stage,  # "stage1", "stage2", "stage3", or None
         }
         analog_vars = ctx["nc_meta"].get("analog_vars", [])
         ctx["fig_analog_b64"] = (
@@ -613,13 +681,20 @@ def generate_instrument_pages(
             if best_nc and analog_vars
             else None
         )
-        # Look up the per-instrument YAML entry for analog metadata
-        _instr_entries = cfg.get("clamp", cfg.get("instruments", []))
+        # Look up the per-instrument YAML entry for analog metadata.
+        # Search both 'clamp' and 'inline' lists (the serial in inline entries
+        # may contain a comma; _safe_serial strips it to the first token).
+        _instr_entries = list(cfg.get("clamp", cfg.get("instruments", []))) + [
+            e
+            for e in cfg.get("inline", [])
+            if isinstance(e, dict) and "instrument" in e
+        ]
         _yaml_entry: Dict[str, Any] = next(
             (
                 e
                 for e in _instr_entries
-                if _safe_serial(str(e.get("serial", ""))) == serial
+                if _safe_serial(str(e.get("serial", "")).split(",")[0].strip())
+                == serial
             ),
             {},
         )

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -30,6 +30,7 @@ from ._html_helpers import (
 from ._grid import generate_grid_page
 from ._instrument import generate_instrument_pages
 from ._stack import generate_stack_page
+from ..utilities import extract_inline_instruments
 
 
 # ---------------------------------------------------------------------------
@@ -224,8 +225,8 @@ _HTML_TEMPLATE = """\
     <tr>
       <td class="num">{{ loop.index }}</td>
       <td>{{ instr.instr_type }}</td>
-      <td><a href="{{ mooring_name }}_{{ instr.serial }}_report.html"
-             style="font-family:monospace;font-size:0.85rem">{{ instr.serial }}</a></td>
+      <td>{% if instr.report_exists %}<a href="{{ mooring_name }}_{{ instr.serial }}_report.html"
+             style="font-family:monospace;font-size:0.85rem">{{ instr.serial }}</a>{% else %}<span style="font-family:monospace;font-size:0.85rem">{{ instr.serial }}</span>{% endif %}</td>
       <td class="num">{{ "%.1f"|format(instr.hab) }}</td>
       <td class="num">{{ "%.0f"|format(instr.depth) if instr.depth is not none else "—" }}</td>
       <td>
@@ -340,8 +341,8 @@ _HTML_TEMPLATE = """\
     <tr{% if instr.stopped_early %} class="row-warn"{% endif %}>
       <td class="num">{{ loop.index }}</td>
       <td>{{ instr.instr_type }}</td>
-      <td><a href="{{ mooring_name }}_{{ instr.serial }}_report.html"
-             style="font-family:monospace;font-size:0.85rem">{{ instr.serial }}</a></td>
+      <td>{% if instr.report_exists %}<a href="{{ mooring_name }}_{{ instr.serial }}_report.html"
+             style="font-family:monospace;font-size:0.85rem">{{ instr.serial }}</a>{% else %}<span style="font-family:monospace;font-size:0.85rem">{{ instr.serial }}</span>{% endif %}</td>
       <td class="num">{{ "%.1f"|format(instr.hab) }}</td>
       {% if instr.nc and instr.nc.get("error") %}
         <td colspan="10" style="color:var(--bad);font-size:0.8rem;">Error: {{ instr.nc.error }}</td>
@@ -624,13 +625,21 @@ def _serials_in_nc(nc_path: Path) -> frozenset:
     Reads the ``serial`` coordinate on the ``N_LEVELS`` dimension.  Returns an
     empty frozenset if the file is missing, unreadable, or has no ``serial``
     coordinate.
+
+    ADCP entries use suffixed serials (e.g. ``16430_hd``, ``16430_b03``).  The
+    returned set also includes the base serial (suffix stripped) so that the YAML
+    instrument serial matches correctly.
     """
+    import re
+
     try:
         import xarray as xr
 
         ds = xr.open_dataset(nc_path, decode_timedelta=False)
         if "serial" in ds.coords:
-            return frozenset(str(s) for s in ds["serial"].values)
+            raw = frozenset(str(s) for s in ds["serial"].values)
+            base = frozenset(re.sub(r"_(hd|b\d+)$", "", s) for s in raw)
+            return raw | base
     except Exception:  # noqa: BLE001
         pass
     return frozenset()
@@ -675,7 +684,7 @@ class MooringReport:
         with open(yaml_path) as f:
             cfg = yaml.safe_load(f)
 
-        ctx = self._build_context(mooring_name, cfg, proc_dir, yaml_path)
+        ctx = self._build_context(mooring_name, cfg, proc_dir, yaml_path, out_dir)
         html = self._render(ctx)
         output_path.write_text(html, encoding="utf-8")
         _status("file", str(output_path.relative_to(self.base_dir)))
@@ -718,13 +727,15 @@ class MooringReport:
         cfg: Dict[str, Any],
         proc_dir: Path,
         yaml_path: Path,
+        out_dir: Optional[Path] = None,
     ) -> Dict[str, Any]:
         deploy_dt = _parse_dt(cfg.get("deployment_time"))
         recover_dt = _parse_dt(cfg.get("recovery_time"))
         waterdepth = cfg.get("waterdepth")
         raw_subdir = str(cfg.get("directory", "raw")).rstrip("/")
 
-        instrument_list = cfg.get("clamp", cfg.get("instruments", []))
+        instrument_list = list(cfg.get("clamp", cfg.get("instruments", [])))
+        instrument_list += extract_inline_instruments(cfg.get("inline", []))
 
         stack_nc = proc_dir / f"{mooring_name}_stack.nc"
         grid_nc = proc_dir / f"{mooring_name}_grid.nc"
@@ -804,6 +815,10 @@ class MooringReport:
                     "stopped_early": stopped_early,
                     "skipped": bool(entry.get("skip")),
                     "skip_reason": entry.get("skip_reason", ""),
+                    "report_exists": (
+                        out_dir is not None
+                        and (out_dir / f"{mooring_name}_{serial}_report.html").exists()
+                    ),
                     "stages": _stage_files(proc_dir, instr_type, mooring_name, serial),
                     "in_stack": serial in stack_serials,
                     "in_grid": (serial in stack_serials) and grid_exists,

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -1134,13 +1134,34 @@ def _make_grid_fig_b64(
 
 
 def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
-    """Stacked T / S pcolormesh panels for the grid report hydrography section.
+    """Stacked temperature / salinity pcolormesh panels for the grid report.
 
-    Panels rendered (only those present in *ds*):
-    - Temperature (RdYlBu_r)
-    - Salinity (YlGnBu_r)
+    Both panels have pressure (dbar) on the Y-axis (inverted, surface at top).
+    Colorbar bounds are clipped to the ``COLORBAR_PLOW``–``COLORBAR_PHIGH`` percentiles
+    of the data to reduce the influence of outliers on color scaling.
 
-    Returns None if neither variable is present.
+    **Temperature** (°C, colormap ``RdYlBu_r``): sea water temperature on the gridded
+    pressure–time grid.
+
+    **Salinity** (PSU, colormap ``YlGnBu_r``): taken from the ``salinity`` variable if
+    present.  If absent but both ``conductivity`` (mS cm⁻¹) and ``temperature`` (°C) are
+    present, Practical Salinity is derived via ``gsw.SP_from_C`` (PSS-78).  Note: this
+    is Practical Salinity, not Absolute Salinity (g kg⁻¹); the latter would require
+    pressure and longitude via ``gsw.SA_from_SP``.
+
+    Panels are rendered only for variables that are present in *ds* or derivable.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Gridded mooring dataset with dimensions ``(time, pressure)``.
+
+    Returns
+    -------
+    str or None
+        Base64-encoded PNG for HTML embedding, or None if no hydrographic data
+        are present.
+
     """
     import matplotlib.pyplot as plt
     import matplotlib.colors as mcolors
@@ -1155,9 +1176,14 @@ def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
         panels.append((var, cmap))
 
     # Also allow derived salinity from T/C
-    if "salinity" not in ds.data_vars and "conductivity" in ds.data_vars and "temperature" in ds.data_vars:
+    if (
+        "salinity" not in ds.data_vars
+        and "conductivity" in ds.data_vars
+        and "temperature" in ds.data_vars
+    ):
         try:
             import gsw
+
             p_1d = ds["pressure"].values
             T = ds["temperature"].transpose("time", "pressure").values
             C = ds["conductivity"].transpose("time", "pressure").values
@@ -1193,7 +1219,9 @@ def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
         _vmax = float(np.nanpercentile(data, P.COLORBAR_PHIGH))
         bounds = _nice_colorbar_bounds(_vmin, _vmax, n=20)
         norm = mcolors.BoundaryNorm(bounds, ncolors=256)
-        pc = ax.pcolormesh(time, pressure, data, shading="nearest", cmap=cmap, norm=norm)
+        pc = ax.pcolormesh(
+            time, pressure, data, shading="nearest", cmap=cmap, norm=norm
+        )
         cb = fig.colorbar(pc, ax=ax, pad=0.02, ticks=bounds[::2])
         cb.set_label(f"{label} ({units})" if units else label)
         ax.invert_yaxis()
@@ -1212,11 +1240,34 @@ def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
 def _make_grid_velocity_stacked_b64(ds: "xr.Dataset") -> Optional[str]:
     """Stacked east / north / up velocity pcolormesh panels for the grid report.
 
-    Uses a shared symmetric Spectral_r colormap across E/N/Up so magnitudes are
-    comparable across panels.  Up velocity uses its own symmetric bounds (usually
-    much smaller than horizontal).
+    All three panels have pressure (dbar) on the Y-axis (inverted, surface at top) and
+    share the same time axis.
 
-    Returns None if no velocity data are present.
+    **Coordinate convention**: velocities are in geographic ENU (East–North–Up), after
+    magnetic declination correction applied in stage 3.  Positive east = rightward facing
+    north; positive north = toward True North; positive up = upward.
+
+    The horizontal panels (east, north) share a symmetric diverging colormap
+    (``Spectral_r``) with bounds ±max(|2nd pctile|, |98th pctile|) of all finite
+    horizontal velocity values, so east and north are directly comparable in magnitude.
+
+    Up velocity uses its own symmetric bounds (same percentile logic, but independent of
+    horizontal) because open-ocean vertical velocities are typically 1–2 cm s⁻¹ while
+    horizontal velocities can reach tens of cm s⁻¹.
+
+    All velocity units are m s⁻¹.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Gridded dataset with dimensions ``(time, pressure)``.
+
+    Returns
+    -------
+    str or None
+        Base64-encoded PNG for HTML embedding, or None if no velocity variables are
+        present.
+
     """
     import matplotlib.pyplot as plt
     import matplotlib.colors as mcolors
@@ -1224,9 +1275,9 @@ def _make_grid_velocity_stacked_b64(ds: "xr.Dataset") -> Optional[str]:
     from .. import parameters as P
 
     vel_vars = [
-        ("east_velocity",  "East velocity",  "m s⁻¹"),
+        ("east_velocity", "East velocity", "m s⁻¹"),
         ("north_velocity", "North velocity", "m s⁻¹"),
-        ("up_velocity",    "Up velocity",    "m s⁻¹"),
+        ("up_velocity", "Up velocity", "m s⁻¹"),
     ]
     present = [(v, lbl, u) for v, lbl, u in vel_vars if v in ds.data_vars]
     if not present:
@@ -1236,17 +1287,23 @@ def _make_grid_velocity_stacked_b64(ds: "xr.Dataset") -> Optional[str]:
     time = ds["time"].values
 
     # Shared symmetric bounds from horizontal velocity (2nd/98th pctile)
-    horiz_vals = np.concatenate([
-        ds[v].values.ravel()
-        for v, _, _ in present
-        if v in ("east_velocity", "north_velocity")
-    ])
+    horiz_vals = np.concatenate(
+        [
+            ds[v].values.ravel()
+            for v, _, _ in present
+            if v in ("east_velocity", "north_velocity")
+        ]
+    )
     finite_h = horiz_vals[np.isfinite(horiz_vals)]
-    abs_max_h = max(
-        abs(float(np.percentile(finite_h, 2))),
-        abs(float(np.percentile(finite_h, 98))),
-        1e-4,
-    ) if len(finite_h) else 1.0
+    abs_max_h = (
+        max(
+            abs(float(np.percentile(finite_h, 2))),
+            abs(float(np.percentile(finite_h, 98))),
+            1e-4,
+        )
+        if len(finite_h)
+        else 1.0
+    )
     h_bounds = _nice_colorbar_bounds(-abs_max_h, abs_max_h, n=20)
     h_norm = mcolors.BoundaryNorm(h_bounds, ncolors=256)
 
@@ -1254,11 +1311,15 @@ def _make_grid_velocity_stacked_b64(ds: "xr.Dataset") -> Optional[str]:
     if "up_velocity" in ds.data_vars:
         up_vals = ds["up_velocity"].values.ravel()
         finite_u = up_vals[np.isfinite(up_vals)]
-        abs_max_u = max(
-            abs(float(np.percentile(finite_u, 2))),
-            abs(float(np.percentile(finite_u, 98))),
-            1e-4,
-        ) if len(finite_u) else 1.0
+        abs_max_u = (
+            max(
+                abs(float(np.percentile(finite_u, 2))),
+                abs(float(np.percentile(finite_u, 98))),
+                1e-4,
+            )
+            if len(finite_u)
+            else 1.0
+        )
         u_bounds = _nice_colorbar_bounds(-abs_max_u, abs_max_u, n=20)
         u_norm = mcolors.BoundaryNorm(u_bounds, ncolors=256)
     else:
@@ -1277,8 +1338,10 @@ def _make_grid_velocity_stacked_b64(ds: "xr.Dataset") -> Optional[str]:
             data = data.copy()
             data[ds[qc_var].transpose("pressure", "time").values >= 3] = np.nan
         bounds = u_bounds if var == "up_velocity" else h_bounds
-        norm   = u_norm   if var == "up_velocity" else h_norm
-        pc = ax.pcolormesh(time, pressure, data, shading="nearest", cmap="Spectral_r", norm=norm)
+        norm = u_norm if var == "up_velocity" else h_norm
+        pc = ax.pcolormesh(
+            time, pressure, data, shading="nearest", cmap="Spectral_r", norm=norm
+        )
         cb = fig.colorbar(pc, ax=ax, pad=0.02, ticks=bounds[::2])
         cb.set_label(units)
         ax.invert_yaxis()
@@ -1301,7 +1364,9 @@ def _make_grid_sigma_b64(ds: "xr.Dataset") -> Optional[str]:
     import matplotlib.dates as mdates
     from .. import parameters as P
 
-    sigma_vars = [v for v in ds.data_vars if v.startswith("sigma") and "pressure" in ds[v].dims]
+    sigma_vars = [
+        v for v in ds.data_vars if v.startswith("sigma") and "pressure" in ds[v].dims
+    ]
     if not sigma_vars:
         return None
 
@@ -1321,7 +1386,9 @@ def _make_grid_sigma_b64(ds: "xr.Dataset") -> Optional[str]:
         _vmax = float(np.nanpercentile(data, P.COLORBAR_PHIGH))
         bounds = _nice_colorbar_bounds(_vmin, _vmax, n=20)
         norm = mcolors.BoundaryNorm(bounds, ncolors=256)
-        pc = ax.pcolormesh(time, pressure, data, shading="nearest", cmap=P.DENSITY_COLORMAP, norm=norm)
+        pc = ax.pcolormesh(
+            time, pressure, data, shading="nearest", cmap=P.DENSITY_COLORMAP, norm=norm
+        )
         cb = fig.colorbar(pc, ax=ax, pad=0.02, ticks=bounds[::2])
         cb.set_label(f"{label} ({units})" if units else label)
         ax.invert_yaxis()
@@ -1620,16 +1687,44 @@ def _make_grid_ts_diagram(ds: "xr.Dataset", n_bins: int = 80) -> Optional[str]:
 
 
 def _make_velocity_iqr_profile_b64(ds: "xr.Dataset") -> Optional[str]:
-    """IQR velocity profiles from the gridded dataset.
+    """Percentile-profile figure for gridded ADCP velocity data.
 
-    Three side-by-side panels:
-    - Left: current speed — p2.5/p25/p50/p75/p97.5 shaded profile.
-    - Middle: east and north velocity on the same axes, each with p25/p50/p75,
-      using Okabe-Ito colours (#0072B2 blue for east, #E69F00 orange for north).
-    - Right: count of non-NaN values at each pressure level.
+    Three side-by-side panels, all with pressure (dbar) on the Y-axis (inverted,
+    surface at top).  All velocity units are m s⁻¹.
 
-    Y-axis is pressure (dbar), inverted (surface at top).  Returns None if no
-    velocity data are present.
+    **Left — current speed** (always ≥ 0):
+        Shaded percentile profile: outer band p2.5–p97.5 (95% range of the
+        distribution); inner band IQR p25–p75; median p50.  Wide IQR at a given
+        depth indicates high velocity variability (e.g. an eddy-active layer or a
+        strong tidal signal); narrow IQR with a large median indicates a persistent
+        mean flow.  ``current_speed`` is computed from ``sqrt(east² + north²)`` if
+        not already present in the dataset.
+
+    **Middle — east and north velocity** (can be negative):
+        Median and IQR (p25/p50/p75) for each component.  East velocity in
+        Okabe-Ito blue (#0072B2); north velocity in Okabe-Ito orange (#E69F00); both
+        colours are distinguishable for common colour-vision deficiencies.
+        Positive east = rightward facing north (geographic ENU after declination
+        correction); positive north = toward True North.  A median near zero with
+        large IQR suggests rotary motion (e.g. tides or near-inertial oscillations);
+        a non-zero median indicates a mean current.
+
+    **Right — count** (dimensionless):
+        Number of non-NaN time steps at each pressure level.  Use this panel to assess
+        data coverage before interpreting velocity statistics: pressure levels with very
+        few records produce unreliable percentile estimates.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Gridded dataset with dimensions ``(time, pressure)`` containing at minimum one
+        of ``current_speed``, ``east_velocity``, or ``north_velocity`` in m s⁻¹.
+
+    Returns
+    -------
+    str or None
+        Base64-encoded PNG for HTML embedding, or None if no velocity data are present.
+
     """
     import warnings
     import matplotlib.pyplot as plt
@@ -1968,14 +2063,37 @@ def _filter_sigma_tukey(
 
 
 def _make_grid_trajectory_b64(ds: "xr.Dataset") -> Optional[str]:
-    """Particle trajectory plot from gridded east/north velocity.
+    """Pseudo-Lagrangian current-vector integral by pressure level for the grid report.
 
-    For each pressure level, integrate east and north velocity over time
-    (Euler forward; NaN velocities set to zero) to produce a pseudo-Lagrangian
-    trajectory.  All trajectories start at the origin.  Lines are coloured by
-    pressure (dbar) using the viridis colormap (shallow → deep).
+    For each pressure level in the gridded dataset, integrates east and north velocity
+    over time using the Euler forward method to produce a cumulative displacement
+    trajectory.  All trajectories start at the origin (0, 0).  The figure shows the net
+    displacement (in **metres**) a neutrally buoyant float would experience at each depth
+    if it were advected by the measured velocity field.  This is a *pseudo-Lagrangian*
+    representation of Eulerian mooring velocity data — the water parcel does not
+    actually stay at the mooring.
 
-    Returns None if east_velocity or north_velocity are absent.
+    **QC masking**: time steps flagged suspect or bad on ``east_velocity_qc`` or
+    ``north_velocity_qc`` (≥ 3) are set to NaN before integration.  NaN time steps
+    contribute zero displacement, which biases trajectories toward the origin during
+    extended data gaps.
+
+    Trajectory lines are coloured by pressure (dbar) using ``viridis_r``: shallow
+    levels (low pressure) are light; deep levels (high pressure) are dark.  Pressure
+    levels with no finite velocity data at any time step are omitted.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Gridded dataset with dimensions ``(time, pressure)``, containing
+        ``east_velocity`` and ``north_velocity`` in m s⁻¹.
+
+    Returns
+    -------
+    str or None
+        Base64-encoded PNG for HTML embedding, or None if east/north velocity are
+        absent or all-NaN.
+
     """
     import matplotlib.pyplot as plt
     import matplotlib.colors as mcolors
@@ -2050,11 +2168,32 @@ def _make_grid_trajectory_b64(ds: "xr.Dataset") -> Optional[str]:
 
 
 def _make_grid_timeseries_b64(ds: "xr.Dataset") -> Optional[str]:
-    """Time series of speed, east, and north velocity at the depth of maximum mean speed.
+    """Velocity time series at the depth of maximum time-mean current speed.
 
-    The target pressure level is chosen as the one with the highest time-mean
-    current speed (or east/north magnitude).  Returns None if velocity data are
-    absent.
+    Three stacked panels (shared time axis, all in m s⁻¹):
+
+    - **Speed** (black): ``sqrt(east² + north²)``; always ≥ 0.
+    - **East velocity** (Okabe-Ito blue #0072B2): positive = eastward flow (geographic
+      ENU, after magnetic declination correction).
+    - **North velocity** (Okabe-Ito orange #E69F00): positive = flow toward True North.
+
+    The target pressure level is chosen automatically as the level with the highest
+    time-mean current speed.  This heuristic selects the most energetic depth in the
+    record and is not guaranteed to be oceanographically meaningful.  The selected
+    pressure is annotated in the figure title.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Gridded dataset with dimensions ``(time, pressure)`` containing at minimum
+        ``east_velocity`` and ``north_velocity`` in m s⁻¹.
+
+    Returns
+    -------
+    str or None
+        Base64-encoded PNG for HTML embedding, or None if horizontal velocity data are
+        absent.
+
     """
     import warnings
     import matplotlib.pyplot as plt
@@ -2295,14 +2434,53 @@ def _make_adcp_trajectories_b64(ds: "xr.Dataset") -> Optional[str]:
 
 
 def _make_adcp_velocity_b64(nc_path: str) -> Optional[str]:
-    """Stacked colour panels for ADCP per-instrument page.
+    """Stacked colour panels for the ADCP per-instrument HTML report page.
 
-    Panels (where data are present):
-    - East / North / Up / Error velocity — symmetric Spectral_r (11 class), shared bounds
-    - Current speed (sqrt(E²+N²))        — sequential YlOrRd, 0 → 98th pctile
-    - Current direction (atan2(E,N) °T)   — cyclic twilight_shifted, 0–360°
+    Reads the stage-3 NetCDF file at *nc_path* and produces a multi-panel
+    time × range pcolormesh figure encoded as a base64 PNG string for HTML embedding.
 
-    Y-axis is the ``range`` coordinate; inverted for downward-looking instruments.
+    **Coordinate convention**: velocities are in geographic ENU (East–North–Up), after
+    magnetic declination correction applied in stage 3.  Positive east = rightward facing
+    north; positive north = toward True North.
+
+    **Direction convention** (``current_direction`` panel): direction *toward which* the
+    water flows, clockwise from True North (0° = northward, 90° = eastward).  This is
+    the oceanographic convention, opposite to meteorological "direction from".
+    Computed as ``atan2(east, north) mod 360``.
+
+    Panels rendered for each variable present in the file:
+
+    ====================  ================================  ===================
+    Variable              Label                             Colormap
+    ====================  ================================  ===================
+    east_velocity         East velocity (m s⁻¹)            Spectral_r (div)
+    north_velocity        North velocity (m s⁻¹)           Spectral_r (div)
+    up_velocity           Up velocity (m s⁻¹)              Spectral_r (div)
+    error_velocity        Error velocity (m s⁻¹)           Spectral_r (div)
+    current_speed         Current speed (m s⁻¹)            plasma (seq, 0→98th)
+    current_direction     Current direction (°T)            hsv (cyclic, 0–360°)
+    bin_pressure          Bin pressure (dbar)               viridis (seq)
+    ====================  ================================  ===================
+
+    Diverging panels (east/north/up/error) share symmetric colormap bounds set to
+    ±max(|2nd pctile|, |98th pctile|) of all finite ENU velocity values.
+
+    Bins flagged at or below the seabed (``seabed_qc >= 3``) are masked to NaN.
+    Y-axis (range coordinate) is inverted for downward-looking instruments (pressure
+    increases into the page); non-inverted for upward-looking.
+
+    Parameters
+    ----------
+    nc_path : str
+        Path to a stage-3 NetCDF file for a single ADCP instrument.
+
+    Returns
+    -------
+    str or None
+        Base64-encoded PNG string (for embedding in HTML as
+        ``<img src="data:image/png;base64,…">``), or None if the file cannot be
+        opened, no velocity data are present, or the range coordinate is absent.
+
     """
     try:
         import matplotlib.pyplot as plt
@@ -2443,7 +2621,7 @@ def _make_adcp_velocity_b64(nc_path: str) -> Optional[str]:
             )
 
             orientation = ds.attrs.get("orientation_yaml") or ds.attrs.get(
-                "orientation_instrument", "up"
+                "orientation_instrument", "down"
             )
             looking_down = str(orientation).lower() == "down"
             ylabel = (

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -273,6 +273,8 @@ def _build_fig_from_ds(
             vmin, vmax = float(np.nanmin(data)), float(np.nanmax(data))
             pad = max((vmax - vmin) * 0.1, 0.5)
             ax.set_ylim(vmax + pad, vmin - pad)
+        elif vname == "heading":
+            ax.set_ylim(0.0, 360.0)
         elif "velocity" in vname:
             _half = max(abs(float(np.nanmax(data))), abs(float(np.nanmin(data))), 1e-6)
             ax.set_ylim(-_half, _half)
@@ -385,7 +387,15 @@ def _make_windows_fig(
                 hspace=0.18,
             )
 
-            def _plot_panel(ax, vname, label, color, invert, mask, col):
+            def _plot_panel(  # noqa: ANN202
+                ax: "plt.Axes",
+                vname: str,
+                label: str,
+                color: str,
+                invert: bool,
+                mask: "np.ndarray",
+                col: str,
+            ) -> None:
                 _suspect_t = float(ds.attrs.get("tilt_suspect_threshold", 20.0))
                 _fail_t = float(ds.attrs.get("tilt_fail_threshold", 30.0))
 
@@ -507,11 +517,23 @@ def _make_data_histogram(nc_path: Path) -> Optional[str]:
 
         panels = _instrument_panels(ds)
         _HIST_EXCLUDE = {"battery_voltage"}
-        plot_panels = [
-            (vn, lbl)
+        plot_panels: list = [
+            (vn, lbl, False)
             for vn, lbl, *_ in panels
             if ds[vn].dims == ("time",) and vn not in _HIST_EXCLUDE
         ]
+        # ADCP: append multi-dim velocity and percent_good panels (flattened).
+        _ADCP_FLAT = [
+            ("east_velocity", "East vel. (all bins, m s⁻¹)"),
+            ("north_velocity", "North vel. (all bins, m s⁻¹)"),
+            ("up_velocity", "Up vel. (all bins, m s⁻¹)"),
+            ("error_velocity", "Error vel. (all bins, m s⁻¹)"),
+            ("percent_good", "Pct good (all bins/beams, %)"),
+        ]
+        for vn, lbl in _ADCP_FLAT:
+            if vn in ds.data_vars and ds[vn].values.ndim > 1:
+                plot_panels.append((vn, lbl, True))  # True = flatten
+
         if not plot_panels:
             ds.close()
             return None
@@ -530,25 +552,46 @@ def _make_data_histogram(nc_path: Path) -> Optional[str]:
         for k in range(len(plot_panels), len(axs)):
             axs[k].set_visible(False)
 
-        for ax, (vname, ylabel) in zip(axs, plot_panels):
-            data = ds[vname].values.astype(float)
+        for ax, (vname, ylabel, flatten) in zip(axs, plot_panels):
+            data = (
+                ds[vname].values.astype(float).ravel()
+                if flatten
+                else ds[vname].values.astype(float)
+            )
 
             qc_var = f"{vname}_qc"
-            if qc_var in ds:
-                flags = ds[qc_var].values.astype(int)
-                mask = np.isfinite(data) & ~np.isin(flags, [4, 9])
-                n_bad = int(np.sum(flags == 4))
+            has_qc = qc_var in ds
+            if has_qc:
+                flags = (
+                    ds[qc_var].values.astype(int).ravel()
+                    if flatten
+                    else ds[qc_var].values.astype(int)
+                )
+                kept_mask = np.isfinite(data) & ~np.isin(flags, [4, 9])
             else:
-                mask = np.isfinite(data)
-                n_bad = 0
+                kept_mask = np.isfinite(data)
+            all_mask = np.isfinite(data)
 
-            plot_data = data[mask]
-            if len(plot_data) == 0:
+            # percent_good has no _qc variable; annotate with ADCP thresholds
+            pg_thresholds = None
+            if vname == "percent_good":
+                from .. import parameters as _P
+
+                pg_thresholds = (
+                    _P.QC_ADCP["percent_good_bad"],
+                    _P.QC_ADCP["percent_good_suspect"],
+                )
+                # Treat bins below bad threshold as "removed" for the histogram
+                kept_mask = all_mask & (data >= _P.QC_ADCP["percent_good_bad"])
+
+            all_data = data[all_mask]
+            kept_data = data[kept_mask]
+            if len(all_data) == 0:
                 ax.set_ylabel(ylabel)
                 ax.text(
                     0.5,
                     0.5,
-                    "no unflagged data",
+                    "no data",
                     transform=ax.transAxes,
                     ha="center",
                     va="center",
@@ -556,47 +599,82 @@ def _make_data_histogram(nc_path: Path) -> Optional[str]:
                 )
                 continue
 
+            # Compute shared bin edges from ALL data so both histograms are comparable
+            if vname == "heading":
+                bin_edges = np.linspace(0.0, 360.0, 81)
+            elif vname == "percent_good":
+                bin_edges = np.linspace(0.0, 100.0, 81)
+            elif "velocity" in vname:
+                _half = max(
+                    abs(float(all_data.min())), abs(float(all_data.max())), 1e-4
+                )
+                bin_edges = np.linspace(-_half, _half, 81)
+            else:
+                bin_edges = 80
+
+            # Grey: all finite data; blue: kept (not bad/missing)
             ax.hist(
-                plot_data,
-                bins=80,
-                color="#2980b9",
-                edgecolor="white",
-                linewidth=0.2,
-                zorder=2,
+                all_data,
+                bins=bin_edges,
+                color="#aaaaaa",
+                alpha=0.6,
+                edgecolor="none",
+                zorder=1,
+                label="all",
             )
-            ax.set_ylabel(ylabel)
+            if len(kept_data) > 0:
+                ax.hist(
+                    kept_data,
+                    bins=bin_edges,
+                    color="#2980b9",
+                    alpha=0.85,
+                    edgecolor="none",
+                    zorder=2,
+                    label="kept",
+                )
+            ax.set_yscale("log")
+            ax.set_ylabel(f"{ylabel}\n(log count)")
 
             s_min = s_max = f_min = f_max = None
-            if qc_var in ds:
+            if has_qc:
                 qattrs = ds[qc_var].attrs
                 s_min = qattrs.get("qc_gross_range_suspect_min")
                 s_max = qattrs.get("qc_gross_range_suspect_max")
                 f_min = qattrs.get("qc_gross_range_fail_min")
                 f_max = qattrs.get("qc_gross_range_fail_max")
 
-            data_lo, data_hi = float(plot_data.min()), float(plot_data.max())
-            pad = max(0.03 * (data_hi - data_lo), 1e-6)
+            all_lo, all_hi = float(all_data.min()), float(all_data.max())
+            pad = max(0.03 * (all_hi - all_lo), 1e-6)
             xlim_lo = (
-                max(float(f_min), data_lo - pad) if f_min is not None else data_lo - pad
+                max(float(f_min), all_lo - pad) if f_min is not None else all_lo - pad
             )
             xlim_hi = (
-                min(float(f_max), data_hi + pad) if f_max is not None else data_hi + pad
+                min(float(f_max), all_hi + pad) if f_max is not None else all_hi + pad
             )
             ax.set_xlim(xlim_lo, xlim_hi)
 
             if vname == "heading":
                 ax.set_xlim(0.0, 360.0)
+            elif vname == "percent_good":
+                ax.set_xlim(0.0, 100.0)
             elif "velocity" in vname:
-                _half = max(abs(data_lo), abs(data_hi), 1e-6)
+                _half = max(abs(all_lo), abs(all_hi), 1e-6)
                 ax.set_xlim(-_half, _half)
 
             legend_handles, legend_labels = [], []
-            for xv, col, ls, lbl in [
+            threshold_lines = [
                 (s_min, "#f39c12", "--", f"suspect min ({s_min})"),
                 (s_max, "#f39c12", "--", f"suspect max ({s_max})"),
                 (f_min, "#e74c3c", ":", f"fail min ({f_min})"),
                 (f_max, "#e74c3c", ":", f"fail max ({f_max})"),
-            ]:
+            ]
+            if pg_thresholds is not None:
+                pg_bad, pg_susp = pg_thresholds
+                threshold_lines += [
+                    (pg_bad, "#e74c3c", ":", f"bad < {pg_bad}%"),
+                    (pg_susp, "#f39c12", "--", f"suspect < {pg_susp}%"),
+                ]
+            for xv, col, ls, lbl in threshold_lines:
                 if xv is not None and xlim_lo <= float(xv) <= xlim_hi:
                     line = ax.axvline(
                         float(xv), color=col, linewidth=1.2, linestyle=ls, zorder=3
@@ -612,11 +690,12 @@ def _make_data_histogram(nc_path: Path) -> Optional[str]:
                     framealpha=0.8,
                 )
 
-            if n_bad > 0:
+            n_removed = int(np.sum(all_mask)) - int(np.sum(kept_mask))
+            if n_removed > 0:
                 ax.text(
                     0.98,
                     0.96,
-                    f"{n_bad} points flagged bad (excluded)",
+                    f"{n_removed} removed (grey)",
                     transform=ax.transAxes,
                     ha="right",
                     va="top",
@@ -626,7 +705,7 @@ def _make_data_histogram(nc_path: Path) -> Optional[str]:
         for ax in axs_grid[-1]:
             if ax.get_visible():
                 ax.set_xlabel("Value")
-        fig.suptitle("Data value distributions", y=1.01)
+        fig.suptitle("Data value distributions  (grey = all,  blue = kept)", y=1.01)
         plt.tight_layout()
         b64 = _fig_to_base64(fig)
         plt.close(fig)
@@ -641,7 +720,9 @@ def _make_data_histogram(nc_path: Path) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 
-def _add_sigma0_contours(ax, S_data, T_data, n_grid: int = 200) -> None:
+def _add_sigma0_contours(
+    ax: "plt.Axes", S_data: "np.ndarray", T_data: "np.ndarray", n_grid: int = 200
+) -> None:
     """Overlay sigma-0 contour lines on a T-S axes."""
     try:
         import gsw
@@ -830,7 +911,13 @@ def _make_spectrum_fig_b64(
         import numpy as np
         from scipy import signal as _signal
 
-        def welch_psd(x, dt_days, segment_length, overlap=0.5, window="hann"):
+        def welch_psd(
+            x: "np.ndarray",
+            dt_days: float,
+            segment_length: int,
+            overlap: float = 0.5,
+            window: str = "hann",
+        ) -> "tuple[np.ndarray, np.ndarray]":
             fs = 1.0 / dt_days
             noverlap = int(round(overlap * segment_length))
             f, p = _signal.welch(
@@ -1053,8 +1140,13 @@ def _rose_ax(
     title: str = "",
     n_dir: int = 16,
     cmap: str = "Blues",
-) -> None:
-    """Draw a current rose on a polar Axes (compass convention, N up, CW)."""
+    max_speed: Optional[float] = None,
+) -> "Optional[tuple]":
+    """Draw a current rose on a polar Axes (compass convention, N up, CW).
+
+    Returns ``(spd_edges, colors)`` so callers can add a shared colorbar, or
+    ``None`` if the panel was hidden due to insufficient data.
+    """
     import matplotlib.pyplot as plt
 
     speed = np.sqrt(east**2 + north**2)
@@ -1063,14 +1155,15 @@ def _rose_ax(
     speed, direction = speed[valid], direction[valid]
     if len(speed) < 2:
         ax.set_visible(False)
-        return
+        return None
 
     dir_edges = np.linspace(0, 360, n_dir + 1)
     dir_centers = (dir_edges[:-1] + dir_edges[1:]) / 2
     theta = np.radians(dir_centers)
     bar_width = 2 * np.pi / n_dir * 0.9
 
-    max_speed = max(float(np.nanpercentile(speed, 99)), 1e-9)
+    if max_speed is None:
+        max_speed = max(float(np.nanpercentile(speed, 99)), 1e-9)
     n_spd = 5
     spd_edges = np.linspace(0, max_speed, n_spd + 1)
     colors = getattr(plt.cm, cmap)(np.linspace(0.25, 1.0, n_spd))
@@ -1103,6 +1196,7 @@ def _rose_ax(
     ax.set_xticklabels(["N", "E", "S", "W"])
     ax.set_rticks([])
     ax.set_title(title, pad=2)
+    return spd_edges, colors
 
 
 def _xyz_to_enu_2d(
@@ -1165,7 +1259,7 @@ def _make_instrument_rose_b64(nc_path: Path) -> Optional[str]:
                 else np.ones(len(e_all), dtype=int)
             )
 
-            def _masked(flag_mask):
+            def _masked(flag_mask: "np.ndarray") -> "tuple[np.ndarray, np.ndarray]":
                 e = e_all.copy()
                 n = n_all.copy()
                 e[~flag_mask] = np.nan
@@ -1316,6 +1410,182 @@ def _make_grid_ts_diagram(ds: "xr.Dataset", n_bins: int = 80) -> Optional[str]:
         return None
 
 
+def _make_velocity_iqr_profile_b64(ds: "xr.Dataset") -> Optional[str]:
+    """IQR velocity profiles from the gridded dataset.
+
+    Three side-by-side panels:
+    - Left: current speed — p2.5/p25/p50/p75/p97.5 shaded profile.
+    - Middle: east and north velocity on the same axes, each with p25/p50/p75,
+      using Okabe-Ito colours (#0072B2 blue for east, #E69F00 orange for north).
+    - Right: count of non-NaN values at each pressure level.
+
+    Y-axis is pressure (dbar), inverted (surface at top).  Returns None if no
+    velocity data are present.
+    """
+    import warnings
+    import matplotlib.pyplot as plt
+    import xarray as _xr
+    from .. import parameters as P
+
+    # Ensure current_speed exists
+    if "current_speed" not in ds.data_vars and all(
+        v in ds.data_vars for v in ("east_velocity", "north_velocity")
+    ):
+        spd = np.sqrt(
+            ds["east_velocity"].values ** 2 + ds["north_velocity"].values ** 2
+        )
+        ds = ds.assign(
+            current_speed=_xr.DataArray(
+                spd,
+                dims=ds["east_velocity"].dims,
+                coords=ds["east_velocity"].coords,
+                attrs={"units": "m s-1", "long_name": "Current speed"},
+            )
+        )
+
+    has_speed = "current_speed" in ds.data_vars
+    has_horiz = all(v in ds.data_vars for v in ("east_velocity", "north_velocity"))
+    if not has_speed and not has_horiz:
+        return None
+
+    pressure = ds["pressure"].values  # 1-D (n_levels,)
+
+    # Count non-NaN values at each pressure level (from east_velocity, or speed)
+    _count_ref = ds["east_velocity"].values if has_horiz else ds["current_speed"].values
+    n_good = np.sum(np.isfinite(_count_ref), axis=0)  # (n_levels,)
+
+    # Okabe-Ito blue and orange — distinguishable for all common colour-vision deficiencies
+    _C_EAST = "#0072B2"
+    _C_NORTH = "#E69F00"
+
+    n_panels = int(has_speed) + int(has_horiz) + 1  # +1 for count panel
+    plt.style.use(str(P.MPLSTYLE))
+    fig, axs = plt.subplots(
+        1,
+        n_panels,
+        figsize=(n_panels * 3.5, 6),
+        sharey=True,
+        gridspec_kw={"width_ratios": [2] * (n_panels - 1) + [1]},
+    )
+    if n_panels == 1:
+        axs = [axs]
+
+    ax_iter = iter(axs[:-1])  # last panel reserved for count
+
+    # ── Panel 1: current speed with 2.5/25/50/75/97.5 ────────────────────────
+    if has_speed:
+        ax = next(ax_iter)
+        data = ds["current_speed"].values  # (time, pressure)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)  # all-NaN pressure levels
+            p025 = np.nanpercentile(data, 2.5, axis=0)
+            p25 = np.nanpercentile(data, 25, axis=0)
+            p50 = np.nanpercentile(data, 50, axis=0)
+            p75 = np.nanpercentile(data, 75, axis=0)
+            p975 = np.nanpercentile(data, 97.5, axis=0)
+        valid = np.isfinite(p50)
+        if valid.any():
+            ax.fill_betweenx(
+                pressure[valid],
+                p025[valid],
+                p975[valid],
+                alpha=0.15,
+                color="steelblue",
+                label="2.5–97.5 %",
+            )
+            ax.fill_betweenx(
+                pressure[valid],
+                p25[valid],
+                p75[valid],
+                alpha=0.35,
+                color="steelblue",
+                label="IQR (25–75 %)",
+            )
+            ax.plot(
+                p50[valid],
+                pressure[valid],
+                color="steelblue",
+                linewidth=1.5,
+                label="Median",
+            )
+            ax.plot(
+                p025[valid],
+                pressure[valid],
+                color="steelblue",
+                linewidth=0.6,
+                linestyle=":",
+            )
+            ax.plot(
+                p975[valid],
+                pressure[valid],
+                color="steelblue",
+                linewidth=0.6,
+                linestyle=":",
+            )
+            ax.set_xlim(left=0)
+        ax.set_xlabel("Current speed (m s⁻¹)")
+        ax.grid(True, linestyle="--", linewidth=0.4, alpha=0.5)
+        ax.legend(loc="lower right")
+
+    # ── Panel 2: east + north on shared axes ─────────────────────────────────
+    if has_horiz:
+        ax = next(ax_iter)
+        absmax = 0.0
+        for varname, color, label in [
+            ("east_velocity", _C_EAST, "East"),
+            ("north_velocity", _C_NORTH, "North"),
+        ]:
+            data = ds[varname].values
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                p25 = np.nanpercentile(data, 25, axis=0)
+                p50 = np.nanpercentile(data, 50, axis=0)
+                p75 = np.nanpercentile(data, 75, axis=0)
+            valid = np.isfinite(p50)
+            if not valid.any():
+                continue
+            ax.fill_betweenx(
+                pressure[valid], p25[valid], p75[valid], alpha=0.25, color=color
+            )
+            ax.plot(
+                p50[valid], pressure[valid], color=color, linewidth=1.5, label=label
+            )
+            ax.plot(
+                p25[valid], pressure[valid], color=color, linewidth=0.6, linestyle="--"
+            )
+            ax.plot(
+                p75[valid], pressure[valid], color=color, linewidth=0.6, linestyle="--"
+            )
+            _abs = np.nanmax(np.abs([p25[valid], p75[valid]]))
+            if np.isfinite(_abs):
+                absmax = max(absmax, _abs)
+        ax.axvline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
+        if absmax > 0:
+            ax.set_xlim(-absmax * 1.15, absmax * 1.15)
+        ax.set_xlabel("Velocity (m s⁻¹)")
+        ax.grid(True, linestyle="--", linewidth=0.4, alpha=0.5)
+        ax.legend(loc="lower right")
+
+    # ── Count panel (rightmost) ───────────────────────────────────────────────
+    ax_count = axs[-1]
+    ax_count.barh(
+        pressure,
+        n_good,
+        height=np.diff(pressure).mean() * 0.8 if len(pressure) > 1 else 5,
+        color="gray",
+        alpha=0.6,
+    )
+    ax_count.set_xlabel("N good")
+    ax_count.grid(True, linestyle="--", linewidth=0.4, alpha=0.5)
+
+    axs[0].set_ylabel("Pressure (dbar)")
+    axs[0].invert_yaxis()  # shared y — invert once only
+    fig.tight_layout()
+    b64 = _fig_to_base64(fig)
+    plt.close(fig)
+    return b64
+
+
 def _make_grid_n2_b64(ds: "xr.Dataset", lat: float = 0.0) -> Optional[str]:
     """Compute and plot buoyancy frequency squared N² on the pressure-time grid."""
     try:
@@ -1397,10 +1667,21 @@ def _make_rose_grid_b64(
     east_all = ds["east_velocity"].values.copy()
     north_all = ds["north_velocity"].values.copy()
 
-    if "east_velocity_qc" in ds.data_vars:
-        qc = ds["east_velocity_qc"].values
-        east_all[qc >= 3] = np.nan
-        north_all[qc >= 3] = np.nan
+    # Mask suspect/bad data from all available QC variables before plotting roses.
+    # seabed_qc handles ADCP bins below the seafloor; percent_good_qc and
+    # error_velocity_qc handle low-quality ADCP pings.  Any flag >= 3
+    # (suspect or worse) is treated as invalid.
+    for _qc_var in (
+        "east_velocity_qc",
+        "seabed_qc",
+        "percent_good_qc",
+        "error_velocity_qc",
+    ):
+        if _qc_var in ds.data_vars:
+            _qc = ds[_qc_var].values
+            if _qc.shape == east_all.shape:
+                east_all[_qc >= 3] = np.nan
+                north_all[_qc >= 3] = np.nan
 
     has_vel = [np.any(np.isfinite(east_all[:, i])) for i in range(east_all.shape[1])]
     aqd_idx = [i for i in range(len(serial_list)) if i < len(has_vel) and has_vel[i]]
@@ -1475,6 +1756,153 @@ def _filter_sigma_tukey(
         smoothed[nan_mask] = np.nan
         result[k, :] = smoothed
     return result
+
+
+def _make_grid_trajectory_b64(ds: "xr.Dataset") -> Optional[str]:
+    """Particle trajectory plot from gridded east/north velocity.
+
+    For each pressure level, integrate east and north velocity over time
+    (Euler forward; NaN velocities set to zero) to produce a pseudo-Lagrangian
+    trajectory.  All trajectories start at the origin.  Lines are coloured by
+    pressure (dbar) using the viridis colormap (shallow → deep).
+
+    Returns None if east_velocity or north_velocity are absent.
+    """
+    import matplotlib.pyplot as plt
+    import matplotlib.colors as mcolors
+    from matplotlib.collections import LineCollection
+    from .. import parameters as P
+
+    if "east_velocity" not in ds.data_vars or "north_velocity" not in ds.data_vars:
+        return None
+
+    pressure = ds["pressure"].values  # 1-D (n_levels,)
+    time = ds["time"].values
+    dt = np.array(
+        [(time[j] - time[j - 1]) / np.timedelta64(1, "s") for j in range(1, len(time))],
+        dtype=float,
+    )
+
+    east = ds["east_velocity"].values.copy()  # (time, pressure)
+    north = ds["north_velocity"].values.copy()
+
+    # Apply QC masking before integration
+    for _qv, _dv in (("east_velocity_qc", east), ("north_velocity_qc", north)):
+        if _qv in ds.data_vars:
+            _qc = ds[_qv].values
+            _dv[_qc >= 3] = np.nan
+
+    # Build one trajectory per pressure level; skip levels with all-NaN velocity
+    trajs = []  # (pressure_val, x_array, y_array)
+    for k, p_val in enumerate(pressure):
+        u = np.nan_to_num(east[:, k], nan=0.0)
+        v = np.nan_to_num(north[:, k], nan=0.0)
+        if not np.any(east[:, k][np.isfinite(east[:, k])]):
+            continue
+        x = np.concatenate([[0.0], np.cumsum(u[:-1] * dt)])
+        y = np.concatenate([[0.0], np.cumsum(v[:-1] * dt)])
+        trajs.append((float(p_val), x, y))
+
+    if not trajs:
+        return None
+
+    p_vals = [t[0] for t in trajs]
+    _bounds = _nice_colorbar_bounds(min(p_vals), max(p_vals), n=20)
+    norm: mcolors.BoundaryNorm = mcolors.BoundaryNorm(_bounds, ncolors=256)
+    cmap = plt.get_cmap("viridis_r")  # shallow (low p) → light; deep → dark
+
+    plt.style.use(str(P.MPLSTYLE))
+    fig, ax = plt.subplots(figsize=(6, 5))
+
+    for p_val, x, y in trajs:
+        points = np.array([x, y]).T.reshape(-1, 1, 2)
+        segments = np.concatenate([points[:-1], points[1:]], axis=1)
+        lc = LineCollection(segments, cmap=cmap, norm=norm, linewidth=0.8, alpha=0.7)
+        lc.set_array(np.full(len(segments), p_val))
+        ax.add_collection(lc)
+
+    sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+    sm.set_array([])
+    fig.colorbar(sm, ax=ax, label="Pressure (dbar)", shrink=0.75, ticks=_bounds)
+
+    ax.plot(0, 0, "o", color="black", markersize=6, zorder=6, label="Start")
+    ax.legend(fontsize=8, loc="upper left")
+    ax.autoscale_view()
+    ax.set_xlabel("East displacement (m)")
+    ax.set_ylabel("North displacement (m)")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
+    ax.axvline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
+    ax.set_aspect("equal", adjustable="datalim")
+    ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.4)
+    fig.tight_layout()
+    b64 = _fig_to_base64(fig)
+    plt.close(fig)
+    return b64
+
+
+def _make_grid_timeseries_b64(ds: "xr.Dataset") -> Optional[str]:
+    """Time series of speed, east, and north velocity at the depth of maximum mean speed.
+
+    The target pressure level is chosen as the one with the highest time-mean
+    current speed (or east/north magnitude).  Returns None if velocity data are
+    absent.
+    """
+    import warnings
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+    from .. import parameters as P
+
+    has_horiz = all(v in ds.data_vars for v in ("east_velocity", "north_velocity"))
+    if not has_horiz:
+        return None
+
+    east = ds["east_velocity"].values  # (time, pressure)
+    north = ds["north_velocity"].values
+    pressure = ds["pressure"].values  # 1-D
+    time_vals = ds["time"].values
+
+    spd = np.sqrt(east**2 + north**2)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        mean_spd = np.nanmean(spd, axis=0)  # (pressure,)
+    if not np.any(np.isfinite(mean_spd)):
+        return None
+    k_max = int(np.nanargmax(mean_spd))
+    p_target = float(pressure[k_max])
+
+    spd_ts = spd[:, k_max]
+    east_ts = east[:, k_max]
+    north_ts = north[:, k_max]
+
+    plt.style.use(str(P.MPLSTYLE))
+    fig, axs = plt.subplots(3, 1, figsize=(10, 6), sharex=True)
+    _C_EAST = "#0072B2"
+    _C_NORTH = "#E69F00"
+
+    axs[0].plot(time_vals, spd_ts, color="k", linewidth=0.8)
+    axs[0].set_ylabel("Speed (m s⁻¹)")
+
+    axs[1].plot(time_vals, east_ts, color=_C_EAST, linewidth=0.8, label="East")
+    axs[1].axhline(0, color="k", linewidth=0.4, linestyle="--", alpha=0.4)
+    axs[1].set_ylabel("East vel. (m s⁻¹)")
+
+    axs[2].plot(time_vals, north_ts, color=_C_NORTH, linewidth=0.8, label="North")
+    axs[2].axhline(0, color="k", linewidth=0.4, linestyle="--", alpha=0.4)
+    axs[2].set_ylabel("North vel. (m s⁻¹)")
+
+    for ax in axs:
+        ax.grid(True, linestyle="--", linewidth=0.4, alpha=0.4)
+    axs[-1].xaxis.set_major_formatter(
+        mdates.ConciseDateFormatter(axs[-1].xaxis.get_major_locator())
+    )
+    fig.suptitle(
+        f"Velocity time series at {p_target:.0f} dbar (depth of maximum mean speed)",
+        y=1.01,
+    )
+    fig.tight_layout()
+    b64 = _fig_to_base64(fig)
+    plt.close(fig)
+    return b64
 
 
 def _make_isopycnal_fig_b64(
@@ -1635,6 +2063,369 @@ def _make_aquadopp_speed_profile(ds: "xr.Dataset") -> Optional[str]:
         plt.close(fig)
         return b64
     except Exception:  # noqa: BLE001  — plot is optional; no aquadopps or missing vars → skip
+        return None
+
+
+def _make_adcp_trajectories_b64(ds: "xr.Dataset") -> Optional[str]:
+    """Per-bin ADCP particle trajectories coloured by HAB, for stack page.
+
+    Takes an already-loaded xarray.Dataset (not a path).
+    """
+    try:
+        import matplotlib.pyplot as plt
+        from oceanarray.plotters._current import plot_adcp_trajectories
+
+        fig = plot_adcp_trajectories(ds)
+        if fig is None:
+            return None
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+        return b64
+    except Exception:  # noqa: BLE001  — plot is optional; no ADCP bins or missing vars → skip
+        return None
+
+
+def _make_adcp_velocity_b64(nc_path: str) -> Optional[str]:
+    """Stacked colour panels for ADCP per-instrument page.
+
+    Panels (where data are present):
+    - East / North / Up / Error velocity — symmetric Spectral_r (11 class), shared bounds
+    - Current speed (sqrt(E²+N²))        — sequential YlOrRd, 0 → 98th pctile
+    - Current direction (atan2(E,N) °T)   — cyclic twilight_shifted, 0–360°
+
+    Y-axis is the ``range`` coordinate; inverted for downward-looking instruments.
+    """
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as mcolors
+        import matplotlib.dates as mdates
+        import xarray as xr
+        from .. import parameters as P
+
+        # (varname, label, panel_type)  — panel_type: "div" | "seq" | "cyc"
+        _COMPONENTS = [
+            ("east_velocity", "East velocity (m s⁻¹)", "div"),
+            ("north_velocity", "North velocity (m s⁻¹)", "div"),
+            ("up_velocity", "Up velocity (m s⁻¹)", "div"),
+            ("error_velocity", "Error velocity (m s⁻¹)", "div"),
+            ("current_speed", "Current speed (m s⁻¹)", "seq"),
+            ("current_direction", "Current direction (°T)", "cyc"),
+            ("bin_pressure", "Bin pressure (dbar)", "seq"),
+        ]
+
+        with xr.open_dataset(nc_path, decode_timedelta=False) as ds:
+            # Compute speed and direction from east/north if both present
+            arrays = {}
+            for v in ds.data_vars:
+                arrays[v] = ds[v]
+            if "east_velocity" in ds and "north_velocity" in ds:
+                e = ds["east_velocity"].values.astype(float)
+                n = ds["north_velocity"].values.astype(float)
+                spd = np.sqrt(e**2 + n**2)
+                # Oceanographic convention: direction water flows TO, 0=N clockwise
+                dirn = np.degrees(np.arctan2(e, n)) % 360.0
+                arrays["current_speed"] = spd
+                arrays["current_direction"] = dirn
+
+            # Apply seabed mask (seabed_qc ≥ 3 → at or below seabed) to all
+            # (time, N_BINS) arrays before plotting.  Done after speed/direction
+            # are computed so they are masked consistently.
+            if "seabed_qc" in ds.data_vars:
+                seabed_mask = ds["seabed_qc"].values >= 3  # (time, N_BINS)
+                masked_arrays = {}
+                for k, v in arrays.items():
+                    arr = v if isinstance(v, np.ndarray) else v.values
+                    if arr.ndim == 2 and arr.shape == seabed_mask.shape:
+                        arr = arr.astype(float).copy()
+                        arr[seabed_mask] = np.nan
+                    masked_arrays[k] = arr
+                arrays = masked_arrays
+
+            present = [(v, lbl, pt) for v, lbl, pt in _COMPONENTS if v in arrays]
+            if not present:
+                return None
+
+            time = ds["time"].values
+
+            if "range" in ds.coords:
+                range_coord = ds["range"].values
+            else:
+                range_coord = None
+                for v, _, _ in present:
+                    if v not in ds:
+                        continue
+                    for dim in ds[v].dims:
+                        if dim == "time":
+                            continue
+                        for _cn, cda in ds.coords.items():
+                            if cda.dims == (dim,):
+                                range_coord = cda.values
+                                break
+                        if range_coord is not None:
+                            break
+                    if range_coord is not None:
+                        break
+            if range_coord is None:
+                return None
+
+            # Shared diverging bounds from ENU components (2nd/98th pctile)
+            div_vals = np.concatenate(
+                [
+                    arrays[v].ravel()
+                    if isinstance(arrays[v], np.ndarray)
+                    else arrays[v].values.ravel()
+                    for v, _, pt in present
+                    if pt == "div"
+                ]
+            )
+            finite_div = div_vals[np.isfinite(div_vals)]
+            abs_max = (
+                max(
+                    abs(float(np.percentile(finite_div, 2))),
+                    abs(float(np.percentile(finite_div, 98))),
+                    1e-4,
+                )
+                if len(finite_div)
+                else 1.0
+            )
+            div_bounds = _nice_colorbar_bounds(-abs_max, abs_max, n=20)
+            div_norm = mcolors.BoundaryNorm(div_bounds, ncolors=256)
+
+            # Sequential bounds for speed (0 → 98th pctile)
+            spd_vals = (
+                arrays["current_speed"].ravel()
+                if "current_speed" in arrays
+                else np.array([])
+            )
+            spd_finite = (
+                spd_vals[np.isfinite(spd_vals)] if len(spd_vals) else np.array([])
+            )
+            spd_max = float(np.percentile(spd_finite, 98)) if len(spd_finite) else 1.0
+            seq_bounds = _nice_colorbar_bounds(0.0, max(spd_max, 1e-4), n=20)
+            seq_norm = mcolors.BoundaryNorm(seq_bounds, ncolors=256)
+
+            # Sequential bounds for bin_pressure (2nd → 98th pctile, dbar)
+            bp_arr = arrays["bin_pressure"] if "bin_pressure" in arrays else None
+            if bp_arr is not None:
+                bp_vals = (
+                    bp_arr if isinstance(bp_arr, np.ndarray) else bp_arr.values
+                ).ravel()
+                bp_finite = bp_vals[np.isfinite(bp_vals)]
+            else:
+                bp_finite = np.array([])
+            if len(bp_finite):
+                bp_bounds = _nice_colorbar_bounds(
+                    float(np.percentile(bp_finite, 2)),
+                    float(np.percentile(bp_finite, 98)),
+                    n=20,
+                )
+            else:
+                bp_bounds = _nice_colorbar_bounds(0.0, 1000.0, n=20)
+            bp_norm = mcolors.BoundaryNorm(bp_bounds, ncolors=256)
+
+            # Cyclic bounds for direction: always 0–360
+            cyc_bounds = np.linspace(0, 360, 21)
+            cyc_norm = mcolors.BoundaryNorm(cyc_bounds, ncolors=256)
+
+            plt.style.use(str(P.MPLSTYLE))
+            n = len(present)
+            fig, axes = plt.subplots(
+                n, 1, figsize=(13, 3.5 * n), sharex=True, squeeze=False
+            )
+
+            orientation = ds.attrs.get("orientation_yaml") or ds.attrs.get(
+                "orientation_instrument", "up"
+            )
+            looking_down = str(orientation).lower() == "down"
+            ylabel = (
+                "Range (m, ↓ deeper)" if looking_down else "Range (m from transducer)"
+            )
+
+            # Determine the deepest range to show.
+            # Prefer seabed_qc: deepest bin that is ever above the seabed
+            # (flag 1 = good).  Fall back to deepest bin with any finite
+            # velocity data.  Fall back further to the full range_coord span.
+            if "seabed_qc" in ds.data_vars:
+                seabed_qc_vals = ds["seabed_qc"].values  # (time, N_BINS)
+                bin_ever_good = np.any(seabed_qc_vals == 1, axis=0)  # (N_BINS,)
+                range_max = (
+                    float(range_coord[bin_ever_good].max())
+                    if bin_ever_good.any()
+                    else float(range_coord.max())
+                )
+            else:
+                range_max = float(range_coord.max())
+                for vel_var in ("east_velocity", "north_velocity", "up_velocity"):
+                    if vel_var not in arrays:
+                        continue
+                    vel = (
+                        arrays[vel_var]
+                        if isinstance(arrays[vel_var], np.ndarray)
+                        else arrays[vel_var].values
+                    )
+                    bin_has_data = np.any(np.isfinite(vel), axis=0)  # (N_BINS,)
+                    if bin_has_data.any():
+                        range_max = float(range_coord[bin_has_data].max())
+                    break
+
+            for ax, (var, label, pt) in zip(axes[:, 0], present):
+                raw = arrays[var]
+                data2d = raw if isinstance(raw, np.ndarray) else raw.values
+                # Ensure (time, N_BINS) then transpose to (N_BINS, time) for pcolormesh
+                if data2d.shape[0] != len(time):
+                    data2d = data2d.T
+                data2d = data2d.T  # now (N_BINS, time)
+
+                if pt == "div":
+                    norm, cmap, cb_label, cb_ticks = (
+                        div_norm,
+                        "Spectral_r",
+                        "m s⁻¹",
+                        div_bounds[::2],
+                    )
+                elif pt == "seq":
+                    if var == "bin_pressure":
+                        norm, cmap, cb_label, cb_ticks = (
+                            bp_norm,
+                            "PuRd",
+                            "dbar",
+                            bp_bounds[::2],
+                        )
+                    else:
+                        norm, cmap, cb_label, cb_ticks = (
+                            seq_norm,
+                            "plasma",
+                            "m s⁻¹",
+                            seq_bounds[::2],
+                        )
+                else:  # cyc
+                    norm, cmap, cb_label, cb_ticks = (
+                        cyc_norm,
+                        "hsv",
+                        "°T",
+                        cyc_bounds[::2],
+                    )
+
+                pc = ax.pcolormesh(
+                    time, range_coord, data2d, shading="nearest", cmap=cmap, norm=norm
+                )
+                cb = fig.colorbar(pc, ax=ax, pad=0.02, ticks=cb_ticks)
+                cb.set_label(cb_label)
+                ax.set_ylabel(ylabel)
+                ax.set_title(label, loc="left")
+                ax.grid(True, linestyle="--", linewidth=0.3, alpha=0.4)
+                # Show from 0 (includes blanking zone) to deepest valid bin.
+                # set_ylim with reversed args inverts for downward-looking.
+                if looking_down:
+                    ax.set_ylim(range_max, 0.0)
+                else:
+                    ax.set_ylim(0.0, range_max)
+
+            locator = mdates.AutoDateLocator()
+            axes[-1, 0].xaxis.set_major_locator(locator)
+            axes[-1, 0].xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
+
+        fig.tight_layout()
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+        return b64
+    except Exception:  # noqa: BLE001  — plot is optional; missing vars or bad data → skip
+        return None
+
+
+def _make_adcp_rose_b64(nc_path: str) -> Optional[str]:
+    """Current rose panels for an ADCP: depth-average plus bins nearest 100/200/300/400 m.
+
+    Selects the depth-average and up to four individual range bins (those closest
+    to 100, 200, 300 and 400 m from the transducer).  A bin is included only when
+    it contains at least two finite velocity samples.  Returns None if east/north
+    velocity are absent or too few samples exist.
+    """
+    try:
+        import matplotlib.pyplot as plt
+        import xarray as xr
+        from .. import parameters as P
+
+        _TARGET_RANGES = [100, 200, 300, 400]  # m from transducer
+
+        with xr.open_dataset(nc_path, decode_timedelta=False) as ds:
+            if "east_velocity" not in ds or "north_velocity" not in ds:
+                return None
+
+            east_2d = ds["east_velocity"].values.astype(float)  # (time, N_BINS)
+            north_2d = ds["north_velocity"].values.astype(float)
+
+            if "range" in ds.coords:
+                range_vals = ds["range"].values
+            else:
+                return None
+
+            # Build panel list: depth-average first, then per-bin
+            panels = []
+
+            e_mean = np.nanmean(east_2d, axis=1)
+            n_mean = np.nanmean(north_2d, axis=1)
+            if np.sum(np.isfinite(e_mean)) >= 2:
+                panels.append((e_mean, n_mean, "Depth average"))
+
+            for target in _TARGET_RANGES:
+                idx = int(np.argmin(np.abs(range_vals - target)))
+                e_bin = east_2d[:, idx]
+                n_bin = north_2d[:, idx]
+                if np.sum(np.isfinite(e_bin)) < 2:
+                    continue
+                actual = float(range_vals[idx])
+                panels.append((e_bin, n_bin, f"{actual:.0f} m"))
+
+            if not panels:
+                return None
+
+            # Shared speed scale across all panels (99th percentile of all data)
+            all_speeds = np.concatenate([np.sqrt(e**2 + n**2) for e, n, _ in panels])
+            shared_max = max(
+                float(np.nanpercentile(all_speeds[np.isfinite(all_speeds)], 99)), 1e-9
+            )
+
+            plt.style.use(str(P.MPLSTYLE))
+            ncols = len(panels)
+            fig, axs = plt.subplots(
+                1,
+                ncols,
+                figsize=(ncols * 3.2, 4.0),
+                subplot_kw={"projection": "polar"},
+                squeeze=False,
+            )
+            spd_edges = colors = None
+            for ax, (east, north, title) in zip(axs[0], panels):
+                result = _rose_ax(ax, east, north, title=title, max_speed=shared_max)
+                if result is not None:
+                    spd_edges, colors = result
+
+            # Add shared colorbar below the rose panels
+            if spd_edges is not None and colors is not None:
+                import matplotlib.colors as mcolors
+                import matplotlib.cm as mcm
+
+                cmap_obj = mcolors.ListedColormap(colors)
+                norm = mcolors.BoundaryNorm(spd_edges, len(colors))
+                sm = mcm.ScalarMappable(cmap=cmap_obj, norm=norm)
+                sm.set_array([])
+                cbar = fig.colorbar(
+                    sm,
+                    ax=axs[0].tolist(),
+                    orientation="horizontal",
+                    fraction=0.04,
+                    pad=0.08,
+                    aspect=40,
+                )
+                cbar.set_label("Speed (m s⁻¹)")
+                cbar.set_ticks(spd_edges)
+                cbar.set_ticklabels([f"{v:.2f}" for v in spd_edges])
+
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+        return b64
+    except Exception:  # noqa: BLE001
         return None
 
 

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -1129,6 +1129,215 @@ def _make_grid_fig_b64(
 
 
 # ---------------------------------------------------------------------------
+# Stacked grid panels (hydrography and velocity)
+# ---------------------------------------------------------------------------
+
+
+def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
+    """Stacked T / S pcolormesh panels for the grid report hydrography section.
+
+    Panels rendered (only those present in *ds*):
+    - Temperature (RdYlBu_r)
+    - Salinity (YlGnBu_r)
+
+    Returns None if neither variable is present.
+    """
+    import matplotlib.pyplot as plt
+    import matplotlib.colors as mcolors
+    import matplotlib.dates as mdates
+    import xarray as _xr
+    from .. import parameters as P
+
+    panels = []
+    for var, cmap in [("temperature", "RdYlBu_r"), ("salinity", "YlGnBu_r")]:
+        if var not in ds.data_vars:
+            continue
+        panels.append((var, cmap))
+
+    # Also allow derived salinity from T/C
+    if "salinity" not in ds.data_vars and "conductivity" in ds.data_vars and "temperature" in ds.data_vars:
+        try:
+            import gsw
+            p_1d = ds["pressure"].values
+            T = ds["temperature"].transpose("time", "pressure").values
+            C = ds["conductivity"].transpose("time", "pressure").values
+            SP_vals = gsw.SP_from_C(C, T, p_1d[np.newaxis, :])
+            ds = ds.assign(
+                salinity=_xr.DataArray(
+                    SP_vals,
+                    dims=("time", "pressure"),
+                    coords={"time": ds["time"], "pressure": ds["pressure"]},
+                    attrs={"units": "1", "long_name": "Practical Salinity"},
+                )
+            )
+            panels.append(("salinity", "YlGnBu_r"))
+        except Exception:  # noqa: BLE001
+            pass
+
+    if not panels:
+        return None
+
+    pressure = ds["pressure"].values
+    time = ds["time"].values
+    plt.style.use(str(P.MPLSTYLE))
+    n = len(panels)
+    fig, axes = plt.subplots(n, 1, figsize=(13, 3.2 * n), sharex=True, squeeze=False)
+    locator = mdates.AutoDateLocator()
+
+    for ax, (var, cmap) in zip(axes[:, 0], panels):
+        da = ds[var]
+        data = da.transpose("pressure", "time").values
+        units = da.attrs.get("units", "")
+        label = da.attrs.get("long_name", var)
+        _vmin = float(np.nanpercentile(data, P.COLORBAR_PLOW))
+        _vmax = float(np.nanpercentile(data, P.COLORBAR_PHIGH))
+        bounds = _nice_colorbar_bounds(_vmin, _vmax, n=20)
+        norm = mcolors.BoundaryNorm(bounds, ncolors=256)
+        pc = ax.pcolormesh(time, pressure, data, shading="nearest", cmap=cmap, norm=norm)
+        cb = fig.colorbar(pc, ax=ax, pad=0.02, ticks=bounds[::2])
+        cb.set_label(f"{label} ({units})" if units else label)
+        ax.invert_yaxis()
+        ax.set_ylabel("Pressure (dbar)")
+        ax.set_title(label, loc="left")
+        ax.grid(True, linestyle="--", linewidth=0.3, alpha=0.4)
+
+    axes[-1, 0].xaxis.set_major_locator(locator)
+    axes[-1, 0].xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
+    fig.tight_layout()
+    b64 = _fig_to_base64(fig)
+    plt.close(fig)
+    return b64
+
+
+def _make_grid_velocity_stacked_b64(ds: "xr.Dataset") -> Optional[str]:
+    """Stacked east / north / up velocity pcolormesh panels for the grid report.
+
+    Uses a shared symmetric Spectral_r colormap across E/N/Up so magnitudes are
+    comparable across panels.  Up velocity uses its own symmetric bounds (usually
+    much smaller than horizontal).
+
+    Returns None if no velocity data are present.
+    """
+    import matplotlib.pyplot as plt
+    import matplotlib.colors as mcolors
+    import matplotlib.dates as mdates
+    from .. import parameters as P
+
+    vel_vars = [
+        ("east_velocity",  "East velocity",  "m s⁻¹"),
+        ("north_velocity", "North velocity", "m s⁻¹"),
+        ("up_velocity",    "Up velocity",    "m s⁻¹"),
+    ]
+    present = [(v, lbl, u) for v, lbl, u in vel_vars if v in ds.data_vars]
+    if not present:
+        return None
+
+    pressure = ds["pressure"].values
+    time = ds["time"].values
+
+    # Shared symmetric bounds from horizontal velocity (2nd/98th pctile)
+    horiz_vals = np.concatenate([
+        ds[v].values.ravel()
+        for v, _, _ in present
+        if v in ("east_velocity", "north_velocity")
+    ])
+    finite_h = horiz_vals[np.isfinite(horiz_vals)]
+    abs_max_h = max(
+        abs(float(np.percentile(finite_h, 2))),
+        abs(float(np.percentile(finite_h, 98))),
+        1e-4,
+    ) if len(finite_h) else 1.0
+    h_bounds = _nice_colorbar_bounds(-abs_max_h, abs_max_h, n=20)
+    h_norm = mcolors.BoundaryNorm(h_bounds, ncolors=256)
+
+    # Separate bounds for up velocity
+    if "up_velocity" in ds.data_vars:
+        up_vals = ds["up_velocity"].values.ravel()
+        finite_u = up_vals[np.isfinite(up_vals)]
+        abs_max_u = max(
+            abs(float(np.percentile(finite_u, 2))),
+            abs(float(np.percentile(finite_u, 98))),
+            1e-4,
+        ) if len(finite_u) else 1.0
+        u_bounds = _nice_colorbar_bounds(-abs_max_u, abs_max_u, n=20)
+        u_norm = mcolors.BoundaryNorm(u_bounds, ncolors=256)
+    else:
+        u_bounds, u_norm = h_bounds, h_norm
+
+    plt.style.use(str(P.MPLSTYLE))
+    n = len(present)
+    fig, axes = plt.subplots(n, 1, figsize=(13, 3.2 * n), sharex=True, squeeze=False)
+    locator = mdates.AutoDateLocator()
+
+    for ax, (var, label, units) in zip(axes[:, 0], present):
+        data = ds[var].transpose("pressure", "time").values
+        # Apply QC mask
+        qc_var = f"{var}_qc"
+        if qc_var in ds.data_vars:
+            data = data.copy()
+            data[ds[qc_var].transpose("pressure", "time").values >= 3] = np.nan
+        bounds = u_bounds if var == "up_velocity" else h_bounds
+        norm   = u_norm   if var == "up_velocity" else h_norm
+        pc = ax.pcolormesh(time, pressure, data, shading="nearest", cmap="Spectral_r", norm=norm)
+        cb = fig.colorbar(pc, ax=ax, pad=0.02, ticks=bounds[::2])
+        cb.set_label(units)
+        ax.invert_yaxis()
+        ax.set_ylabel("Pressure (dbar)")
+        ax.set_title(label, loc="left")
+        ax.grid(True, linestyle="--", linewidth=0.3, alpha=0.4)
+
+    axes[-1, 0].xaxis.set_major_locator(locator)
+    axes[-1, 0].xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
+    fig.tight_layout()
+    b64 = _fig_to_base64(fig)
+    plt.close(fig)
+    return b64
+
+
+def _make_grid_sigma_b64(ds: "xr.Dataset") -> Optional[str]:
+    """Stacked sigma0 pcolormesh panel(s) for the stratification section."""
+    import matplotlib.pyplot as plt
+    import matplotlib.colors as mcolors
+    import matplotlib.dates as mdates
+    from .. import parameters as P
+
+    sigma_vars = [v for v in ds.data_vars if v.startswith("sigma") and "pressure" in ds[v].dims]
+    if not sigma_vars:
+        return None
+
+    pressure = ds["pressure"].values
+    time = ds["time"].values
+    plt.style.use(str(P.MPLSTYLE))
+    n = len(sigma_vars)
+    fig, axes = plt.subplots(n, 1, figsize=(13, 3.2 * n), sharex=True, squeeze=False)
+    locator = mdates.AutoDateLocator()
+
+    for ax, sv in zip(axes[:, 0], sigma_vars):
+        da = ds[sv]
+        data = da.transpose("pressure", "time").values
+        units = da.attrs.get("units", "kg m⁻³")
+        label = da.attrs.get("long_name", sv)
+        _vmin = float(np.nanpercentile(data, P.COLORBAR_PLOW))
+        _vmax = float(np.nanpercentile(data, P.COLORBAR_PHIGH))
+        bounds = _nice_colorbar_bounds(_vmin, _vmax, n=20)
+        norm = mcolors.BoundaryNorm(bounds, ncolors=256)
+        pc = ax.pcolormesh(time, pressure, data, shading="nearest", cmap=P.DENSITY_COLORMAP, norm=norm)
+        cb = fig.colorbar(pc, ax=ax, pad=0.02, ticks=bounds[::2])
+        cb.set_label(f"{label} ({units})" if units else label)
+        ax.invert_yaxis()
+        ax.set_ylabel("Pressure (dbar)")
+        ax.set_title(label, loc="left")
+        ax.grid(True, linestyle="--", linewidth=0.3, alpha=0.4)
+
+    axes[-1, 0].xaxis.set_major_locator(locator)
+    axes[-1, 0].xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
+    fig.tight_layout()
+    b64 = _fig_to_base64(fig)
+    plt.close(fig)
+    return b64
+
+
+# ---------------------------------------------------------------------------
 # Rose diagrams
 # ---------------------------------------------------------------------------
 

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -19,6 +19,7 @@ from ._plots import (
     _make_stack_ts_diagram,
     _make_multi_aquadopp_trajectories,
     _make_aquadopp_speed_profile,
+    _make_adcp_trajectories_b64,
     _make_analog_timeseries,
 )
 from .. import parameters as P
@@ -116,12 +117,13 @@ _STACK_HTML_TEMPLATE = """\
   {% if fig_sal_b64 %}<a href="#sal">Salinity</a>{% endif %}
   {% if fig_east_vel_b64 or fig_north_vel_b64 or fig_up_vel_b64 %}<a href="#vel">Velocity</a>{% endif %}
   {% if fig_aquadopp_tilt_b64 %}<a href="#tilt">Tilt</a>{% endif %}
-  {% if fig_trajectories_b64 %}<a href="#trajectories">Trajectories</a>{% endif %}
+  {% if fig_trajectories_b64 or fig_adcp_trajectories_b64 %}<a href="#trajectories">Trajectories</a>{% endif %}
   {% if fig_speed_profile_b64 %}<a href="#speed-profile">Speed profile</a>{% endif %}
   {% if fig_analog_b64 %}<a href="#analog">Analog channels</a>{% endif %}
   {% if fig_ts_stack_b64 %}<a href="#ts">T-S diagram</a>{% endif %}
   {% if fig_rose_grid_b64 %}<a href="#roses">Current roses</a>{% endif %}
   {% if fig_spacing_b64 %}<a href="#spacing">Spacing</a>{% endif %}
+  <a href="#dims">Dimensions</a>
   <a href="#vars">Variables</a>
 </nav>
 
@@ -208,15 +210,28 @@ _STACK_HTML_TEMPLATE = """\
 <img class="fig" src="data:image/png;base64,{{ fig_aquadopp_tilt_b64 }}" alt="Aquadopp tilt panels">
 {% endif %}
 
-{% if fig_trajectories_b64 %}
-<h2 id="trajectories">Aquadopp particle trajectories</h2>
+{% if fig_trajectories_b64 or fig_adcp_trajectories_b64 %}
+<h2 id="trajectories">Particle trajectories</h2>
 <p class="note">
-  Pseudo-Lagrangian displacement for each Aquadopp: east/north velocity integrated over time
+  Pseudo-Lagrangian displacement: east/north velocity integrated over time
   (Euler forward; NaN velocities set to zero).  All trajectories share a common origin (0,&nbsp;0).
-  Colour shows temperature along each path (shared scale). End points labelled with serial number
-  and height above bottom.
+  Aquadopp: colour shows temperature (shared scale); end points labelled with serial and HAB.
+  ADCP: per-bin trajectories coloured by height above bottom; bins entirely below the seabed are omitted.
 </p>
-<img class="fig" style="max-width:50%" src="data:image/png;base64,{{ fig_trajectories_b64 }}" alt="Aquadopp trajectories">
+<div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-start">
+  {% if fig_trajectories_b64 %}
+  <div style="flex:1;min-width:280px">
+    <p style="text-align:center;font-weight:600;margin-bottom:0.3rem">Aquadopp</p>
+    <img class="fig" style="max-width:100%;width:100%" src="data:image/png;base64,{{ fig_trajectories_b64 }}" alt="Aquadopp trajectories">
+  </div>
+  {% endif %}
+  {% if fig_adcp_trajectories_b64 %}
+  <div style="flex:1;min-width:280px">
+    <p style="text-align:center;font-weight:600;margin-bottom:0.3rem">ADCP</p>
+    <img class="fig" style="max-width:100%;width:100%" src="data:image/png;base64,{{ fig_adcp_trajectories_b64 }}" alt="ADCP trajectories">
+  </div>
+  {% endif %}
+</div>
 {% endif %}
 
 {% if fig_speed_profile_b64 %}
@@ -265,6 +280,19 @@ _STACK_HTML_TEMPLATE = """\
 <h2 id="spacing">Adjacent instrument spacing</h2>
 <p class="note">Distribution of pressure differences between adjacent instrument pairs (pairs &lt; 2 dbar apart excluded as co-located).</p>
 <img class="fig" src="data:image/png;base64,{{ fig_spacing_b64 }}" alt="Instrument spacing histogram">
+{% endif %}
+
+<!-- ══ NetCDF dimensions ══ -->
+<h2 id="dims">NetCDF dimensions &mdash; {{ nc_file }}</h2>
+{% if nc_meta.dims %}
+<table class="var-table" style="max-width:28rem">
+  <thead><tr><th>Dimension</th><th class="num">Size</th></tr></thead>
+  <tbody>
+    {% for dim, size in nc_meta.dims.items() %}
+    <tr><td class="mono">{{ dim }}</td><td class="num">{{ "{:,}".format(size) }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endif %}
 
 <!-- ══ NetCDF variables ══ -->
@@ -759,6 +787,7 @@ def generate_stack_page(
         fig_ts_stack_b64 = _make_stack_ts_diagram(ds)
         fig_aquadopp_tilt_b64 = _make_aquadopp_tilt_panels(ds, step=step)
         fig_trajectories_b64 = _make_multi_aquadopp_trajectories(ds)
+        fig_adcp_trajectories_b64 = _make_adcp_trajectories_b64(ds)
         fig_speed_profile_b64 = _make_aquadopp_speed_profile(ds)
 
         ds.close()
@@ -814,6 +843,7 @@ def generate_stack_page(
             fig_ts_stack_b64=fig_ts_stack_b64,
             fig_aquadopp_tilt_b64=fig_aquadopp_tilt_b64,
             fig_trajectories_b64=fig_trajectories_b64,
+            fig_adcp_trajectories_b64=fig_adcp_trajectories_b64,
             fig_speed_profile_b64=fig_speed_profile_b64,
             fig_analog_b64=fig_analog_b64,
             generated=ctx["generated"],

--- a/oceanarray/stage1.py
+++ b/oceanarray/stage1.py
@@ -1025,7 +1025,6 @@ class MooringProcessor:
 
         """
         import json
-        import numpy as np  # noqa: F401 — used in potential future extensions
 
         # 1. Rename the spatial bin dimension: range → N_BINS
         if "range" in dataset.dims:
@@ -1044,6 +1043,7 @@ class MooringProcessor:
             "U": ("up_velocity", "Up velocity"),
             "err": ("error_velocity", "Error velocity"),
         }
+        _enu_extracted: list[str] = []
         if "vel" in dataset.data_vars:
             vel = dataset["vel"]
             for dir_label, (var_name, long_name) in _DIR_MAP.items():
@@ -1051,6 +1051,7 @@ class MooringProcessor:
                     component = vel.sel(dir=dir_label).transpose("time", ADCP_BIN_DIM)
                     component.attrs.update({"units": "m s-1", "long_name": long_name})
                     dataset[var_name] = component
+                    _enu_extracted.append(var_name)
             dataset = dataset.drop_vars("vel")
             if "dir" in dataset.coords:
                 dataset = dataset.drop_vars("dir")
@@ -1117,8 +1118,21 @@ class MooringProcessor:
         except Exception:  # noqa: BLE001 — raw_metadata absent or malformed; proceed without
             pass
 
-        # 7. Set coordinate system (ENU from dolfyn; declination not yet applied)
-        dataset.attrs["coordinate_system"] = "ENU"
+        # 7. Set coordinate system — only mark ENU if at least one ENU component was
+        #    extracted.  If the RDI was configured in beam or instrument coords dolfyn
+        #    uses different dir labels and _DIR_MAP matches nothing; calling the result
+        #    "ENU" would be wrong and would confuse stage3.
+        if _enu_extracted:
+            dataset.attrs["coordinate_system"] = "ENU"
+        else:
+            dataset.attrs["coordinate_system"] = "UNK"
+            self._log_print(
+                f"  WARNING: _normalize_rdi_raw extracted no ENU velocity components "
+                f"for {instrument_config.get('serial', 'UNKNOWN')}.  "
+                f"The RDI file may use beam or instrument coordinates rather than "
+                f"earth frame.  'coordinate_system' set to 'UNK'; stage3 will not "
+                f"apply beam→ENU rotation.  Re-process after converting to earth frame."
+            )
 
         # 8. Store YAML orientation and warn on mismatch with raw file
         orientation_yaml = instrument_config.get("orientation")

--- a/oceanarray/stage1.py
+++ b/oceanarray/stage1.py
@@ -12,12 +12,17 @@ import xarray as xr
 import yaml
 import seasenselib
 from seasenselib.writers import NetCdfWriter
-from .utilities import _status, cast_output_dtypes
+from .utilities import _status, cast_output_dtypes, extract_inline_instruments
+from . import parameters as P
 
 # Suppress noisy INFO/WARNING messages from seasenselib/pycnv.
 logging.getLogger("seasenselib").setLevel(logging.WARNING)
 logging.getLogger("seasenselib.pipeline.derivation").setLevel(logging.ERROR)
 logging.getLogger("pycnv").setLevel(logging.WARNING)
+
+
+# Re-export for backward compatibility; canonical definition is in parameters.py.
+ADCP_BIN_DIM: str = P.ADCP_BIN_DIM
 
 
 def _dms_str_to_decimal(s: str) -> Optional[float]:
@@ -195,6 +200,7 @@ class MooringProcessor:
         "rbr-dat",
         "rbr-hex-oa",  # internal oceanarray hex reader for TR-1050; use rbr-hex once seasenselib supports it
         "sbe-hex",
+        "rdi-raw",  # RDI ADCP raw binary (requires mhkit[dolfyn])
     }
 
     # Variables to remove for specific file types
@@ -551,6 +557,32 @@ class MooringProcessor:
         if _csv_drop:
             dataset = dataset.drop_vars(_csv_drop)
 
+        # ── 7. Consolidate per-beam amplitude and correlation into (time, beam) ─
+        # Combine amplitude_beam1/2/3 → amplitude(time, beam) and
+        # correlation_beam1/2/3 → correlation(time, beam) to match the 3-D
+        # layout used by the RDI ADCP reader.  Only applied when all three beam
+        # variables are present and 1-D (shape guard against future 2-D readers).
+        for _basename, _units, _long_name in [
+            ("amplitude", "counts", "Acoustic signal amplitude"),
+            ("correlation", "%", "Acoustic signal correlation"),
+        ]:
+            _bvars = [f"{_basename}_beam{i}" for i in range(1, 4)]
+            if not all(v in dataset.data_vars for v in _bvars):
+                continue
+            if any(dataset[v].ndim != 1 for v in _bvars):
+                continue
+            _tdim = dataset[_bvars[0]].dims[0]
+            _arr = np.stack([dataset[v].values for v in _bvars], axis=-1).astype(
+                np.float32
+            )
+            dataset[_basename] = xr.DataArray(
+                _arr,
+                dims=(_tdim, "beam"),
+                coords={"beam": np.array([1, 2, 3], dtype=np.int8)},
+                attrs={"units": _units, "long_name": _long_name},
+            )
+            dataset = dataset.drop_vars(_bvars)
+
         return dataset
 
     def _add_sbe_ascii_sensor_vars(
@@ -869,7 +901,12 @@ class MooringProcessor:
     def _clean_dataset_variables(
         self, dataset: xr.Dataset, file_type: str
     ) -> xr.Dataset:
-        """Remove unwanted variables and coordinates from dataset."""
+        """Remove unwanted variables and coordinates for specific file types.
+
+        Removals are driven by ``VARS_TO_REMOVE`` and ``COORDS_TO_REMOVE``, which
+        are only populated for SBE file types (``sbe-cnv``, ``sbe-ascii``).
+        For Nortek, RBR, and RDI ADCP file types this method is a no-op.
+        """
         # Remove variables
         vars_to_remove = self.VARS_TO_REMOVE.get(file_type, [])
         for var in vars_to_remove:
@@ -936,6 +973,166 @@ class MooringProcessor:
         dataset["end_time"] = instrument_config.get(
             "end_time", dataset.attrs["recovery_time"]
         )
+
+        return dataset
+
+    def _normalize_rdi_raw(
+        self,
+        dataset: xr.Dataset,
+        instrument_config: Dict[str, Any],
+    ) -> xr.Dataset:
+        """Normalise the dataset produced by the ``rdi-raw`` seasenselib reader.
+
+        The rdi-raw reader (via mhkit/dolfyn) returns:
+
+        - ``vel(dir, range, time)`` with ``dir=['E','N','U','err']`` — already in
+          Earth frame because ``coord_sys=earth`` was set in the RDI configuration.
+          However, ``magnetic_var_deg=0.0`` is common, meaning **no magnetic
+          declination was applied**; stage3 must apply the ppigrf correction.
+        - ``amp``, ``corr``, ``prcnt_gd`` with dims ``(beam, range, time)``.
+        - ``beam2inst_orientmat(x1, x2)`` — static beam→instrument rotation matrix.
+
+        Steps applied:
+
+        1. Rename the ``range`` spatial dimension to ``ADCP_BIN_DIM`` (``"N_BINS"``).
+           The ``range`` coordinate (metres above transducer) is preserved under the
+           new dimension name.
+        2. Split ``vel`` into ``east_velocity``, ``north_velocity``, ``up_velocity``,
+           and ``error_velocity``, each with dims ``(time, N_BINS)``.  Drops ``vel``
+           and the ``dir`` coordinate.
+        3. Transpose quality variables to ``(time, N_BINS, beam)``.
+        4. Flatten ``beam2inst_orientmat`` to global attrs ``beam2inst_M{i}{j}``
+           and drop the variable and its ``x1``/``x2`` dimension coordinates.
+        5. Transpose ``orientmat`` to ``(time, earth, inst)`` (time-first).
+        6. Extract instrument metadata from the ``raw_metadata`` JSON blob:
+           cell size, blanking distance, beam angle, pings per ensemble, and
+           ``instrument_magnetic_variation_deg``.
+        7. Set ``coordinate_system = "ENU"``.
+        8. Store ``orientation_instrument`` from the raw file and
+           ``orientation_yaml`` from the YAML ``orientation`` key (if present);
+           emit a WARNING if they disagree — a correction will be needed in stage3.
+
+        This method is faithful to the raw data: no values are modified or removed.
+        Pressure overflow values and other sensor artefacts are preserved as-is;
+        flagging is deferred to stage3.
+
+        Args:
+            dataset: Dataset as returned by ``seasenselib.read(..., file_type="rdi-raw")``.
+            instrument_config: Per-instrument YAML configuration dict.
+
+        Returns:
+            Normalised dataset ready for metadata attachment and NetCDF writing.
+
+        """
+        import json
+        import numpy as np  # noqa: F401 — used in potential future extensions
+
+        # 1. Rename the spatial bin dimension: range → N_BINS
+        if "range" in dataset.dims:
+            dataset = dataset.rename_dims({"range": ADCP_BIN_DIM})
+
+        # 2. Split vel(dir, N_BINS, time) into named components (time, N_BINS)
+        _DIR_MAP = {
+            "E": (
+                "east_velocity",
+                "East velocity (magnetic ENU; declination correction not applied)",
+            ),
+            "N": (
+                "north_velocity",
+                "North velocity (magnetic ENU; declination correction not applied)",
+            ),
+            "U": ("up_velocity", "Up velocity"),
+            "err": ("error_velocity", "Error velocity"),
+        }
+        if "vel" in dataset.data_vars:
+            vel = dataset["vel"]
+            for dir_label, (var_name, long_name) in _DIR_MAP.items():
+                if dir_label in vel.dir.values:
+                    component = vel.sel(dir=dir_label).transpose("time", ADCP_BIN_DIM)
+                    component.attrs.update({"units": "m s-1", "long_name": long_name})
+                    dataset[var_name] = component
+            dataset = dataset.drop_vars("vel")
+            if "dir" in dataset.coords:
+                dataset = dataset.drop_vars("dir")
+
+        # 3. Rename dolfyn quality variable names to oceanarray standard names,
+        #    transpose to (time, N_BINS, beam), and set long_name.
+        _QUAL_RENAME: Dict[str, Tuple[str, str]] = {
+            "amp": ("amplitude", "Acoustic signal amplitude"),
+            "corr": ("correlation", "Acoustic signal correlation"),
+            "prcnt_gd": ("percent_good", "Percent good"),
+        }
+        for dolfyn_name, (std_name, long_name) in _QUAL_RENAME.items():
+            if dolfyn_name in dataset.data_vars:
+                da = dataset[dolfyn_name].transpose("time", ADCP_BIN_DIM, "beam")
+                da.attrs.setdefault("long_name", long_name)
+                dataset[std_name] = da
+                dataset = dataset.drop_vars(dolfyn_name)
+
+        # Rename c_sound → speed_of_sound (matches Aquadopp convention)
+        if "c_sound" in dataset.data_vars:
+            dataset = dataset.rename_vars({"c_sound": "speed_of_sound"})
+
+        # 4. Store beam2inst rotation matrix as global attrs; drop variable + dim coords
+        if "beam2inst_orientmat" in dataset.data_vars:
+            mat = dataset["beam2inst_orientmat"].values
+            for _i in range(mat.shape[0]):
+                for _j in range(mat.shape[1]):
+                    dataset.attrs[f"beam2inst_M{_i + 1}{_j + 1}"] = float(mat[_i, _j])
+            dataset = dataset.drop_vars("beam2inst_orientmat")
+            for _dim_coord in ("x1", "x2"):
+                if _dim_coord in dataset.coords:
+                    dataset = dataset.drop_vars(_dim_coord)
+
+        # 5. Transpose orientmat to (time, earth, inst)
+        if "orientmat" in dataset.data_vars:
+            dataset["orientmat"] = dataset["orientmat"].transpose(
+                "time", "earth", "inst"
+            )
+
+        # 6. Extract instrument metadata from the raw_metadata JSON blob
+        try:
+            _raw_meta = json.loads(dataset.attrs.get("raw_metadata", "{}"))
+            _ga = (
+                _raw_meta.get("blocks", {})
+                .get("other", {})
+                .get("global_attributes", {})
+            )
+            for _raw_key, _attr_name in [
+                ("cell_size", "cell_size_m"),
+                ("blank_dist", "blanking_distance_m"),
+                ("beam_angle", "beam_angle_deg"),
+                ("n_cells", "n_cells"),
+                ("pings_per_ensemble", "n_pings_per_ensemble"),
+                ("carrier_freq", "carrier_freq_khz"),
+            ]:
+                if _raw_key in _ga:
+                    dataset.attrs[_attr_name] = _ga[_raw_key]
+            _mag_var = _ga.get("magnetic_var_deg")
+            if _mag_var is not None:
+                dataset.attrs["instrument_magnetic_variation_deg"] = float(_mag_var)
+            _orient_raw = _ga.get("orientation")
+            if _orient_raw:
+                dataset.attrs["orientation_instrument"] = str(_orient_raw)
+        except Exception:  # noqa: BLE001 — raw_metadata absent or malformed; proceed without
+            pass
+
+        # 7. Set coordinate system (ENU from dolfyn; declination not yet applied)
+        dataset.attrs["coordinate_system"] = "ENU"
+
+        # 8. Store YAML orientation and warn on mismatch with raw file
+        orientation_yaml = instrument_config.get("orientation")
+        if orientation_yaml:
+            dataset.attrs["orientation_yaml"] = str(orientation_yaml)
+        _orient_instrument = dataset.attrs.get("orientation_instrument", "")
+        if orientation_yaml and _orient_instrument:
+            if orientation_yaml.lower() != _orient_instrument.lower():
+                self._log_print(
+                    f"WARNING: ADCP orientation mismatch — raw file says "
+                    f"'{_orient_instrument}' but YAML says '{orientation_yaml}'. "
+                    f"Velocity signs and beam geometry may be incorrect. "
+                    f"A correction must be applied in stage3."
+                )
 
         return dataset
 
@@ -1132,6 +1329,10 @@ class MooringProcessor:
 
         relative_output = output_file.relative_to(self.base_dir)
 
+        # For rdi-raw: reshape vel/quality arrays and extract instrument metadata
+        if file_type == "rdi-raw":
+            dataset = self._normalize_rdi_raw(dataset, instrument_config)
+
         # Store Nortek pressure sensor calibration coefficients from .hdr as attrs
         if file_type in ("nortek-aqd", "nortek-ascii") and header_file:
             pcal = _parse_nortek_pressure_cal(Path(header_file))
@@ -1320,8 +1521,16 @@ class MooringProcessor:
             self._log_print(f"ERROR: Input directory not found: {input_dir}")
             return False
 
-        # Process each instrument — support both 'instruments' (legacy) and 'clamp' (new format)
-        instrument_list = yaml_data.get("clamp", yaml_data.get("instruments", []))
+        # Process each instrument — support both 'instruments' (legacy) and 'clamp' (new format).
+        # Also scan the 'inline' hardware list for entries that have an instrument field.
+        instrument_list = list(yaml_data.get("clamp", yaml_data.get("instruments", [])))
+        inline_instruments = extract_inline_instruments(yaml_data.get("inline", []))
+        if inline_instruments:
+            self._log_print(
+                f"Found {len(inline_instruments)} instrument(s) in 'inline' list: "
+                + ", ".join(str(ic.get("serial", "?")) for ic in inline_instruments)
+            )
+        instrument_list = instrument_list + inline_instruments
 
         # Filter by serial if requested
         if serials:

--- a/oceanarray/stage2.py
+++ b/oceanarray/stage2.py
@@ -47,7 +47,12 @@ import xarray as xr
 import yaml
 from seasenselib.writers import NetCdfWriter
 
-from .utilities import _status, cast_output_dtypes, drop_all_zero_vars
+from .utilities import (
+    _status,
+    cast_output_dtypes,
+    drop_all_zero_vars,
+    extract_inline_instruments,
+)
 
 
 def _parse_clock_str(s: str) -> Optional[pd.Timestamp]:
@@ -674,9 +679,10 @@ class Stage2Processor:
         self._log_print(f"Recovery time: {recover_time}")
 
         # Process each instrument — support both 'instruments' (legacy) and 'clamp' (new format)
-        instrument_list = mooring_config.get(
-            "clamp", mooring_config.get("instruments", [])
+        instrument_list = list(
+            mooring_config.get("clamp", mooring_config.get("instruments", []))
         )
+        instrument_list += extract_inline_instruments(mooring_config.get("inline", []))
 
         # Filter by serial if requested
         if serials:

--- a/oceanarray/stage3.py
+++ b/oceanarray/stage3.py
@@ -944,12 +944,55 @@ def _compute_adcp_bin_pressure(
     lat: float,
     log_fn: Any = None,
 ) -> xr.Dataset:
-    """Compute pressure at each ADCP bin from transducer pressure and range.
+    """Compute pressure at each ADCP bin from transducer pressure and along-beam range.
 
-    Creates ``bin_pressure(time, N_BINS)`` in dbar.  Orientation is read from
-    the ``orientation_yaml`` attribute (preferred) or ``orientation_instrument``
-    (fallback).  For a downward-looking ADCP bins are deeper than the
-    transducer so pressure increases; for upward-looking it decreases.
+    For each time step, adds a pressure offset per bin based on the bin's distance
+    from the transducer.  The offset is ``gsw.p_from_z(-range_m, lat)``, which
+    approximates the hydrostatic pressure contribution of *range_m* metres of
+    seawater at the given latitude.
+
+    **Note on ``range`` units**: the RDI WorkHorse firmware already converts slant range
+    to vertical distance before writing to the raw output (using the nominal beam angle;
+    see RDI ADCP Coordinate Transformation manual §4.2, Equation 8).  Dolfyn reads these
+    vertical distances directly, so ``range`` is already in metres of vertical depth —
+    no beam-angle correction is needed.
+
+    **Approximation** (fixable post-OdB; see ``.claude/refactor-plan-postOdB-20260721.md``):
+    ``gsw.p_from_z(-range_m, lat)`` computes the pressure of a water column of depth
+    *range_m* measured from the *sea surface*, not the true pressure increment at the
+    ADCP's actual depth.  Error at 300 m range from a 500 m transducer is ~2–3 dbar —
+    within the seabed-QC margin (~20 dbar) for current moorings.
+
+    The sign follows instrument orientation:
+
+    - Downward-looking (``orientation == "down"``): bins are deeper than the
+      transducer → pressure increases with bin index.
+    - Upward-looking (``orientation == "up"``): bins are shallower than the
+      transducer → pressure decreases with bin index.
+
+    If orientation cannot be determined from dataset attributes a WARNING is emitted
+    and ``"down"`` is assumed.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Stage 3 ADCP dataset.  Must contain ``pressure(time)`` in dbar (pressure at
+        the transducer head) and ``range(N_BINS)`` in metres (bin centre distance from
+        the transducer face).  Orientation is read from the ``orientation_yaml`` global
+        attribute (preferred) or ``orientation_instrument`` (fallback).
+    lat : float
+        Mooring latitude in decimal degrees (positive North), used by
+        ``gsw.p_from_z`` for the gravitational/centrifugal correction.
+    log_fn : callable, optional
+        Logging callback (e.g. ``logger.info``).
+
+    Returns
+    -------
+    xr.Dataset
+        Input dataset with ``bin_pressure(time, N_BINS)`` added in dbar.
+        The variable's ``comment`` attribute records the formula and orientation used.
+        Returns *ds* unchanged if ``pressure`` or ``range`` are absent.
+
     """
     import gsw
     from . import parameters as _P
@@ -960,8 +1003,16 @@ def _compute_adcp_bin_pressure(
         return ds
 
     orientation = ds.attrs.get("orientation_yaml") or ds.attrs.get(
-        "orientation_instrument", "down"
+        "orientation_instrument"
     )
+    if not orientation:
+        orientation = "down"
+        if log_fn:
+            log_fn(
+                "  WARNING: ADCP orientation unknown (no orientation_yaml or "
+                "orientation_instrument attr) — assuming downward-looking. "
+                "bin_pressure signs may be wrong for upward-looking instruments."
+            )
     sign = 1.0 if str(orientation).lower() == "down" else -1.0
 
     p_trans = ds["pressure"].values.astype(float)  # (time,)
@@ -1002,29 +1053,45 @@ def _apply_adcp_seabed_qc(
 ) -> xr.Dataset:
     """Flag ADCP bins that are at or below the seabed.
 
-    Bins whose ``bin_pressure`` exceeds the estimated seabed pressure are
-    flagged suspect (3); bins more than *fail_margin_m* metres below the
-    seabed are flagged bad (4).  The flag is stored as
-    ``seabed_qc(time, N_BINS)`` and merged into the per-component velocity
-    QC variables via ``_merge_flags``.
+    Bins whose ``bin_pressure`` exceeds the estimated seabed pressure are flagged
+    suspect (3); bins more than *fail_margin_m* metres below the seabed are flagged
+    bad (4).  The flag is stored as the standalone variable ``seabed_qc(time, N_BINS)``.
+
+    **Flag scale** (OceanSITES / QARTOD convention):
+    1 = good, 3 = suspect, 4 = bad, 9 = missing.
+
+    **Standalone flag**: ``seabed_qc`` is *not* merged into ``east_velocity_qc``,
+    ``north_velocity_qc``, or ``up_velocity_qc``.  Downstream code that needs clean
+    velocity data must explicitly include all relevant flags, for example::
+
+        clean = (ds.east_velocity_qc == 1) & (ds.seabed_qc == 1)
+
+    The seabed pressure threshold is computed via ``gsw.p_from_z(-water_depth_m, lat)``,
+    consistent with ``_compute_adcp_bin_pressure``.
 
     Parameters
     ----------
     ds : xr.Dataset
-        Stage 3 dataset containing ``bin_pressure(time, N_BINS)``.
+        Stage 3 ADCP dataset containing ``bin_pressure(time, N_BINS)`` in dbar.
     water_depth_m : float
-        Water depth at the mooring site in metres (from YAML ``waterdepth``
-        key).  If ≤ 0 the function is a no-op.
+        Water depth at the mooring site in metres (from YAML ``waterdepth`` key).
+        If ≤ 0 the function is a no-op.
     lat : float
-        Latitude (decimal degrees) for ``gsw.p_from_z`` conversion.
+        Mooring latitude in decimal degrees, used by ``gsw.p_from_z``.
     qc_attrs : dict
         OceanSITES flag attribute dict written to ``seabed_qc``.
     fail_margin_m : float
-        Depth margin below seabed that triggers the bad (4) flag.
-        Default 20 m.  Bins between 0 and *fail_margin_m* below the seabed
-        receive the suspect (3) flag.
+        Margin below the seabed (in metres) that separates suspect (3) from bad (4).
+        Default 20 m.  Bins between 0 and *fail_margin_m* below the seabed receive
+        flag 3; bins more than *fail_margin_m* below receive flag 4.
     log_fn : callable, optional
         Logging callback.
+
+    Returns
+    -------
+    xr.Dataset
+        Input dataset with ``seabed_qc(time, N_BINS)`` added.
+        Returns *ds* unchanged if ``water_depth_m <= 0`` or ``bin_pressure`` is absent.
 
     """
     if water_depth_m <= 0:
@@ -1151,6 +1218,21 @@ def _apply_adcp_velocity_qc(
         OceanSITES flag attribute dict written to every ``*_qc`` variable.
     log_fn : callable, optional
         Logging callback.
+
+    Returns
+    -------
+    xr.Dataset
+        Input dataset with the following standalone QC variables added (where their
+        parent data variables are present):
+
+        - ``east_velocity_qc(time, N_BINS)`` — gross-range flag on east velocity
+        - ``north_velocity_qc(time, N_BINS)`` — gross-range flag on north velocity
+        - ``up_velocity_qc(time, N_BINS)`` — gross-range flag on up velocity
+        - ``percent_good_qc(time, N_BINS)`` — 4-beam percent-good flag
+        - ``error_velocity_qc(time, N_BINS)`` — error velocity magnitude flag
+
+        All flags use the OceanSITES scale: 1 = good, 3 = suspect, 4 = bad, 9 = missing.
+        Variables are standalone; no merging across criteria is performed.
 
     """
     # 1. Gross-range on each ENU velocity component independently.
@@ -1655,9 +1737,9 @@ class Stage3Processor:
 
             # ── Tilt QC ────────────────────────────────────────────────
             # Flags all velocity variables when pitch+roll tilt exceeds threshold.
-            # Skipped for ADCP: percent_good and error_velocity already capture
-            # ensemble-level quality; tilt thresholding is handled per-bin by
-            # _apply_adcp_velocity_qc instead.
+            # Skipped for ADCP: percent_good (col 3) and error_velocity capture
+            # ensemble-level quality without a separate tilt threshold step.
+            # Note: this does NOT mean tilt is checked per-bin — it is not.
             tilt_cfg = info["tilt"]
             if is_adcp:
                 n_tilt_susp, n_tilt_bad = 0, 0

--- a/oceanarray/stage3.py
+++ b/oceanarray/stage3.py
@@ -51,7 +51,11 @@ import numpy as np
 import xarray as xr
 import yaml
 
-from .utilities import cast_output_dtypes, drop_all_zero_vars
+from .utilities import (
+    cast_output_dtypes,
+    drop_all_zero_vars,
+    extract_inline_instruments,
+)
 
 
 HAB_THRESHOLD = 2.0  # metres — use near-neighbour below this Δhab
@@ -482,13 +486,17 @@ def _merge_flags(*flag_arrays: np.ndarray) -> np.ndarray:
     """Merge multiple int8 flag arrays using priority ordering.
 
     Returns element-wise flag with highest priority (worst quality).
+    Works on arrays of any shape (1-D time series or 2-D time×N_BINS).
     """
-    result = flag_arrays[0].copy()
+    # Lookup table: priority[flag] for flags 0-9
+    # _QC_PRIORITY: {9:6, 4:5, 3:4, 8:3, 2:2, 1:1, 0:0}; unlisted flags → 0
+    _priority = np.array([0, 1, 2, 4, 5, 0, 0, 0, 3, 6], dtype=np.int8)
+    result = np.asarray(flag_arrays[0], dtype=np.int8).copy()
     for fa in flag_arrays[1:]:
-        for i in range(len(result)):
-            a, b = int(result[i]), int(fa[i])
-            result[i] = a if _QC_PRIORITY.get(a, 0) >= _QC_PRIORITY.get(b, 0) else b
-    return result.astype(np.int8)
+        fa = np.asarray(fa, dtype=np.int8)
+        replace = _priority[fa.clip(0, 9)] > _priority[result.clip(0, 9)]
+        result = np.where(replace, fa, result).astype(np.int8)
+    return result
 
 
 def _deep_merge(base: Dict, override: Dict) -> Dict:
@@ -668,11 +676,18 @@ def _apply_tilt_qc(
     vel_vars = [v for v in _VELOCITY_VARS if v in ds.data_vars]
     for varname in vel_vars:
         qc_varname = f"{varname}_qc"
+        # For ADCP, velocity is 2-D (time, N_BINS); broadcast (time,) → (time, N_BINS).
+        if ds[varname].values.ndim > 1:
+            flags_for_var = np.broadcast_to(
+                tilt_flags[:, np.newaxis], ds[varname].shape
+            ).copy()
+        else:
+            flags_for_var = tilt_flags.copy()
         if qc_varname in ds:
             existing = ds[qc_varname].values.astype(np.int8)
-            new_flags = _merge_flags(existing, tilt_flags)
+            new_flags = _merge_flags(existing, flags_for_var)
         else:
-            new_flags = tilt_flags.copy()
+            new_flags = flags_for_var
         ds[qc_varname] = xr.Variable(
             ds[varname].dims,
             new_flags,
@@ -924,6 +939,332 @@ def _apply_enu_velocity_qc(
     return ds
 
 
+def _compute_adcp_bin_pressure(
+    ds: xr.Dataset,
+    lat: float,
+    log_fn: Any = None,
+) -> xr.Dataset:
+    """Compute pressure at each ADCP bin from transducer pressure and range.
+
+    Creates ``bin_pressure(time, N_BINS)`` in dbar.  Orientation is read from
+    the ``orientation_yaml`` attribute (preferred) or ``orientation_instrument``
+    (fallback).  For a downward-looking ADCP bins are deeper than the
+    transducer so pressure increases; for upward-looking it decreases.
+    """
+    import gsw
+    from . import parameters as _P
+
+    if "pressure" not in ds.data_vars or "range" not in ds.coords:
+        if log_fn:
+            log_fn("  ADCP bin_pressure: skipped (no pressure or range coord)")
+        return ds
+
+    orientation = ds.attrs.get("orientation_yaml") or ds.attrs.get(
+        "orientation_instrument", "down"
+    )
+    sign = 1.0 if str(orientation).lower() == "down" else -1.0
+
+    p_trans = ds["pressure"].values.astype(float)  # (time,)
+    range_m = ds["range"].values.astype(float)  # (N_BINS,)
+
+    # gsw.p_from_z(z, lat): z is depth in m (negative = below surface)
+    dp = gsw.p_from_z(-range_m, lat)  # (N_BINS,) pressure offset per bin
+
+    bin_p = p_trans[:, np.newaxis] + sign * dp[np.newaxis, :]  # (time, N_BINS)
+
+    ds["bin_pressure"] = xr.Variable(
+        ("time", _P.ADCP_BIN_DIM),
+        bin_p.astype(np.float32),
+        attrs={
+            "long_name": "pressure at ADCP bin",
+            "units": "dbar",
+            "comment": (
+                f"transducer pressure + gsw.p_from_z(-range, lat={lat:.2f}°)"
+                f" × sign({orientation}-looking)"
+            ),
+        },
+    )
+    if log_fn:
+        log_fn(
+            f"  ADCP bin_pressure: {ds['range'].size} bins, "
+            f"orientation={orientation}, lat={lat:.2f}°"
+        )
+    return ds
+
+
+def _apply_adcp_seabed_qc(
+    ds: xr.Dataset,
+    water_depth_m: float,
+    lat: float,
+    qc_attrs: Dict[str, Any],
+    fail_margin_m: float = 20.0,
+    log_fn: Any = None,
+) -> xr.Dataset:
+    """Flag ADCP bins that are at or below the seabed.
+
+    Bins whose ``bin_pressure`` exceeds the estimated seabed pressure are
+    flagged suspect (3); bins more than *fail_margin_m* metres below the
+    seabed are flagged bad (4).  The flag is stored as
+    ``seabed_qc(time, N_BINS)`` and merged into the per-component velocity
+    QC variables via ``_merge_flags``.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Stage 3 dataset containing ``bin_pressure(time, N_BINS)``.
+    water_depth_m : float
+        Water depth at the mooring site in metres (from YAML ``waterdepth``
+        key).  If ≤ 0 the function is a no-op.
+    lat : float
+        Latitude (decimal degrees) for ``gsw.p_from_z`` conversion.
+    qc_attrs : dict
+        OceanSITES flag attribute dict written to ``seabed_qc``.
+    fail_margin_m : float
+        Depth margin below seabed that triggers the bad (4) flag.
+        Default 20 m.  Bins between 0 and *fail_margin_m* below the seabed
+        receive the suspect (3) flag.
+    log_fn : callable, optional
+        Logging callback.
+
+    """
+    if water_depth_m <= 0:
+        if log_fn:
+            log_fn("  seabed QC: skipped (waterdepth not set in mooring YAML)")
+        return ds
+    if "bin_pressure" not in ds.data_vars:
+        if log_fn:
+            log_fn("  seabed QC: skipped (bin_pressure not in dataset)")
+        return ds
+
+    import gsw
+    from . import parameters as _P
+
+    p_seabed = float(gsw.p_from_z(-water_depth_m, lat))
+    p_fail = float(gsw.p_from_z(-(water_depth_m + fail_margin_m), lat))
+
+    bin_p = ds["bin_pressure"].values  # (time, N_BINS)
+    seabed_flags = np.ones(bin_p.shape, dtype=np.int8)  # 1 = good
+    seabed_flags = np.where(bin_p > p_seabed, np.int8(3), seabed_flags)  # suspect
+    seabed_flags = np.where(bin_p > p_fail, np.int8(4), seabed_flags)  # bad
+    seabed_flags = seabed_flags.astype(np.int8)
+
+    n_suspect = int(np.sum(seabed_flags == 3))
+    n_bad = int(np.sum(seabed_flags == 4))
+
+    ds["seabed_qc"] = xr.Variable(
+        ("time", _P.ADCP_BIN_DIM),
+        seabed_flags,
+        {
+            "long_name": "Seabed proximity QC flag",
+            "comment": (
+                f"Bins at or below seabed ({water_depth_m:.0f} m, "
+                f"p_seabed={p_seabed:.1f} dbar): flag 3 (suspect); "
+                f"bins >{fail_margin_m:.0f} m below seabed "
+                f"(p={p_fail:.1f} dbar): flag 4 (bad). "
+                "Standalone — not merged into velocity_qc."
+            ),
+            **qc_attrs,
+        },
+    )
+
+    if log_fn:
+        log_fn(
+            f"  seabed QC: water_depth={water_depth_m:.0f} m, "
+            f"p_seabed={p_seabed:.1f} dbar, "
+            f"p_fail={p_fail:.1f} dbar (+{fail_margin_m:.0f} m), "
+            f"suspect={n_suspect}, bad={n_bad}"
+        )
+    return ds
+
+
+def _apply_adcp_velocity_qc(
+    ds: xr.Dataset,
+    gr_cfg: Dict[str, Any],
+    prcnt_gd_bad: float,
+    prcnt_gd_suspect: float,
+    error_vel_threshold: float,
+    qc_attrs: Dict[str, Any],
+    log_fn: Any = None,
+) -> xr.Dataset:
+    """Apply QC to ADCP 2D velocity variables (time × N_BINS).
+
+    Each QC criterion produces its **own standalone variable**; flags are
+    **not** merged across variables.  Downstream users combine them to mask
+    data, e.g.::
+
+        good = (
+            (ds.east_velocity_qc == 1)
+            & (ds.percent_good_qc == 1)
+            & (ds.error_velocity_qc == 1)
+            & (ds.seabed_qc == 1)
+        )
+
+    QC variables produced
+    ---------------------
+    ``east/north/up_velocity_qc``
+        Gross-range flag on the velocity component value itself (same
+        fail_span / suspect_span thresholds as point instruments).  Flag 1
+        means the velocity value is within the accepted range; it says nothing
+        about acoustic quality.
+
+    ``percent_good_qc(time, N_BINS)``
+        RDI ADCPs write four percent-good columns per ensemble per bin:
+
+        =======  =============================================================
+        Col 0    % pings accepted as 3-beam solutions (one beam rejected)
+        Col 1    % pings rejected by the error-velocity threshold
+        Col 2    % pings rejected by low correlation or low amplitude
+        **Col 3**  **% pings accepted as 4-beam solutions ← quality metric**
+        =======  =============================================================
+
+        Column 3 (4-beam solutions) is the relevant quality indicator.
+        Averaging all four columns is wrong: when data is perfect, col 3 ≈
+        100 % and cols 0–2 ≈ 0 %, giving a mean of ~25 %, which falls below
+        any reasonable suspect threshold and flags everything.  This function
+        therefore uses column 3 alone (falling back to the column mean for
+        non-4-beam ADCPs that store fewer than 4 columns).
+
+        Flags: col3 < *prcnt_gd_bad* → bad (4);
+        col3 < *prcnt_gd_suspect* → suspect (3); otherwise good (1).
+
+    ``error_velocity_qc(time, N_BINS)``
+        For a 4-beam ADCP the error velocity is the difference between two
+        independent estimates of vertical velocity from opposite beam pairs.
+        It is zero for a perfect measurement; large values indicate beam
+        decorrelation (e.g. fish, bubbles, mooring motion).
+        |error_velocity| > *error_vel_threshold* → bad (4).
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Stage 2 dataset with 2-D ADCP velocity variables.
+    gr_cfg : dict
+        Gross-range config (same format as ``_load_qc_config`` returns).
+    prcnt_gd_bad : float
+        4-beam percent good below this → flag 4 (bad). Percent.
+    prcnt_gd_suspect : float
+        4-beam percent good below this (but above prcnt_gd_bad) → flag 3
+        (suspect). Percent.
+    error_vel_threshold : float
+        |error_velocity| above this → flag 4 (bad). m s⁻¹.
+    qc_attrs : dict
+        OceanSITES flag attribute dict written to every ``*_qc`` variable.
+    log_fn : callable, optional
+        Logging callback.
+
+    """
+    # 1. Gross-range on each ENU velocity component independently.
+    #    Flags only reflect whether that component's value is out of range.
+    for varname in ("east_velocity", "north_velocity", "up_velocity"):
+        if varname not in ds.data_vars:
+            continue
+        cfg = gr_cfg.get(varname)
+        if not cfg:
+            continue
+        data = ds[varname].values.astype(float)
+        fail_min, fail_max = cfg["fail_span"]
+        susp_min, susp_max = cfg.get("suspect_span", cfg["fail_span"])
+        flags = np.where(
+            ~np.isfinite(data),
+            np.int8(9),
+            np.where(
+                (data < fail_min) | (data > fail_max),
+                np.int8(4),
+                np.where((data < susp_min) | (data > susp_max), np.int8(3), np.int8(1)),
+            ),
+        ).astype(np.int8)
+        qc_var = f"{varname}_qc"
+        threshold_attrs: Dict[str, Any] = {
+            "qc_gross_range_fail_min": float(fail_min),
+            "qc_gross_range_fail_max": float(fail_max),
+            "qc_gross_range_suspect_min": float(susp_min),
+            "qc_gross_range_suspect_max": float(susp_max),
+        }
+        ds[qc_var] = xr.Variable(
+            ds[varname].dims,
+            flags,
+            attrs={
+                "long_name": f"quality flag for {varname}",
+                **qc_attrs,
+                **threshold_attrs,
+            },
+        )
+
+    # 2. percent_good QC — standalone variable, NOT merged into velocity_qc.
+    #    RDI ADCPs store four percent-good columns per bin:
+    #      [0] 3-beam solutions  [1] rejected (error vel)
+    #      [2] rejected (low corr/amp)  [3] 4-beam solutions  ← the useful one
+    #    Using column 3 only; averaging all columns gives ~25% even for
+    #    perfect data (100% 4-beam, 0% others), which would flag everything.
+    if "percent_good" in ds.data_vars:
+        pg = ds["percent_good"].values.astype(float)  # (time, N_BINS, beam)
+        if pg.ndim == 3 and pg.shape[2] >= 4:
+            pg_col3 = pg[:, :, 3]  # 4-beam solutions column
+        else:
+            pg_col3 = np.nanmean(pg, axis=-1)  # fallback for non-4-beam ADCPs
+        pg_flags = np.where(
+            ~np.isfinite(pg_col3),
+            np.int8(9),
+            np.where(
+                pg_col3 < prcnt_gd_bad,
+                np.int8(4),
+                np.where(pg_col3 < prcnt_gd_suspect, np.int8(3), np.int8(1)),
+            ),
+        ).astype(np.int8)
+        n_bad_pg = int(np.sum(pg_flags == 4))
+        n_susp_pg = int(np.sum(pg_flags == 3))
+        if log_fn:
+            log_fn(
+                f"  ADCP percent_good QC (col-3 4-beam): bad={n_bad_pg}, suspect={n_susp_pg} "
+                f"(thresholds: bad<{prcnt_gd_bad}%, suspect<{prcnt_gd_suspect}%)"
+            )
+        from . import parameters as _P
+
+        ds["percent_good_qc"] = xr.Variable(
+            ("time", _P.ADCP_BIN_DIM),
+            pg_flags,
+            attrs={
+                "long_name": "QC flag for ADCP percent good (4-beam solutions, column 3)",
+                "comment": (
+                    f"Based on RDI percent_good column 3 (4-beam solutions). "
+                    f"bad<{prcnt_gd_bad}%, suspect<{prcnt_gd_suspect}%. "
+                    "Standalone — not merged into velocity_qc."
+                ),
+                **qc_attrs,
+            },
+        )
+
+    # 3. error_velocity QC — standalone variable, NOT merged into velocity_qc.
+    if "error_velocity" in ds.data_vars:
+        ev = ds["error_velocity"].values.astype(float)  # (time, N_BINS)
+        ev_flags = np.where(
+            ~np.isfinite(ev),
+            np.int8(9),
+            np.where(np.abs(ev) > error_vel_threshold, np.int8(4), np.int8(1)),
+        ).astype(np.int8)
+        n_ev_bad = int(np.sum(ev_flags == 4))
+        if log_fn:
+            log_fn(
+                f"  ADCP error_velocity QC: bad={n_ev_bad} "
+                f"(threshold: |ev|>{error_vel_threshold:.2f} m s-1). Standalone."
+            )
+        ds["error_velocity_qc"] = xr.Variable(
+            ds["error_velocity"].dims,
+            ev_flags,
+            attrs={
+                "long_name": "QC flag for error velocity",
+                "comment": (
+                    f"|error_velocity| > {error_vel_threshold:.2f} m s-1 → bad (4). "
+                    "Standalone — not merged into velocity_qc."
+                ),
+                "qc_threshold_fail_m_s": float(error_vel_threshold),
+                **qc_attrs,
+            },
+        )
+
+    return ds
+
+
 class Stage3Processor:
     """Pressure interpolation + QARTOD QC for all mooring instruments."""
 
@@ -978,9 +1319,10 @@ class Stage3Processor:
         with open(config_file) as f:
             mooring_config = yaml.safe_load(f)
 
-        instrument_list = mooring_config.get(
-            "clamp", mooring_config.get("instruments", [])
+        instrument_list = list(
+            mooring_config.get("clamp", mooring_config.get("instruments", []))
         )
+        instrument_list += extract_inline_instruments(mooring_config.get("inline", []))
 
         # ── Mooring location for BEAM→ENU declination ──────────────────
         from .mooring_level import _parse_latlon_with_source
@@ -988,6 +1330,8 @@ class Stage3Processor:
         _mooring_lat, _mooring_lon, _latlon_source = _parse_latlon_with_source(
             mooring_config
         )
+
+        _water_depth_m = float(mooring_config.get("waterdepth") or 0.0)
 
         # ── Build instrument table ──────────────────────────────────────
         instruments: List[Dict[str, Any]] = []
@@ -1043,6 +1387,7 @@ class Stage3Processor:
                     "lat": _mooring_lat,
                     "lon": _mooring_lon,
                     "latlon_source": _latlon_source,
+                    "water_depth_m": _water_depth_m,
                 }
             )
 
@@ -1218,12 +1563,15 @@ class Stage3Processor:
 
         is_target = info in targets
         pressure_bad_flag = info["qc_flags"].get("pressure", 0) >= 3
+        is_adcp = info.get("instrument", "").lower() == "adcp"
 
         self._log(
             f"-->   Processing {info.get('instrument', 'unknown')}: {nc_path.name}"
         )
 
         try:
+            from . import parameters as P
+
             ds = xr.open_dataset(nc_path, decode_timedelta=False).load()
             target_time = ds["time"].values
             history_notes = []
@@ -1246,7 +1594,15 @@ class Stage3Processor:
             # ── QARTOD QC tests (temperature, conductivity, salinity, …) ─
             gr_cfg = info["gross_range"]
             sp_cfg = info["spike"]
-            ds = _apply_qc_tests(ds, gr_cfg, sp_cfg, qc_attrs)
+            # For ADCP, exclude 2-D velocity vars from the ioos_qc path
+            # (gross_range_test expects 1-D input); velocity QC is handled
+            # below by _apply_adcp_velocity_qc.
+            if is_adcp:
+                _ENU_KEYS = {"east_velocity", "north_velocity", "up_velocity"}
+                gr_cfg_scalar = {k: v for k, v in gr_cfg.items() if k not in _ENU_KEYS}
+                ds = _apply_qc_tests(ds, gr_cfg_scalar, sp_cfg, qc_attrs)
+            else:
+                ds = _apply_qc_tests(ds, gr_cfg, sp_cfg, qc_attrs)
 
             # ── Fold T/C/P parent QC into salinity_qc ─────────────────
             ds = _merge_salinity_parent_qc(ds, qc_attrs)
@@ -1274,22 +1630,48 @@ class Stage3Processor:
                 )
 
             # ── ENU velocity QC + up→east/north flag propagation ──────
-            # Run gross-range on ENU vars just created by _apply_beam_to_enu,
-            # then propagate up_velocity_qc so bad w flags u and v too.
             if ds.attrs.get("coordinate_system") == "ENU":
-                ds = _apply_enu_velocity_qc(ds, gr_cfg, qc_attrs)
+                if is_adcp:
+                    adcp_qc = P.QC_ADCP
+                    ds = _apply_adcp_velocity_qc(
+                        ds,
+                        gr_cfg=gr_cfg,
+                        prcnt_gd_bad=adcp_qc["percent_good_bad"],
+                        prcnt_gd_suspect=adcp_qc["percent_good_suspect"],
+                        error_vel_threshold=adcp_qc["error_velocity_threshold"],
+                        qc_attrs=qc_attrs,
+                        log_fn=self._log,
+                    )
+                    ds = _compute_adcp_bin_pressure(ds, info["lat"], log_fn=self._log)
+                    ds = _apply_adcp_seabed_qc(
+                        ds,
+                        water_depth_m=info.get("water_depth_m", 0.0),
+                        lat=info["lat"],
+                        qc_attrs=qc_attrs,
+                        log_fn=self._log,
+                    )
+                else:
+                    ds = _apply_enu_velocity_qc(ds, gr_cfg, qc_attrs)
 
             # ── Tilt QC ────────────────────────────────────────────────
-            # Flags all velocity variables (beam and ENU) when combined
-            # pitch+roll tilt exceeds threshold.
+            # Flags all velocity variables when pitch+roll tilt exceeds threshold.
+            # Skipped for ADCP: percent_good and error_velocity already capture
+            # ensemble-level quality; tilt thresholding is handled per-bin by
+            # _apply_adcp_velocity_qc instead.
             tilt_cfg = info["tilt"]
-            ds, n_tilt_susp, n_tilt_bad = _apply_tilt_qc(ds, tilt_cfg, qc_attrs)
-            if n_tilt_susp or n_tilt_bad:
+            if is_adcp:
+                n_tilt_susp, n_tilt_bad = 0, 0
                 history_notes.append(
-                    f"tilt QC (tilt≥{tilt_cfg['suspect_threshold']}°→suspect, "
-                    f"tilt≥{tilt_cfg['fail_threshold']}°→bad): "
-                    f"suspect={n_tilt_susp}, bad={n_tilt_bad}"
+                    "tilt QC skipped for ADCP (percent_good+error_velocity QC applied instead)"
                 )
+            else:
+                ds, n_tilt_susp, n_tilt_bad = _apply_tilt_qc(ds, tilt_cfg, qc_attrs)
+                if n_tilt_susp or n_tilt_bad:
+                    history_notes.append(
+                        f"tilt QC (tilt≥{tilt_cfg['suspect_threshold']}°→suspect, "
+                        f"tilt≥{tilt_cfg['fail_threshold']}°→bad): "
+                        f"suspect={n_tilt_susp}, bad={n_tilt_bad}"
+                    )
             if ds.attrs.get("coordinate_system") == "ENU" and coord_sys_before != "ENU":
                 _ba = ds.attrs.get("nortek_beam_angle", "?")
                 _ba_src = ds.attrs.get("nortek_beam_angle_source", "")
@@ -1307,7 +1689,7 @@ class Stage3Processor:
             for v in sorted(ds.data_vars):
                 if v.endswith("_qc") and not v.endswith("_orig_qc"):
                     counts = np.bincount(
-                        ds[v].values.astype(np.int8).clip(0, 9), minlength=10
+                        ds[v].values.astype(np.int8).clip(0, 9).ravel(), minlength=10
                     )
                     n_good = int(counts[1])
                     n_susp = int(counts[3])

--- a/oceanarray/tools.py
+++ b/oceanarray/tools.py
@@ -161,6 +161,7 @@ def flag_salinity_outliers(ds, n_std=4):
 
 def flag_temporal_spikes(ds, var="CNDC", threshold=5):
     """Flags large absolute differences in time for each depth.
+
     threshold: maximum allowed difference in units of the variable
     """
     diff = np.abs(ds[var].diff("TIME", label="upper"))

--- a/oceanarray/tools.py
+++ b/oceanarray/tools.py
@@ -118,6 +118,27 @@ def find_cold_entry_exit(
 
 
 def calc_psal(ds):
+    """Compute Practical Salinity from conductivity, temperature, and pressure.
+
+    Uses the Gibbs SeaWater (GSW) toolbox: ``gsw.SP_from_C`` applies the
+    PSS-78 equation to derive Practical Salinity (dimensionless, roughly PSU)
+    from conductivity (mS cm⁻¹), temperature (°C), and pressure (dbar).
+
+    If ``PSAL`` is already present in *ds* the function is a no-op.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing ``CNDC`` (conductivity, mS cm⁻¹), ``TEMP``
+        (temperature, °C), and ``PRES`` (pressure, dbar).
+
+    Returns
+    -------
+    xarray.Dataset
+        Input dataset with ``PSAL`` added (same dimensions as ``CNDC``),
+        or unchanged if ``PSAL`` was already present.
+
+    """
     if "PSAL" not in ds:
         SP = gsw.SP_from_C(ds["CNDC"], ds["TEMP"], ds["PRES"])
         ds["PSAL"] = (ds["CNDC"].dims, SP.data)

--- a/oceanarray/utilities.py
+++ b/oceanarray/utilities.py
@@ -3,12 +3,71 @@
 import math
 from datetime import datetime
 from functools import wraps
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 import xarray as xr
 
 from oceanarray import logger
+
+
+def extract_inline_instruments(
+    inline_list: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Extract processable instrument entries from the mooring YAML ``inline`` list.
+
+    Most ``inline`` entries describe passive hardware (ropes, shackles, floats).
+    This function filters for entries that have an ``instrument`` field and either
+    a ``filename`` (to be processed) or ``skip: true`` (to be reported as skipped).
+
+    Normalisation applied to each matching entry:
+
+    - ``hab`` is set from ``hab_bottom`` if ``hab`` is not already present.
+      For a downward-looking instrument the transducer is at the bottom of the
+      housing (``hab_bottom``); for an upward-looking one use ``hab_top``.
+    - ``serial`` is split on the first comma and the first token is used as the
+      primary serial number.  Any remaining tokens are joined and stored under
+      ``beacon_id`` in the returned dict.
+    - ``source: "inline"`` is added to distinguish these entries from ``clamp``
+      entries in downstream logging.
+
+    **Serial parsing is fragile**: the convention ``serial: 16430, R01-024``
+    assumes the *first* comma-separated token is the instrument serial and the
+    rest is a transponder/beacon ID.  If a YAML author places the beacon serial
+    first, the wrong value will be used as the output filename stem.  The
+    validator emits a WARNING for any inline entry whose serial contains a comma
+    so operators can confirm the ordering is correct.
+
+    Args:
+        inline_list: The raw list parsed from the ``inline`` YAML key.
+
+    Returns:
+        List of normalised instrument-config dicts ready for stage processing.
+
+    """
+    result: List[Dict[str, Any]] = []
+    for entry in inline_list:
+        if not isinstance(entry, dict):
+            continue
+        if "instrument" not in entry:
+            continue
+        if not entry.get("filename") and not entry.get("skip"):
+            continue
+
+        normalized: Dict[str, Any] = dict(entry)
+
+        if "hab" not in normalized and "hab_bottom" in normalized:
+            normalized["hab"] = normalized["hab_bottom"]
+
+        serial_raw = str(entry.get("serial", ""))
+        if "," in serial_raw:
+            parts = [p.strip() for p in serial_raw.split(",")]
+            normalized["serial"] = parts[0]
+            normalized["beacon_id"] = ", ".join(parts[1:])
+
+        normalized["source"] = "inline"
+        result.append(normalized)
+    return result
 
 
 def concat_with_scalar_vars(

--- a/oceanarray/validation.py
+++ b/oceanarray/validation.py
@@ -103,12 +103,20 @@ VALID_INSTRUMENTS: Dict[str, Dict[str, Any]] = {
         "typical_file_types": ["nortek-aqd", "nortek-ascii"],
     },
     "adcp": {
-        "description": "Acoustic Doppler Current Profiler",
-        "typical_file_types": ["adcp-matlab"],
+        "description": "Acoustic Doppler Current Profiler (lowercase; use 'ADCP' in YAML)",
+        "typical_file_types": ["rdi-raw", "adcp-matlab"],
+    },
+    "ADCP": {
+        "description": "Acoustic Doppler Current Profiler (RDI or similar)",
+        "typical_file_types": ["rdi-raw", "adcp-matlab"],
     },
     "tr1050": {
         "description": "Turner TR-1050 fluorometer (via RBR logger)",
-        "typical_file_types": ["rbr-matlab"],
+        "typical_file_types": ["rbr-matlab", "rbr-hex-oa"],
+    },
+    "seapoint": {
+        "description": "Seapoint turbidity sensor (via RBR logger)",
+        "typical_file_types": ["rbr-rsk", "rbr-dat"],
     },
 }
 
@@ -130,6 +138,8 @@ VALID_FILE_TYPES = {
     "rbr-dat",
     "rbr-matlab",
     "adcp-matlab",
+    "rdi-raw",  # RDI ADCP raw binary; requires mhkit[dolfyn]
+    "rbr-hex-oa",  # internal oceanarray hex reader for TR-1050; use rbr-hex once seasenselib supports it
 }
 
 UNSUPPORTED_FILE_TYPES: Dict[str, str] = {}
@@ -175,17 +185,29 @@ def validate_mooring_yaml(yaml_path: str) -> List[ValidationIssue]:
         if key not in data:
             issues.append(ValidationIssue("ERROR", f"Missing required key: '{key}'"))
 
-    # Validate instrument list (supports both 'clamp' and legacy 'instruments')
+    # Validate instrument list (supports both 'clamp' and legacy 'instruments').
+    # Also validate inline hardware entries that carry instrument data.
     instrument_list = data.get("clamp", data.get("instruments", []))
-    if not instrument_list:
+    inline_list = data.get("inline", [])
+    inline_instruments = [
+        e
+        for e in inline_list
+        if isinstance(e, dict)
+        and "instrument" in e
+        and (e.get("filename") or e.get("skip"))
+    ]
+    combined_list = list(instrument_list) + inline_instruments
+
+    if not combined_list:
         issues.append(
             ValidationIssue(
-                "WARNING", "No instruments found under 'clamp' or 'instruments'"
+                "WARNING",
+                "No instruments found under 'clamp', 'instruments', or 'inline'",
             )
         )
         return issues
 
-    for i, entry in enumerate(instrument_list):
+    for i, entry in enumerate(combined_list):
         if not isinstance(entry, dict):
             continue
 
@@ -205,6 +227,22 @@ def validate_mooring_yaml(yaml_path: str) -> List[ValidationIssue]:
                     f"(e.g. '*') — they will be stripped automatically when constructing output filenames",
                 )
             )
+
+        # Fragile serial parsing for inline instruments with compound serials.
+        # extract_inline_instruments splits on the first comma and uses the first
+        # token as the instrument serial.  Warn so operators can verify the ordering.
+        if entry.get("source") == "inline" or entry in inline_instruments:
+            if "," in serial_str:
+                parts = [p.strip() for p in serial_str.split(",")]
+                issues.append(
+                    ValidationIssue(
+                        "WARNING",
+                        f"{prefix} inline serial='{serial_str}' contains a comma — "
+                        f"the first token '{parts[0]}' will be used as the instrument serial "
+                        f"and '{', '.join(parts[1:])}' stored as beacon_id.  "
+                        f"Confirm the instrument serial comes first.",
+                    )
+                )
 
         if instrument is None:
             issues.append(
@@ -256,7 +294,7 @@ def validate_mooring_yaml(yaml_path: str) -> List[ValidationIssue]:
                 )
             )
 
-        if not filename:
+        if not filename and not entry.get("skip"):
             issues.append(
                 ValidationIssue(
                     "WARNING",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,7 @@ ppigrf  # IGRF magnetic declination (used in stage3 for Nortek BEAM→ENU correc
 ioos_qc
 
 
+# RDI ADCP reader (rdi-raw file type) requires dolfyn via mhkit
+dolfyn  # or: pip install "mhkit[dolfyn]"
+
 # seasenselib is installed separately: pip install -e seasenselib


### PR DESCRIPTION
Adds end-to-end support for RDI WorkHorse ADCP data (75 kHz downward-looking, `rdi-raw` via dolfyn) to the oceanarray processing pipeline.  16 files changed, +2417 / −316 lines.

## Phase 1 — YAML parser (`parameters.py`, `validation.py`)

- `inline` list entries that carry both `instrument` and `filename` fields are now  recognised as instruments and passed through the full processing chain alongside `clamp` entries.
- `serial` field with a comma (e.g. `16430, R01-024`) is split: first token is the primary serial used for filenames/output; remainder stored as `beacon_id`.  The validator emits a WARNING for any inline instrument with a comma-separated serial so the operator can confirm the ordering.
- `hab_bottom` is used as `hab` for downward-looking instruments; `hab_top` for upward.
- Added `rdi-raw` to the set of recognised file types.

## Phase 2 — Stage 1 reader (`stage1.py`)

- `_normalize_rdi_raw`: reads RDI raw file via dolfyn (see `seasenselib` v0.6.0), splits `vel(dir, range, time)` into `east_velocity`, `north_velocity`, `up_velocity`, `error_velocity` with dims `(time, N_BINS)` using the `ADCP_BIN_DIM` constant (never hard-coded as `"N_BINS"`).
- Renames dolfyn variables to the project convention: `amp` → `amplitude`, `corr` → `correlation`, `prcnt_gd` → `percent_good`, `c_sound` → `speed_of_sound`.
- `range` stored as a 1-D coordinate `(N_BINS,)` (height above transducer, metres).
- `pressure` stored faithfully including 97 overflow ensembles; will be flagged in stage 3.
- Global attrs: `coordinate_system = "ENU"`, `orientation` from raw file, `orientation_yaml` from YAML (warns on mismatch), `instrument_magnetic_variation_deg` from RDI config (provenance for the 0.0° setting — declination applied in stage 3).
- Aquadopp `amplitude_beam1/2/3` and `correlation_beam1/2/3` consolidated into 2-D `amplitude(time, beam)` and `correlation(time, beam)` arrays in this same pass.

## Phase 3 — Stage 2 (`stage2.py`, +12 lines)

- Deployment trim and clock-drift correction now propagates correctly through 2-D ADCP variables (`time × N_BINS`) without collapsing to 1-D.

## Phase 4 — Stage 3 (`stage3.py`)

- `seabed_qc`: bins flagged 3/4 when the bin pressure exceeds seabed pressure (from YAML `waterdepth`) at each time step.  Flag 1 = good (above seabed), 3 = suspect (near seabed), 4 = fail (below seabed).
- `percent_good_qc`: bins where mean percent-good across beams < threshold (default 50 %) flagged 3; stored as `percent_good_qc`.
- `error_velocity_qc`: bins where |error velocity| exceeds threshold (default 0.15 m s⁻¹) flagged 3.
- Magnetic declination applied to `east_velocity` / `north_velocity` (same path as Aquadopp) when `magnetic_declination` attr is set.
- `bin_pressure` computed from instrument depth and `range` coordinate.
- QC flag attribute names stored in output for provenance.

## Phase 5 — Stack / grid integration (`mooring_level.py`)

- **Head/bin separation**: ADCP is expanded into a `{serial}_hd` entry (temperature, heading, pitch, roll etc. at transducer depth) plus one `{serial}_b##` entry per valid velocity bin.  Prevents transducer temperature from appearing at every depth level.
- **Seabed bin filtering**: bins where `seabed_qc >= 3` for *every* time step are skipped entirely from N_LEVELS expansion.
- **Grid QC masking**: `seabed_qc`, `percent_good_qc`, `error_velocity_qc` applied as flag ≥ 3 → NaN before vertical interpolation.
- **Serial matching** (`_mooring.py`): `_serials_in_nc` strips `_hd`/`_b##` suffixes so the YAML serial `16430` matches stack/grid entries — ADCP shows Stack ✓ / Grid ✓ in the main mooring report.
- Stack history string specifies "nearest-neighbour in time" / "linear in time"; grid specifies "linear interpolation in pressure".

## Phase 6 — Per-instrument ADCP report (`report/_instrument.py`, `_plots.py`)

- Per-instrument HTML report for ADCP: stacked pcolormesh panels for east/north/up/error velocity, current speed, current direction, and bin pressure.  All on a shared time axis, y-axis = range above transducer (inverted for downward-looking).
- Seabed mask applied before plotting; deepest valid bin determines y-axis extent.
- Rose diagrams masked by `seabed_qc`, `percent_good_qc`, `error_velocity_qc` before binning.
- Colormaps: diverging `Spectral_r` + `BoundaryNorm(bounds, ncolors=256)` for E/N/Up/err; `plasma` for speed; `hsv` for direction (consistent with grid report).
- Dimensions table added before the NetCDF variables section.
- ADCP particle trajectory (Euler-forward from per-bin E/N velocity, coloured by HAB) added to the stack report side-by-side with the Aquadopp trajectory.

## Grid report reorganisation (`report/_grid.py`, `_plots.py`)

- **Hydrography** section: T + S stacked in one compact figure (3.2 in per panel, shared x-axis) — replaces separate T and S panels with HTML headings between them.
- **Velocity** section: E, N, Up stacked in one compact figure with `Spectral_r`; separate symmetric bounds for up velocity.
- **T-S diagram** moved before stratification-derived quantities.
- **Velocity IQR profiles**: 3 panels — speed (2.5/25/50/75/97.5 %), east+north (Okabe-Ito colours, IQR shading), non-NaN count per depth bin.
- **Particle trajectory** from gridded pressure levels (Euler-forward, coloured by pressure).
- **Velocity time series** at depth of maximum mean current speed.
- **Stratification** section: sigma0 stacked panel + N² + isopycnal depth time series (unfiltered zoom + 24 h Tukey filtered) + temperature power spectrum.
- All figures wrapped in `<details open>` for collapsibility.