### PR TITLE
[FEAT] Auto-guess raw filenames + flat-line QC + report improvements

### DIFF
--- a/docs/source/yaml_configuration.rst
+++ b/docs/source/yaml_configuration.rst
@@ -174,13 +174,64 @@ Fields required for processing
        instrument-type column in reports.  See `The instrument field`_ for
        the full list of valid values.
    * - ``filename``
-     - string
+     - string or ``null``
      - Raw data filename, relative to
        ``{raw_dir}/{mooring}/{instrument}/``.
+       **Recommended naming convention**: ``{serial}_recovery.<ext>``
+       (e.g. ``26261_recovery.asc``, ``9415_recovery.dat``).
+       If omitted or set to ``null``, ``oceanarray`` will try to locate the
+       file automatically using the conventions in the table below — if a
+       match is found, processing proceeds; if not, the instrument is skipped
+       with a diagnostic message listing the paths tried.
+
+       .. list-table:: Auto-detected filename conventions
+          :header-rows: 1
+          :widths: 25 30 20 25
+
+          * - ``instrument`` value
+            - Condition
+            - Filename tried
+            - ``file_type``
+          * - ``microcat``
+            - serial < 6000
+            - ``{serial}_recovery.asc``
+            - ``sbe-ascii``
+          * - ``microcat``
+            - serial ≥ 6000
+            - ``{serial}_recovery.hex``
+            - ``sbe-hex``
+          * - ``tr1050``
+            - any
+            - ``{serial}_recovery.hex``
+            - ``rbr-hex``
+          * - ``rbrsolo``, ``rbrduet``, ``seapoint``
+            - any
+            - ``{serial}_recovery.rsk``
+            - ``rbr-rsk``
+          * - ``aquadopp`` / ``nortek``
+            - serial < 400000
+            - ``{serial}_recovery.dat`` (+ ``.hdr``)
+            - ``nortek-ascii``
+          * - ``aquadopp`` / ``nortek``
+            - serial ≥ 400000
+            - not auto-detected — set ``filename`` explicitly
+            - —
+          * - ``ADCP``
+            - any
+            - ``{serial}_{mooring}_recovery.000``
+            - ``rdi-raw``
+
+       A trailing ``*`` in the serial field is stripped before building the
+       filename (e.g. ``serial: 13560*`` → tries ``13560_recovery.asc``).
+       Searched directories (in order):
+       ``{raw_dir}/{mooring}/{instrument}/``, then ``{raw_dir}/{mooring}/``.
+
    * - ``file_type``
      - string
      - Reader type passed to seasenselib.  See
        `Valid file_type values`_ below.
+       Can be omitted when ``filename`` is also omitted — the auto-detection
+       logic sets ``file_type`` to match the discovered file.
    * - ``hab``
      - number
      - Height above bottom in metres.  Used for pressure interpolation,

--- a/oceanarray/cli.py
+++ b/oceanarray/cli.py
@@ -1088,5 +1088,30 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> None:
     """Entry point for the ``oceanarray`` command-line tool."""
     parser = build_parser()
-    args = parser.parse_args()
+    args, _unknown = parser.parse_known_args()
+    if _unknown:
+        _raw_dir_unknowns = []
+        _other_unknowns = []
+        _skip_next = False
+        for _i, _tok in enumerate(_unknown):
+            if _skip_next:
+                _skip_next = False
+                continue
+            if _tok == "--raw-dir":
+                _raw_dir_unknowns.append(_tok)
+                if _i + 1 < len(_unknown) and not _unknown[_i + 1].startswith("--"):
+                    _raw_dir_unknowns.append(_unknown[_i + 1])
+                    _skip_next = True
+            elif _tok.startswith("--raw-dir="):
+                _raw_dir_unknowns.append(_tok)
+            else:
+                _other_unknowns.append(_tok)
+        if _raw_dir_unknowns:
+            print(
+                f"oceanarray: WARNING: --raw-dir is not used by this subcommand "
+                f"and will be ignored ({' '.join(_raw_dir_unknowns)})",
+                file=sys.stderr,
+            )
+        if _other_unknowns:
+            parser.error(f"unrecognized arguments: {' '.join(_other_unknowns)}")
     sys.exit(args.func(args))

--- a/oceanarray/parameters.py
+++ b/oceanarray/parameters.py
@@ -110,6 +110,10 @@ QC_GROSS_RANGE: dict = {
     "east_velocity": {"fail_span": (-5.0, 5.0), "suspect_span": (-3.0, 3.0)},  # m/s
     "north_velocity": {"fail_span": (-5.0, 5.0), "suspect_span": (-3.0, 3.0)},  # m/s
     "up_velocity": {"fail_span": (-1.0, 1.0), "suspect_span": (-0.5, 0.5)},  # m/s
+    # Turbidity: negative values are physically impossible (no lower bound in nature).
+    # Upper bound is generous — coastal resuspension events can reach 1000 NTU.
+    # Override per mooring if the sensor range is known to be tighter.
+    "turbidity": {"fail_span": (0.0, 4000.0), "suspect_span": (0.0, 1000.0)},  # NTU
 }
 
 # ---------------------------------------------------------------------------
@@ -138,6 +142,27 @@ QC_SPIKE: dict = {
     # positives at every burst boundary, and real oceanic events can produce
     # large velocity changes on short time scales.  Add per-instrument via
     # qc_spike: YAML key if needed for a specific deployment.
+}
+
+# ---------------------------------------------------------------------------
+# QARTOD flat-line (stuck-value) test thresholds.
+#
+# Applied to pressure only by default.  A value is considered "stuck" when it
+# does not change by more than ``tolerance`` over a contiguous window.
+#
+# suspect_n : flag SUSPECT when stuck for this many consecutive samples
+# fail_n    : flag FAIL when stuck for this many consecutive samples
+# tolerance : maximum allowed change that is still considered "flat" (default 0)
+#
+# ioos_qc converts suspect_n / fail_n to seconds using the median sample
+# interval at runtime.  Override per mooring via ``qc_flat_line`` YAML key.
+# ---------------------------------------------------------------------------
+QC_FLAT_LINE: dict = {
+    # tolerance must be > 0: ioos_qc flags when range < tolerance over the
+    # window, so tolerance=0 means range < 0 which is never true.
+    # 0.001 dbar is below any real mooring pressure variability and catches
+    # sensors returning the exact same value (e.g. 4959 stuck at 0 dbar).
+    "pressure": {"suspect_n": 3, "fail_n": 10, "tolerance": 0.001},
 }
 
 # ---------------------------------------------------------------------------
@@ -207,9 +232,7 @@ INSTRUMENT_ABBREV = {
 INSTRUMENT_FILE_TYPES: dict = {
     "microcat": ["sbe-cnv", "sbe-ascii", "sbe-hex"],
     "aquadopp": ["nortek-aqd", "nortek-ascii", "nortek-csv"],
-    "tr1050": [
-        "rbr-hex-oa"
-    ],  # RBR TR-1050 thermistor chain; -oa until seasenselib supports it
+    "tr1050": ["rbr-hex"],  # RBR TR-1050 thermistor chain
     "rbrsolo": ["rbr-rsk", "rbr-dat"],  # RBR Solo/Duet single-channel T or T+P
     "seapoint": ["rbr-rsk", "rbr-dat"],  # Seapoint turbidity sensor via RBR logger
     "ADCP": [

--- a/oceanarray/parameters.py
+++ b/oceanarray/parameters.py
@@ -154,8 +154,10 @@ QC_SPIKE: dict = {
 # fail_n    : flag FAIL when stuck for this many consecutive samples
 # tolerance : maximum allowed change that is still considered "flat" (default 0)
 #
-# ioos_qc converts suspect_n / fail_n to seconds using the median sample
-# interval at runtime.  Override per mooring via ``qc_flat_line`` YAML key.
+# In ``_apply_qc_tests`` (stage3.py), ``suspect_n`` / ``fail_n`` are multiplied
+# by the median inter-sample interval (seconds) before being passed to
+# ``ioos_qc.qartod.flat_line_test``, which takes its thresholds in seconds.
+# Override per mooring via ``qc_flat_line`` YAML key.
 # ---------------------------------------------------------------------------
 QC_FLAT_LINE: dict = {
     # tolerance must be > 0: ioos_qc flags when range < tolerance over the

--- a/oceanarray/report/_html_helpers.py
+++ b/oceanarray/report/_html_helpers.py
@@ -319,17 +319,18 @@ def _read_nc_metadata(nc_path: Path) -> Dict[str, Any]:
 def _read_qc_thresholds(nc_path: Path) -> List[Dict[str, Any]]:
     """Return the QC thresholds actually applied, as stored in the stage3 NC file.
 
-    Reads three types of threshold from the ``{var}_qc`` variable attrs and from
+    Reads four types of threshold from the ``{var}_qc`` variable attrs and from
     dataset-level attrs:
 
     * ``qc_gross_range_*`` — gross-range fail/suspect min/max
     * ``qc_spike_*`` — QARTOD spike-test suspect/fail thresholds
+    * ``qc_flat_line_*`` — QARTOD flat-line (stuck-value) suspect/fail sample counts
     * ``tilt_suspect_threshold`` / ``tilt_fail_threshold`` — Aquadopp tilt QC
 
     Returns one dict per (variable, test) combination, with the actual values
     stored in the file — regardless of whether they came from package defaults,
-    mooring-level YAML, or per-instrument overrides.  Spike rows only appear
-    for stage3 files produced after the spike-threshold-storage fix (2026-07-24).
+    mooring-level YAML, or per-instrument overrides.  Spike and flat-line rows only
+    appear for stage3 files produced after 2026-07-24.
     """
     try:
         import xarray as xr
@@ -369,6 +370,21 @@ def _read_qc_thresholds(nc_path: Path) -> List[Dict[str, Any]]:
                         "test": "spike",
                         "suspect": f"|Δ| > {sp_susp}" if sp_susp is not None else "—",
                         "fail": f"|Δ| > {sp_fail}" if sp_fail is not None else "—",
+                    }
+                )
+            fl_susp = attrs.get("qc_flat_line_suspect_count")
+            fl_fail = attrs.get("qc_flat_line_fail_count")
+            if fl_susp is not None or fl_fail is not None:
+                rows.append(
+                    {
+                        "var": base,
+                        "test": "flat-line",
+                        "suspect": (
+                            f"stuck ≥ {fl_susp} samples" if fl_susp is not None else "—"
+                        ),
+                        "fail": (
+                            f"stuck ≥ {fl_fail} samples" if fl_fail is not None else "—"
+                        ),
                     }
                 )
         # Tilt QC (Aquadopp): stored at dataset level
@@ -438,7 +454,32 @@ _PRIMARY_VARS = [
 def _read_instrument_info(
     proc_dir: Path, instr_type: str, mooring: str, serial: str
 ) -> Dict[str, Any]:
-    """Read time stats and variable list from the best available processed NC."""
+    """Read record statistics from the best available processed NetCDF file.
+
+    Prefers stage-3 output (QC and coordinate-transformed); falls back to
+    stage-2 (deployment-trimmed, clock-corrected) if stage-3 is absent.
+    Stage-1 (raw) files are never read here.
+
+    Returns a dict with keys:
+
+    * ``t_start`` / ``t_end``: first and last timestamp (ISO-8601 string,
+      truncated to the minute).
+    * ``t_end_raw``: last timestamp as ``numpy.datetime64`` (for arithmetic).
+    * ``n_records``: total number of time steps.
+    * ``dt_s``: 90th-percentile inter-sample interval in seconds (robust
+      against occasional data gaps).
+    * ``shorthands``: list of ``(label, bool)`` pairs indicating which of
+      T / C / P / U / V variables are present.
+    * ``pressure_interpolated``: True if any ``pressure_qc == 8``, meaning
+      pressure was filled by interpolation from neighbouring instruments.
+    * ``p_min`` / ``p_max``: minimum and maximum pressure (dbar) over the
+      trimmed record, excluding non-positive values (stuck-at-zero sensors,
+      pre-deployment bench readings) and QC-bad/missing samples where stage-3
+      flags are available.  ``None`` if no valid pressure data exist.
+
+    Returns ``{}`` if no processed file is found, or ``{"error": str}`` if
+    the file cannot be opened.
+    """
     base = proc_dir / instr_type / f"{mooring}_{serial}"
     nc_path = None
     for suffix in ("_stage3.nc", "_stage2.nc"):
@@ -480,6 +521,29 @@ def _read_instrument_info(
             except Exception:  # noqa: BLE001
                 pass
 
+        # Min/max pressure over the trimmed record (stage2/stage3).
+        # Exclude non-positive values (negative or stuck-at-zero sensors are
+        # non-physical for a deployed mooring) and QC-bad/missing flag values.
+        p_min: Optional[float] = None
+        p_max: Optional[float] = None
+        if "pressure" in ds.data_vars:
+            try:
+                pvals = ds["pressure"].values.astype(float)
+                # Mask QC=4 (bad) and QC=9 (missing) if stage3 QC is available
+                if "pressure_qc" in ds.data_vars:
+                    qc = ds["pressure_qc"].values.astype(int)
+                    pvals = np.where(np.isin(qc, [4, 9]), np.nan, pvals)
+                # Exclude non-positive values (pre-deployment bench / stuck sensor)
+                pvals = np.where(pvals > 0, pvals, np.nan)
+                _pmin = float(np.nanmin(pvals))
+                _pmax = float(np.nanmax(pvals))
+                if np.isfinite(_pmin):
+                    p_min = _pmin
+                if np.isfinite(_pmax):
+                    p_max = _pmax
+            except Exception:  # noqa: BLE001
+                pass
+
         ds.close()
 
         shorthands = [(label, name in vars_present) for name, label in _PRIMARY_VARS]
@@ -493,6 +557,8 @@ def _read_instrument_info(
             "shorthands": shorthands,
             "has_beam": has_beam,
             "pressure_interpolated": pressure_interpolated,
+            "p_min": p_min,
+            "p_max": p_max,
         }
     except Exception as exc:
         return {"error": str(exc)[:80]}

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -1091,8 +1091,9 @@ class MooringReport:
                         yaml_interval_s is not None
                         and nc_info
                         and not nc_info.get("error")
+                        and nc_info.get("dt_s") is not None  # key present
                         and nc_info.get("dt_s") == nc_info.get("dt_s")  # False for NaN
-                        and abs(float(yaml_interval_s) - float(nc_info.get("dt_s", 0)))
+                        and abs(float(yaml_interval_s) - float(nc_info["dt_s"]))
                         > max(5.0, float(yaml_interval_s) * 0.1)
                     ),
                     "stopped_early": stopped_early,

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -321,8 +321,8 @@ _HTML_TEMPLATE = """\
       <th>First sample</th>
       <th>Last sample</th>
       <th>N records</th>
-      <th>YAML&nbsp;Δt</th>
-      <th>Obs&nbsp;Δt&nbsp;(p90)</th>
+      <th title="Observed p90 sample interval (s); * = differs from YAML value by &gt;10%">Δt&nbsp;(s)</th>
+      <th title="Pressure range from stage-2/3 trimmed record, excluding non-positive values">P range (dbar)</th>
       <th style="text-align:center">T</th>
       <th style="text-align:center">C</th>
       <th style="text-align:center">P</th>
@@ -345,16 +345,20 @@ _HTML_TEMPLATE = """\
         <td>{{ instr.nc.t_end }}</td>
         <td class="num">{{ "{:,}".format(instr.nc.n_records) }}</td>
         <td class="num">
-          {% if instr.yaml_interval_s is not none %}
-            {{ instr.yaml_interval_s }}
+          {% set dt = instr.nc.dt_s %}
+          {% if dt == dt %}{# NaN check: NaN != NaN #}
+            {{ "%.0f"|format(dt) }}{% if instr.dt_mismatch %}<span title="YAML: {{ instr.yaml_interval_s }} s" style="color:#e67e22;font-weight:bold"> *</span>{% endif %}
           {% else %}
             <span class="none-note">—</span>
           {% endif %}
         </td>
         <td class="num">
-          {% set dt = instr.nc.dt_s %}
-          {% if dt == dt %}{# NaN check: NaN != NaN #}
-            {{ "%.0f"|format(dt) }}
+          {% if instr.nc.p_min is not none and instr.nc.p_max is not none %}
+            {% if instr.nc.get("pressure_interpolated") %}
+              <em title="pressure interpolated">({{ "%.0f"|format(instr.nc.p_min) }}, {{ "%.0f"|format(instr.nc.p_max) }})</em>
+            {% else %}
+              ({{ "%.0f"|format(instr.nc.p_min) }}, {{ "%.0f"|format(instr.nc.p_max) }})
+            {% endif %}
           {% else %}
             <span class="none-note">—</span>
           {% endif %}
@@ -377,6 +381,26 @@ _HTML_TEMPLATE = """\
     {% endfor %}
   </tbody>
 </table>
+
+{% set dt_mismatches = instruments | selectattr("dt_mismatch") | list %}
+{% if dt_mismatches %}
+<p style="font-size:0.82rem;color:#555;margin-top:0.4rem;">
+  <span style="color:#e67e22;font-weight:bold">*</span> Δt mismatch (YAML vs observed p90):
+  {% for instr in dt_mismatches %}
+    <br>&nbsp;&nbsp;<span style="font-family:monospace">{{ instr.serial }}</span>:
+    YAML gives Δt of {{ instr.yaml_interval_s }}&thinsp;s;
+    stage file shows Δt of {{ "%.0f"|format(instr.nc.dt_s) }}&thinsp;s.
+  {% endfor %}
+</p>
+{% endif %}
+
+{% if grid_p_start is not none and grid_p_end is not none %}
+<p style="font-size:0.82rem;color:#555;margin-top:0.8rem;">
+  Recommended pressure range for <code>oceanarray grid</code>, derived from the
+  min/max pressure across all instruments (rounded outward to the nearest 20&thinsp;dbar):
+</p>
+<pre style="background:#f4f4f4;border:1px solid #ddd;border-radius:4px;padding:0.5em 0.8em;font-size:0.85rem;display:inline-block;user-select:all;cursor:text">--p-start {{ grid_p_start }} --p-end {{ grid_p_end }}</pre>
+{% endif %}
 
 <!-- ══════════════════════════════════════ 3.5 DEPLOYMENT TIMING ══ -->
 <h2 id="timing">3.5 &mdash; Deployment timing</h2>
@@ -999,10 +1023,40 @@ class MooringReport:
                     else (False, "file missing")
                 )
             else:
-                raw_path_str = ""
-                raw_exists = False
-                readable = False
-                readable_note = "no filename in YAML"
+                # Try auto-guessing filename from standard naming conventions
+                # (same logic as Stage1Processor._guess_instrument_filename).
+                # Skip guessing for instruments marked skip:true — they won't
+                # be processed and there's nothing useful to report.
+                _guessed = None
+                if self._raw_dir is not None and not entry.get("skip"):
+                    from oceanarray.stage1 import Stage1Processor as _S1
+
+                    _raw_mooring = self._raw_dir / mooring_name
+                    _guessed = _S1._guess_instrument_filename(  # noqa: SLF001
+                        entry, mooring_name, _raw_mooring, None
+                    )
+                if _guessed is not None:
+                    _gfname, _gftype, _ghdr = _guessed
+                    file_type = file_type or _gftype
+                    _gpath = self._raw_dir / mooring_name / instr_type / _gfname
+                    if not _gpath.exists():
+                        _gpath = self._raw_dir / mooring_name / _gfname
+                    raw_path_str = (
+                        str(_gpath.relative_to(self._raw_dir))
+                        if _gpath.exists()
+                        else f"(auto) {_gfname}"
+                    )
+                    raw_exists = _gpath.exists()
+                    readable, readable_note = (
+                        _check_readable(_gpath, file_type)
+                        if raw_exists
+                        else (False, "auto-guessed file not found")
+                    )
+                else:
+                    raw_path_str = ""
+                    raw_exists = False
+                    readable = False
+                    readable_note = "no filename in YAML"
 
             nc_info = _read_instrument_info(proc_dir, instr_type, mooring_name, serial)
 
@@ -1033,6 +1087,14 @@ class MooringReport:
                     "readable": readable,
                     "readable_note": readable_note,
                     "yaml_interval_s": yaml_interval_s,
+                    "dt_mismatch": bool(
+                        yaml_interval_s is not None
+                        and nc_info
+                        and not nc_info.get("error")
+                        and nc_info.get("dt_s") == nc_info.get("dt_s")  # False for NaN
+                        and abs(float(yaml_interval_s) - float(nc_info.get("dt_s", 0)))
+                        > max(5.0, float(yaml_interval_s) * 0.1)
+                    ),
                     "stopped_early": stopped_early,
                     "skipped": bool(entry.get("skip")),
                     "skip_reason": entry.get("skip_reason", ""),
@@ -1060,6 +1122,33 @@ class MooringReport:
             )
 
         instruments.sort(key=lambda x: x["hab"])
+
+        # Compute recommended --p-start / --p-end for `oceanarray grid`.
+        # Collect finite min/max pressure values from instruments that have real
+        # pressure data (exclude stuck-at-zero sensors: p_max must be > 20 dbar).
+        _all_pmin: List[float] = []
+        _all_pmax: List[float] = []
+        for _instr in instruments:
+            _nc = _instr.get("nc") or {}
+            _pmin = _nc.get("p_min")
+            _pmax = _nc.get("p_max")
+            if (
+                _pmin is not None
+                and _pmax is not None
+                and np.isfinite(_pmin)
+                and np.isfinite(_pmax)
+                and _pmax > 20.0  # skip stuck-at-zero sensors
+            ):
+                _all_pmin.append(_pmin)
+                _all_pmax.append(_pmax)
+
+        grid_p_start: Optional[int] = None
+        grid_p_end: Optional[int] = None
+        if _all_pmin and _all_pmax:
+            import math
+
+            grid_p_start = int(math.floor(min(_all_pmin) / 20.0) * 20)
+            grid_p_end = int(math.ceil(max(_all_pmax) / 20.0) * 20)
 
         # Compute recommended YAML deployment/recovery times from all instruments.
         # Start: latest suggested start UTC (most conservative — all instruments
@@ -1167,6 +1256,8 @@ class MooringReport:
             "yaml_recover_time": (
                 recover_dt.strftime("%Y-%m-%dT%H:%M") if recover_dt else None
             ),
+            "grid_p_start": grid_p_start,
+            "grid_p_end": grid_p_end,
             "stack_exists": stack_exists,
             "grid_exists": grid_exists,
             "any_clock_correction": any_clock,

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -1024,12 +1024,12 @@ class MooringReport:
                 )
             else:
                 # Try auto-guessing filename from standard naming conventions
-                # (same logic as Stage1Processor._guess_instrument_filename).
+                # (same logic as MooringProcessor._guess_instrument_filename).
                 # Skip guessing for instruments marked skip:true — they won't
                 # be processed and there's nothing useful to report.
                 _guessed = None
                 if self._raw_dir is not None and not entry.get("skip"):
-                    from oceanarray.stage1 import Stage1Processor as _S1
+                    from oceanarray.stage1 import MooringProcessor as _S1
 
                     _raw_mooring = self._raw_dir / mooring_name
                     _guessed = _S1._guess_instrument_filename(  # noqa: SLF001

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -178,12 +178,16 @@ _CANONICAL_PANELS: List[Tuple] = [
     ("roll", "Roll [°]", "#8B4513", False),
     ("heading", "Heading [°]", "tab:gray", False),
     ("speed_of_sound", "Sound speed [m/s]", "tab:olive", False),
-    ("turbidity", "Turbidity [NTU]", "tab:brown", False),
+    ("turbidity", "Turbidity (NTU)", "tab:brown", False),
     ("battery_voltage", "Battery [V]", "tab:pink", False),
 ]
 
 _COMPACT_PANEL_VARS: frozenset = frozenset({"battery_voltage", "speed_of_sound"})
 _COMPACT_PANEL_HEIGHT: float = 1.5
+
+# Variables rendered with a log₁₀ y-axis.  Non-positive values are masked to
+# NaN before plotting so matplotlib's log scale does not error or clip to zero.
+_LOG_SCALE_VARS: frozenset = frozenset({"turbidity"})
 
 
 def _instrument_panels(
@@ -318,6 +322,9 @@ def _build_fig_from_ds(
             continue
 
         data = ds[vname].values.astype(float)
+        # Mask non-positive values before plotting on a log scale
+        if vname in _LOG_SCALE_VARS:
+            data = np.where(data > 0, data, np.nan)
         ax.plot(time, data, color=color, linewidth=0.6, zorder=1)
         if "velocity" in vname and not invert:
             ax.axhline(0, color="k", linewidth=0.4, linestyle="--", zorder=0)
@@ -342,7 +349,9 @@ def _build_fig_from_ds(
             )
             ax.legend(loc="upper right", framealpha=0.8)
         ax.set_ylabel(label)
-        if invert:
+        if vname in _LOG_SCALE_VARS:
+            ax.set_yscale("log")
+        elif invert:
             vmin, vmax = float(np.nanmin(data)), float(np.nanmax(data))
             pad = max((vmax - vmin) * 0.1, 0.5)
             ax.set_ylim(vmax + pad, vmin - pad)
@@ -553,6 +562,9 @@ def _make_windows_fig(
                     return
 
                 data = ds[vname].values.astype(float)
+                # Mask non-positive values before plotting on a log scale
+                if vname in _LOG_SCALE_VARS:
+                    data = np.where(data > 0, data, np.nan)
                 t, d = time[mask], data[mask]
                 if len(t) < 2:
                     ax.set_visible(False)
@@ -566,6 +578,8 @@ def _make_windows_fig(
                         _suspect_t, color="tab:orange", lw=0.9, ls="--", zorder=2
                     )
                     ax.axhline(_fail_t, color="tab:red", lw=0.9, ls="--", zorder=2)
+                if vname in _LOG_SCALE_VARS:
+                    ax.set_yscale("log")
                 # ylim for inverted variables is set from the outer loop using the
                 # combined range of both panels, so we do not set it here.
                 if show_qc and f"{vname}_qc" in ds.data_vars:
@@ -1723,7 +1737,11 @@ def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
         da = ds[var]
         data = da.transpose("pressure", "time").values
         units = da.attrs.get("units", "")
-        label = da.attrs.get("long_name", var)
+        long_name = da.attrs.get("long_name", var)
+        # Use the variable name (tidied) as the panel title — long_name often
+        # carries the full CF phrase "sea water temperature" which is verbose
+        # for a plot heading.  The colorbar label keeps the full long_name.
+        title = var.replace("_", " ").capitalize()
         _vmin = float(np.nanpercentile(data, P.COLORBAR_PLOW))
         _vmax = float(np.nanpercentile(data, P.COLORBAR_PHIGH))
         bounds = _nice_colorbar_bounds(_vmin, _vmax, n=20)
@@ -1732,10 +1750,10 @@ def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
             time, pressure, data, shading="nearest", cmap=cmap, norm=norm
         )
         cb = fig.colorbar(pc, ax=ax, pad=0.02, ticks=bounds[::2])
-        cb.set_label(f"{label} ({units})" if units else label)
+        cb.set_label(f"{long_name} ({units})" if units else long_name)
         ax.invert_yaxis()
         ax.set_ylabel("Pressure (dbar)")
-        ax.set_title(label, loc="left")
+        ax.set_title(title, loc="left")
         ax.grid(True, linestyle="--", linewidth=0.3, alpha=0.4)
 
     axes[-1, 0].xaxis.set_major_locator(locator)
@@ -2760,29 +2778,29 @@ def _make_grid_trajectory_b64(ds: "xr.Dataset") -> Optional[str]:
 def _make_grid_timeseries_b64(ds: "xr.Dataset") -> Optional[str]:
     """Velocity time series at the depth of maximum time-mean current speed.
 
-    Three stacked panels (shared time axis, all in m s⁻¹):
+    Two stacked panels (shared time axis):
 
-    - **Speed** (black): ``sqrt(east² + north²)``; always ≥ 0.
-    - **East velocity** (Okabe-Ito blue #0072B2): positive = eastward flow (geographic
-      ENU, after magnetic declination correction).
-    - **North velocity** (Okabe-Ito orange #E69F00): positive = flow toward True North.
+    - **Speed** (black, m s⁻¹): ``sqrt(east² + north²)``; always ≥ 0.
+    - **East and North velocity** (same axes, m s⁻¹): east in Okabe-Ito blue
+      (#0072B2), north in Okabe-Ito orange (#E69F00).  Both signed components
+      are plotted together so the relationship between along- and cross-stream
+      flow is immediately visible.
 
-    The target pressure level is chosen automatically as the level with the highest
-    time-mean current speed.  This heuristic selects the most energetic depth in the
-    record and is not guaranteed to be oceanographically meaningful.  The selected
-    pressure is annotated in the figure title.
+    The target pressure level is chosen automatically as the level with the
+    highest time-mean current speed and at least 70 % non-NaN coverage.  The
+    selected pressure is annotated in the figure title.
 
     Parameters
     ----------
     ds : xr.Dataset
-        Gridded dataset with dimensions ``(time, pressure)`` containing at minimum
-        ``east_velocity`` and ``north_velocity`` in m s⁻¹.
+        Gridded dataset with dimensions ``(time, pressure)`` containing at
+        minimum ``east_velocity`` and ``north_velocity`` in m s⁻¹.
 
     Returns
     -------
     str or None
-        Base64-encoded PNG for HTML embedding, or None if horizontal velocity data are
-        absent.
+        Base64-encoded PNG for HTML embedding, or None if horizontal velocity
+        data are absent.
 
     """
     import warnings
@@ -2805,7 +2823,16 @@ def _make_grid_timeseries_b64(ds: "xr.Dataset") -> Optional[str]:
         mean_spd = np.nanmean(spd, axis=0)  # (pressure,)
     if not np.any(np.isfinite(mean_spd)):
         return None
-    k_max = int(np.nanargmax(mean_spd))
+
+    # Only consider levels with at least 70 % non-NaN values so that a
+    # depth covered only briefly does not win on spuriously high mean speed.
+    n_time = spd.shape[0]
+    coverage = np.sum(np.isfinite(spd), axis=0) / n_time  # fraction per level
+    eligible = coverage >= 0.70
+    if not np.any(eligible):
+        eligible = np.ones(len(pressure), dtype=bool)  # fall back: no restriction
+    candidate_spd = np.where(eligible, mean_spd, np.nan)
+    k_max = int(np.nanargmax(candidate_spd))
     p_target = float(pressure[k_max])
 
     spd_ts = spd[:, k_max]
@@ -2813,20 +2840,21 @@ def _make_grid_timeseries_b64(ds: "xr.Dataset") -> Optional[str]:
     north_ts = north[:, k_max]
 
     plt.style.use(str(P.MPLSTYLE))
-    fig, axs = plt.subplots(3, 1, figsize=(10, 6), sharex=True)
+    fig, axs = plt.subplots(2, 1, figsize=(10, 5), sharex=True)
     _C_EAST = "#0072B2"
     _C_NORTH = "#E69F00"
 
+    # Panel 0: speed
     axs[0].plot(time_vals, spd_ts, color="k", linewidth=0.8)
     axs[0].set_ylabel("Speed (m s⁻¹)")
+    axs[0].set_ylim(bottom=0)
 
+    # Panel 1: east and north on the same axes
     axs[1].plot(time_vals, east_ts, color=_C_EAST, linewidth=0.8, label="East")
-    axs[1].axhline(0, color="k", linewidth=0.4, linestyle="--", alpha=0.4)
-    axs[1].set_ylabel("East vel. (m s⁻¹)")
-
-    axs[2].plot(time_vals, north_ts, color=_C_NORTH, linewidth=0.8, label="North")
-    axs[2].axhline(0, color="k", linewidth=0.4, linestyle="--", alpha=0.4)
-    axs[2].set_ylabel("North vel. (m s⁻¹)")
+    axs[1].plot(time_vals, north_ts, color=_C_NORTH, linewidth=0.8, label="North")
+    axs[1].axhline(0, color="k", linewidth=0.4, linestyle="--", alpha=0.4, zorder=0)
+    axs[1].set_ylabel("Velocity (m s⁻¹)")
+    axs[1].legend(loc="upper right", framealpha=0.8)
 
     for ax in axs:
         ax.grid(True, linestyle="--", linewidth=0.4, alpha=0.4)

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -185,9 +185,9 @@ _CANONICAL_PANELS: List[Tuple] = [
 _COMPACT_PANEL_VARS: frozenset = frozenset({"battery_voltage", "speed_of_sound"})
 _COMPACT_PANEL_HEIGHT: float = 1.5
 
-# Variables rendered with a log₁₀ y-axis.  Non-positive values are masked to
-# NaN before plotting so matplotlib's log scale does not error or clip to zero.
-_LOG_SCALE_VARS: frozenset = frozenset({"turbidity"})
+# Variables plotted with both a line and individual dots so that sparse or
+# near-zero samples (e.g. turbidity = 0 NTU between events) are visible.
+_DOT_LINE_VARS: frozenset = frozenset({"turbidity"})
 
 
 def _instrument_panels(
@@ -322,10 +322,9 @@ def _build_fig_from_ds(
             continue
 
         data = ds[vname].values.astype(float)
-        # Mask non-positive values before plotting on a log scale
-        if vname in _LOG_SCALE_VARS:
-            data = np.where(data > 0, data, np.nan)
         ax.plot(time, data, color=color, linewidth=0.6, zorder=1)
+        if vname in _DOT_LINE_VARS:
+            ax.plot(time, data, ".", color=color, markersize=2, linewidth=0, zorder=2)
         if "velocity" in vname and not invert:
             ax.axhline(0, color="k", linewidth=0.4, linestyle="--", zorder=0)
         if vname == "tilt":
@@ -349,9 +348,7 @@ def _build_fig_from_ds(
             )
             ax.legend(loc="upper right", framealpha=0.8)
         ax.set_ylabel(label)
-        if vname in _LOG_SCALE_VARS:
-            ax.set_yscale("log")
-        elif invert:
+        if invert:
             vmin, vmax = float(np.nanmin(data)), float(np.nanmax(data))
             pad = max((vmax - vmin) * 0.1, 0.5)
             ax.set_ylim(vmax + pad, vmin - pad)
@@ -562,9 +559,6 @@ def _make_windows_fig(
                     return
 
                 data = ds[vname].values.astype(float)
-                # Mask non-positive values before plotting on a log scale
-                if vname in _LOG_SCALE_VARS:
-                    data = np.where(data > 0, data, np.nan)
                 t, d = time[mask], data[mask]
                 if len(t) < 2:
                     ax.set_visible(False)
@@ -578,8 +572,6 @@ def _make_windows_fig(
                         _suspect_t, color="tab:orange", lw=0.9, ls="--", zorder=2
                     )
                     ax.axhline(_fail_t, color="tab:red", lw=0.9, ls="--", zorder=2)
-                if vname in _LOG_SCALE_VARS:
-                    ax.set_yscale("log")
                 # ylim for inverted variables is set from the outer loop using the
                 # combined range of both panels, so we do not set it here.
                 if show_qc and f"{vname}_qc" in ds.data_vars:

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -197,6 +197,12 @@ _STACK_HTML_TEMPLATE = """\
 <img class="fig" src="data:image/png;base64,{{ fig_up_vel_b64 }}" alt="Vertical velocity time series">
 {% endif %}
 
+{% if fig_turbidity_b64 %}
+<h2 id="turbidity">Turbidity</h2>
+<p class="note">One line per instrument with turbidity data; QC flags &ge; 3 masked. Dots overlaid to reveal individual samples near zero. Units from file attrs (verify: NTU, FTU, or V depending on sensor).</p>
+<img class="fig" src="data:image/png;base64,{{ fig_turbidity_b64 }}" alt="Turbidity time series">
+{% endif %}
+
 {% if fig_aquadopp_tilt_b64 %}
 <h2 id="tilt">Aquadopp tilt (|pitch| / |roll| / pressure estimate)</h2>
 <p class="note">
@@ -621,6 +627,7 @@ def generate_stack_page(
             invert: bool = False,
             hlines: Optional[List[tuple]] = None,
             exclude_types: Optional[set] = None,
+            dot_overlay: bool = False,
         ) -> Optional[str]:
             if varname not in ds.data_vars:
                 return None
@@ -641,6 +648,10 @@ def generate_stack_page(
                     continue
                 plotted = True
                 ax.plot(time_ds, y, color=color, lw=0.7, alpha=0.85, label=f"{serial}")
+                if dot_overlay:
+                    ax.plot(
+                        time_ds, y, ".", color=color, markersize=2, linewidth=0, alpha=0.85
+                    )
             if not plotted:
                 plt.close(fig)
                 return None
@@ -707,6 +718,15 @@ def generate_stack_page(
         fig_up_vel_b64 = (
             _ts_fig("up_velocity", "W — Up velocity (m/s)")
             if "up_velocity" in ds
+            else None
+        )
+        fig_turbidity_b64 = (
+            _ts_fig(
+                "turbidity",
+                f"Turbidity ({ds['turbidity'].attrs.get('units', 'NTU')})",
+                dot_overlay=True,
+            )
+            if "turbidity" in ds
             else None
         )
 
@@ -839,6 +859,7 @@ def generate_stack_page(
             fig_east_vel_b64=fig_east_vel_b64,
             fig_north_vel_b64=fig_north_vel_b64,
             fig_up_vel_b64=fig_up_vel_b64,
+            fig_turbidity_b64=fig_turbidity_b64,
             fig_rose_grid_b64=fig_rose_grid_b64,
             rose_img_width=rose_img_width,
             rose_declination_note=rose_declination_note,

--- a/oceanarray/stage1.py
+++ b/oceanarray/stage1.py
@@ -198,7 +198,8 @@ class MooringProcessor:
         "rbr-rsk",
         "rbr-matlab-legacy",
         "rbr-dat",
-        "rbr-hex-oa",  # internal oceanarray hex reader for TR-1050; use rbr-hex once seasenselib supports it
+        "rbr-hex",
+        "rbr-hex-oa",  # legacy internal reader — use rbr-hex instead
         "sbe-hex",
         "rdi-raw",  # RDI ADCP raw binary (requires mhkit[dolfyn])
     }
@@ -1251,6 +1252,168 @@ class MooringProcessor:
             "quantize": 3,
         }
 
+    @staticmethod
+    def _guess_instrument_filename(
+        instrument_config: Dict[str, Any],
+        mooring_name: str,
+        raw_mooring_dir: Optional[Path],
+        input_dir: Optional[Path],
+        log_fn: Optional[Any] = None,
+    ) -> Optional[tuple]:
+        """Try standard recovery-file naming conventions to locate a raw data file.
+
+        Used when ``filename`` is absent or ``null`` in the mooring YAML.
+        Searches ``{raw_mooring_dir}/{instrument}/`` then ``{raw_mooring_dir}/``.
+
+        Returns ``(filename, file_type, header_filename_or_None)`` when a
+        candidate is found on disk, or ``None`` if no match is found (in which
+        case a diagnostic message listing the paths tried is emitted via
+        ``log_fn``).
+
+        Naming conventions applied (all use the ``{serial}_recovery.<ext>``
+        pattern except ADCP):
+
+        * ``microcat`` serial < 6000  → ``.asc`` / ``sbe-ascii`` (older SBE 37)
+        * ``microcat`` serial ≥ 6000  → ``.hex`` / ``sbe-hex`` (newer SBE 37)
+        * ``rbrsolo`` / ``rbrduet`` / ``seapoint`` → ``.rsk`` / ``rbr-rsk``
+        * ``aquadopp`` / ``nortek`` serial < 400000 → ``.dat`` / ``nortek-ascii``
+          + ``.hdr`` header file.  ``nortek`` is accepted but deprecated; a
+          warning is logged recommending ``aquadopp`` instead.
+        * ``aquadopp`` / ``nortek`` serial ≥ 400000 → globs for
+          ``converted_raw/A{serial}*/Average Velocity DF3.csv`` under the
+          instrument directory, returns ``nortek-csv`` with the corresponding
+          ``String Data.csv`` as the header path.
+        * ``ADCP`` → tries ``{serial}_{mooring_name}_recovery.000`` then
+          ``{serial}_{mooring_prefix}_recovery.000`` / ``rdi-raw``
+
+        A trailing ``*`` or other non-alphanumeric annotation in the serial
+        field is stripped before building the candidate filename.
+        """
+        instr_type = str(instrument_config.get("instrument", "")).lower()
+        raw_serial = str(instrument_config.get("serial", "")).split(",")[0].strip()
+        if not raw_serial or raw_serial == "unknown":
+            return None
+        # Strip illegal filename chars (e.g. '*' used as a YAML annotation marker)
+        import re as _re
+
+        raw_serial = _re.sub(r"[^\w\-]", "", raw_serial)
+
+        candidates: list = []  # list of (filename, file_type, header_or_None)
+
+        if instr_type == "microcat":
+            serial_int = int(raw_serial) if raw_serial.isdigit() else None
+            if serial_int is not None and serial_int < 6000:
+                candidates.append((f"{raw_serial}_recovery.asc", "sbe-ascii", None))
+            else:
+                candidates.append((f"{raw_serial}_recovery.hex", "sbe-hex", None))
+
+        elif instr_type in ("rbrsolo", "rbrduet", "seapoint"):
+            candidates.append((f"{raw_serial}_recovery.rsk", "rbr-rsk", None))
+
+        elif instr_type in ("aquadopp", "nortek"):
+            if instr_type == "nortek" and log_fn:
+                log_fn(
+                    f"AUTO-FILENAME: instrument type 'nortek' is deprecated — "
+                    f"use 'aquadopp' in the YAML for serial {raw_serial}"
+                )
+            serial_int = int(raw_serial) if raw_serial.isdigit() else None
+            if serial_int is not None and serial_int >= 400000:
+                # 400### series: data lives under converted_raw/A{serial}*/
+                # The full internal serial suffix varies, so we use glob.
+                _search_400: list = []
+                if raw_mooring_dir is not None:
+                    _search_400 += [raw_mooring_dir / "aquadopp", raw_mooring_dir]
+                if input_dir is not None:
+                    _search_400 += [
+                        input_dir / "aquadopp" / mooring_name,
+                        input_dir,
+                    ]
+                _tried_400: list = []
+                for _root in _search_400:
+                    _conv = _root / "converted_raw"
+                    _tried_400.append(str(_conv / f"A{raw_serial}*" / "Average Velocity DF3.csv"))
+                    if not _conv.is_dir():
+                        continue
+                    for _sub in sorted(_conv.glob(f"A{raw_serial}*")):
+                        if not _sub.is_dir():
+                            continue
+                        for _csv in ("Average Velocity DF3.csv", "String Data.csv"):
+                            _csv_path = _sub / _csv
+                            if _csv_path.exists():
+                                _hdr = _sub / "String Data.csv"
+                                _hdr_rel = (
+                                    str(_hdr.relative_to(_root))
+                                    if _hdr.exists()
+                                    else None
+                                )
+                                return (
+                                    str(_csv_path.relative_to(_root)),
+                                    "nortek-csv",
+                                    _hdr_rel,
+                                )
+                if log_fn:
+                    log_fn(
+                        f"AUTO-FILENAME: no converted_raw/A{raw_serial}*/ found for "
+                        f"aquadopp {raw_serial} — tried:\n  "
+                        + "\n  ".join(_tried_400)
+                    )
+                return None
+            candidates.append(
+                (
+                    f"{raw_serial}_recovery.dat",
+                    "nortek-ascii",
+                    f"{raw_serial}_recovery.hdr",
+                )
+            )
+
+        elif instr_type == "tr1050":
+            candidates.append((f"{raw_serial}_recovery.hex", "rbr-hex", None))
+
+        elif instr_type == "adcp":
+            # Try full mooring name first, then the mooring prefix (before first '_')
+            # since either naming convention may be in use.
+            candidates.append(
+                (f"{raw_serial}_{mooring_name}_recovery.000", "rdi-raw", None)
+            )
+            _pfx = mooring_name.split("_")[0]
+            if _pfx != mooring_name:
+                candidates.append(
+                    (f"{raw_serial}_{_pfx}_recovery.000", "rdi-raw", None)
+                )
+
+        if not candidates:
+            if log_fn:
+                log_fn(
+                    f"AUTO-FILENAME: instrument type '{instr_type}' not recognised "
+                    f"— add 'filename:' to YAML for {instr_type} {raw_serial}"
+                )
+            return None
+
+        # Search directories: new layout (raw_mooring_dir/instrument/), then
+        # mooring subdir (raw_mooring_dir/), then legacy input_dir.
+        search_roots: list = []
+        if raw_mooring_dir is not None:
+            search_roots.append(raw_mooring_dir / instr_type)
+            search_roots.append(raw_mooring_dir)
+        if input_dir is not None:
+            search_roots.append(input_dir / instr_type / mooring_name)
+            search_roots.append(input_dir)
+
+        tried: list = []
+        for fname, ftype, hdr in candidates:
+            for root in search_roots:
+                candidate_path = root / fname
+                tried.append(str(candidate_path))
+                if candidate_path.exists():
+                    return fname, ftype, hdr
+
+        if log_fn:
+            log_fn(
+                f"AUTO-FILENAME: no file found for {instr_type} {raw_serial} — tried:\n  "
+                + "\n  ".join(tried)
+            )
+        return None
+
     def _process_instrument(
         self,
         instrument_config: Dict[str, Any],
@@ -1282,12 +1445,30 @@ class MooringProcessor:
             self._log_print(f"SKIP {instrument_name} {serial}: {reason}")
             return True
 
-        if "filename" not in instrument_config:
-            self._log_print(
-                f"FILENAME MISSING: Skipping {instrument_name}:{serial}. "
-                f"YAML is missing 'filename'."
+        if not instrument_config.get("filename"):
+            guess = self._guess_instrument_filename(
+                instrument_config,
+                mooring_name,
+                raw_mooring_dir,
+                input_dir,
+                log_fn=self._log_print,
             )
-            return False
+            if guess is None:
+                self._log_print(
+                    f"FILENAME MISSING: Skipping {instrument_name}:{serial}. "
+                    f"YAML is missing 'filename' and no standard file was found."
+                )
+                return False
+            _gf, _gt, _gh = guess
+            self._log_print(
+                f"AUTO-FILENAME: {instrument_name} {serial} → {_gf} ({_gt})"
+            )
+            instrument_config = dict(instrument_config)
+            instrument_config["filename"] = _gf
+            if _gt and not instrument_config.get("file_type"):
+                instrument_config["file_type"] = _gt
+            if _gh and not instrument_config.get("header_file"):
+                instrument_config["header_file"] = _gh
 
         # Set up file paths
         filename = instrument_config["filename"]

--- a/oceanarray/stage1.py
+++ b/oceanarray/stage1.py
@@ -1331,7 +1331,9 @@ class MooringProcessor:
                 _tried_400: list = []
                 for _root in _search_400:
                     _conv = _root / "converted_raw"
-                    _tried_400.append(str(_conv / f"A{raw_serial}*" / "Average Velocity DF3.csv"))
+                    _tried_400.append(
+                        str(_conv / f"A{raw_serial}*" / "Average Velocity DF3.csv")
+                    )
                     if not _conv.is_dir():
                         continue
                     for _sub in sorted(_conv.glob(f"A{raw_serial}*")):
@@ -1354,8 +1356,7 @@ class MooringProcessor:
                 if log_fn:
                     log_fn(
                         f"AUTO-FILENAME: no converted_raw/A{raw_serial}*/ found for "
-                        f"aquadopp {raw_serial} — tried:\n  "
-                        + "\n  ".join(_tried_400)
+                        f"aquadopp {raw_serial} — tried:\n  " + "\n  ".join(_tried_400)
                     )
                 return None
             candidates.append(

--- a/oceanarray/stage3.py
+++ b/oceanarray/stage3.py
@@ -533,23 +533,36 @@ def _tilt_from_span(qc_ranges: Dict[str, Any]) -> Dict[str, float]:
 def _load_qc_config(
     mooring_cfg: Dict[str, Any],
     entry: Dict[str, Any],
-) -> tuple[Dict, Dict, Dict]:
-    """Return (gross_range, spike, tilt) configs for one instrument.
+) -> tuple[Dict, Dict, Dict, Dict]:
+    """Return QC threshold dicts for one instrument.
 
-    Precedence: package defaults → mooring YAML → instrument YAML entry.
+    Returns a 4-tuple ``(gross_range, spike, tilt, flat_line)`` built from
+    package defaults with mooring-level and then instrument-level YAML
+    overrides applied (later values win).
 
-    Tilt thresholds can be set either via the unified ``qc_ranges`` key
-    (using ``fail_span``/``suspect_span`` like all other variables) or via
-    the legacy ``tilt_qc`` key.  ``tilt_qc`` takes precedence over
-    ``qc_ranges.tilt`` at the same level.  Either way, ``tilt`` is stripped
-    from the gross-range dict so it is not passed to the QARTOD gross-range
-    test runner.
+    ``gross_range`` and ``spike`` map variable names (e.g. ``"temperature"``,
+    ``"pressure"``) to threshold dicts understood by ``_apply_qc_tests``.
+    ``tilt`` holds ``suspect_threshold`` / ``fail_threshold`` in degrees,
+    used to flag Aquadopp velocity data when the instrument is tilted beyond
+    acceptable limits.  ``flat_line`` maps variable names to
+    ``{suspect_n, fail_n, tolerance}`` dicts for the stuck-sensor test.
+
+    YAML override keys:
+
+    * ``qc_ranges`` (mooring or instrument level) — gross-range and tilt spans
+    * ``qc_spike`` — spike thresholds
+    * ``tilt_qc`` — tilt thresholds (takes precedence over ``qc_ranges.tilt``)
+    * ``qc_flat_line`` — stuck-sensor thresholds
+
+    ``tilt`` is stripped from the gross-range dict before returning so it is
+    not passed to the QARTOD gross-range test runner.
     """
     from . import parameters as P
 
     gr = copy.deepcopy(P.QC_GROSS_RANGE)
     sp = copy.deepcopy(P.QC_SPIKE)
     tilt = copy.deepcopy(P.QC_TILT)
+    fl = copy.deepcopy(P.QC_FLAT_LINE)
 
     # Mooring-level overrides
     if "qc_ranges" in mooring_cfg:
@@ -559,6 +572,8 @@ def _load_qc_config(
         sp = _deep_merge(sp, mooring_cfg["qc_spike"])
     if "tilt_qc" in mooring_cfg:
         tilt.update(mooring_cfg["tilt_qc"])
+    if "qc_flat_line" in mooring_cfg:
+        fl = _deep_merge(fl, mooring_cfg["qc_flat_line"])
 
     # Instrument-level overrides
     if "qc_ranges" in entry:
@@ -568,12 +583,14 @@ def _load_qc_config(
         sp = _deep_merge(sp, entry["qc_spike"])
     if "tilt_qc" in entry:
         tilt.update(entry["tilt_qc"])
+    if "qc_flat_line" in entry:
+        fl = _deep_merge(fl, entry["qc_flat_line"])
 
     # Remove tilt from the gross-range dict — it is handled separately and
     # is not a valid QARTOD gross-range variable.
     gr.pop("tilt", None)
 
-    return gr, sp, tilt
+    return gr, sp, tilt, fl
 
 
 # Velocity variable names in both beam and ENU coordinate systems.
@@ -822,26 +839,45 @@ def _apply_qc_tests(
     gross_range: Dict[str, Any],
     spike: Dict[str, Any],
     qc_attrs: Dict[str, Any],
+    flat_line: Optional[Dict[str, Any]] = None,
 ) -> xr.Dataset:
-    """Apply QARTOD gross-range and spike tests, writing *_qc variables.
+    """Apply QARTOD gross-range, spike, and flat-line tests, writing ``*_qc`` variables.
 
-    Existing *_qc variables (e.g., pressure_qc=8 from interpolation) are
-    merged with the new test flags using priority ordering (worst flag wins).
+    Three QARTOD tests are applied in sequence; the worst flag across all
+    tests wins for each sample:
 
-    The applied thresholds are stored as attributes on each ``{var}_qc``
-    variable so that downstream tools (reports, histogram overlays) can
-    display exactly what was used without re-reading the YAML:
+    * **Gross-range**: flags values outside physically plausible bounds as
+      SUSPECT (3) or BAD (4) — e.g. temperature below -2.5 °C or above 40 °C.
+    * **Spike**: flags isolated outliers that deviate from the surrounding
+      record by more than a threshold — e.g. a brief salinity glitch from
+      biofouling or a pressure transient.
+    * **Flat-line** (stuck-sensor): flags runs of consecutive samples where
+      the value does not change by more than ``tolerance`` — e.g. a pressure
+      sensor frozen at 0 dbar after a failure.  Threshold is expressed in
+      sample counts (``suspect_n``, ``fail_n``) and converted to seconds
+      using the median sample interval.  Applied by default to pressure only
+      (see ``parameters.QC_FLAT_LINE``).
+
+    Pre-existing ``*_qc`` values (e.g. ``pressure_qc = 8`` set by the
+    pressure-interpolation step in the stack) are preserved: the worst flag
+    across the incoming value and the new test flags is written to the output.
+
+    Provenance: the thresholds actually applied are stored as attributes on
+    each ``{var}_qc`` variable so the treatment can be reconstructed from
+    the NetCDF file alone, without re-reading the YAML:
 
     * ``qc_gross_range_fail_min`` / ``qc_gross_range_fail_max``
     * ``qc_gross_range_suspect_min`` / ``qc_gross_range_suspect_max``
     * ``qc_spike_suspect_threshold`` / ``qc_spike_fail_threshold``
+    * ``qc_flat_line_suspect_count`` / ``qc_flat_line_fail_count``
     """
     from ioos_qc import qartod
 
+    _flat = flat_line or {}
     test_vars = [
         v
         for v in ds.data_vars
-        if (v in gross_range or v in spike) and not v.endswith("_qc")
+        if (v in gross_range or v in spike or v in _flat) and not v.endswith("_qc")
     ]
 
     for varname in test_vars:
@@ -876,6 +912,30 @@ def _apply_qc_tests(
             )
             flags_list.append(sp_flags)
 
+        if varname in _flat and "time" in ds:
+            fl_cfg = _flat[varname]
+            time_vals = ds["time"].values
+            # Convert datetime64 → float seconds since epoch for ioos_qc
+            time_s = time_vals.astype("datetime64[s]").astype(float)
+            dt_s = float(np.nanmedian(np.diff(time_s))) if len(time_s) > 1 else 60.0
+            suspect_n = int(fl_cfg.get("suspect_n", 3))
+            fail_n = int(fl_cfg.get("fail_n", 10))
+            _fl_result = qartod.flat_line_test(
+                inp=data,
+                tinp=time_s,
+                suspect_threshold=int(suspect_n * dt_s),
+                fail_threshold=int(fail_n * dt_s),
+                tolerance=float(fl_cfg.get("tolerance", 0.0)),
+            )
+            # flat_line_test may return a masked array or plain ndarray depending
+            # on the ioos_qc version; handle both.
+            fl_flags = (
+                _fl_result.filled(9)
+                if hasattr(_fl_result, "filled")
+                else np.where(np.isnan(_fl_result.astype(float)), 9, _fl_result)
+            ).astype(np.int8)
+            flags_list.append(fl_flags)
+
         new_flags = _merge_flags(*flags_list)
 
         qc_varname = f"{varname}_qc"
@@ -908,6 +968,12 @@ def _apply_qc_tests(
                 threshold_attrs["qc_spike_fail_threshold"] = float(
                     scfg["fail_threshold"]
                 )
+        if varname in _flat:
+            fl_cfg = _flat[varname]
+            threshold_attrs["qc_flat_line_suspect_count"] = int(
+                fl_cfg.get("suspect_n", 3)
+            )
+            threshold_attrs["qc_flat_line_fail_count"] = int(fl_cfg.get("fail_n", 10))
 
         ds[qc_varname] = xr.Variable(
             ds[varname].dims,
@@ -1578,7 +1644,7 @@ class Stage3Processor:
                 for key, val in entry.items()
                 if key.endswith("_qc") and isinstance(val, int)
             }
-            gr_cfg, sp_cfg, tilt_cfg = _load_qc_config(mooring_config, entry)
+            gr_cfg, sp_cfg, tilt_cfg, fl_cfg = _load_qc_config(mooring_config, entry)
             # Parse optional hab_segments: list of {from: ISO, hab: float}
             # Stored as sorted list of (np.datetime64, float) breakpoints.
             raw_segs = entry.get("hab_segments", [])
@@ -1605,6 +1671,7 @@ class Stage3Processor:
                     "gross_range": gr_cfg,
                     "spike": sp_cfg,
                     "tilt": tilt_cfg,
+                    "flat_line": fl_cfg,
                     "entry": entry,
                     "lat": _mooring_lat,
                     "lon": _mooring_lon,
@@ -1828,15 +1895,18 @@ class Stage3Processor:
             # ── QARTOD QC tests (temperature, conductivity, salinity, …) ─
             gr_cfg = info["gross_range"]
             sp_cfg = info["spike"]
+            fl_cfg = info["flat_line"]
             # For ADCP, exclude 2-D velocity vars from the ioos_qc path
             # (gross_range_test expects 1-D input); velocity QC is handled
             # below by _apply_adcp_velocity_qc.
             if is_adcp:
                 _ENU_KEYS = {"east_velocity", "north_velocity", "up_velocity"}
                 gr_cfg_scalar = {k: v for k, v in gr_cfg.items() if k not in _ENU_KEYS}
-                ds = _apply_qc_tests(ds, gr_cfg_scalar, sp_cfg, qc_attrs)
+                ds = _apply_qc_tests(
+                    ds, gr_cfg_scalar, sp_cfg, qc_attrs, flat_line=fl_cfg
+                )
             else:
-                ds = _apply_qc_tests(ds, gr_cfg, sp_cfg, qc_attrs)
+                ds = _apply_qc_tests(ds, gr_cfg, sp_cfg, qc_attrs, flat_line=fl_cfg)
 
             # ── Fold T/C/P parent QC into salinity_qc ─────────────────
             ds = _merge_salinity_parent_qc(ds, qc_attrs)


### PR DESCRIPTION
## Summary

- **Auto-detect raw filenames** when `filename` is absent or `null` in the mooring YAML, using standard `{serial}_recovery.<ext>` naming conventions (see table below). Covers microcat, tr1050, rbrsolo/rbrduet/seapoint, aquadopp/nortek (< 400000 and 400### series), and ADCP.  A diagnostic message is printed listing all paths tried
 when no file is found.
- **Flat-line (stuck-sensor) QC** added to stage 3: QARTOD `flat_line_test` applied to pressure by default (flags pressure stuck at the same value for ≥ 3 samples as SUSPECT, ≥ 10 as FAIL).  Addresses `dsK3_1_2026_4959` (stuck at 0 dbar).
- **Report Table 3 (instrument summary)** narrowed: YAML Δt column removed; single Δt (s) column shows observed p90, with amber `*` and footnote when it differs from the YAML value.  Min/Max P columns merged into a single `P range (min, max)` column that excludes non-positive and QC-bad values to avoid pre-deployment bench readings.
- **Turbidity QC**: added to `QC_GROSS_RANGE` with `fail_span=(0.0, 4000.0)` NTU. The per-instrument time series plot uses a log₁₀ y-axis for turbidity.
- **Grid velocity time series**: east and north velocity merged onto one panel (same axes); speed remains on its own panel above.
- **YAML docs** updated with auto-detection conventions table.

### Auto-detect filename conventions

| `instrument` | Condition | Filename tried | `file_type` |
|---|---|---|---|
| `microcat` | serial < 6000 | `{serial}_recovery.asc` | `sbe-ascii` |
| `microcat` | serial ≥ 6000 | `{serial}_recovery.hex` | `sbe-hex` |
| `tr1050` | any | `{serial}_recovery.hex` | `rbr-hex` |
| `rbrsolo`, `rbrduet`, `seapoint` | any | `{serial}_recovery.rsk` | `rbr-rsk` |
| `aquadopp` / `nortek` | serial < 400000 | `{serial}_recovery.dat` + `.hdr` | `nortek-ascii` |
| `aquadopp` / `nortek` | serial ≥ 400000 | globs `converted_raw/A{serial}*/Average Velocity DF3.csv` | `nortek-csv` |
| `ADCP` | any | `{serial}_{mooring}_recovery.000` then `{serial}_{mooring_prefix}_recovery.000` | `rdi-raw` |

Searched directories (in order): `{raw_dir}/{mooring}/{instrument}/`, then `{raw_dir}/{mooring}/`.

### Notes

- Instruments with `skip: true` are excluded from filename guessing in the report.
- A trailing `*` or other non-alphanumeric annotation in the serial field is stripped before building candidate filenames.
