### PR TITLE
[FEAT] dissolved oxygen pipeline, velocity QC unification, pressure interpolation fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,57 +1,35 @@
-name: Run tests
+name: Run unit tests
 
 on:
+  push:
+    branches: ["**"]
   pull_request:
-    branches:
-      - main
-    paths:
-      - '**.py'
-      - '**.ipynb'
 
 jobs:
-  job_mytests:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.11"]
       fail-fast: true
-    defaults:
-      run:
-        shell: bash -l {0}
+
     steps:
-    - name: Run a one-line script
-      run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; else pip install -r requirements-dev.txt; fi
-    - name: Install oceanarray
-      run: |
-        python -m pip install -e . --no-deps --force-reinstall
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
 
-    - name: Test with pytest
-      run: |
-        pytest
+      - name: Install oceanarray
+        run: pip install -e . --no-deps --force-reinstall
 
-# Use the below code after deploying a release
-#    - name: Setup Micromamba Python ${{ matrix.python-version }}
-#      uses: mamba-org/setup-micromamba@v2
-#      with:
-#        environment-name: TEST
-#        init-shell: bash
-#        create-args: >-
-#          python=${{ matrix.python-version }} --file requirements-dev.txt --channel conda-forge
-
-
-
-#    - name: Full Tests
-#      run: |
-#        python -m pytest --cov=seagliderOG1 --cov-report term-missing  tests/
+      - name: Run unit tests
+        run: pytest tests/unit -m "not slow and not local" -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; else pip install -r requirements-dev.txt; fi
 
       - name: Install oceanarray
         run: pip install -e . --no-deps --force-reinstall

--- a/oceanarray/mooring_level.py
+++ b/oceanarray/mooring_level.py
@@ -53,6 +53,12 @@ STACK_VARS = [
     "percent_good_qc",
     "error_velocity_qc",
     "seabed_qc",
+    "turbidity",
+    "turbidity_qc",
+    "dissolved_oxygen",
+    "dissolved_oxygen_qc",
+    "oxygen_saturation_pct",
+    "apparent_oxygen_utilization",
 ]
 
 # Variables passed through without QC masking at the stack step.

--- a/oceanarray/parameters.py
+++ b/oceanarray/parameters.py
@@ -114,6 +114,16 @@ QC_GROSS_RANGE: dict = {
     # Upper bound is generous — coastal resuspension events can reach 1000 NTU.
     # Override per mooring if the sensor range is known to be tighter.
     "turbidity": {"fail_span": (0.0, 4000.0), "suspect_span": (0.0, 1000.0)},  # NTU
+    # Dissolved oxygen (SBE ODO sensor, µmol/L).  Deep North Atlantic: 200–320 µmol/L.
+    # Negative values are physically impossible → fail.  >500 µmol/L is unrealistic
+    # even near the surface (photosynthetic supersaturation ~350–400 µmol/L).
+    # Override per mooring via qc_ranges YAML key.
+    "dissolved_oxygen": {
+        "fail_span": (0.0, 500.0),
+        "suspect_span": (0.0, 450.0),
+    },  # umol/L
+    # O2 % saturation: >200 % would indicate severe bubble entrainment or sensor fault.
+    "oxygen_saturation_pct": {"fail_span": (0.0, 200.0), "suspect_span": (0.0, 150.0)},
 }
 
 # ---------------------------------------------------------------------------

--- a/oceanarray/report/_grid.py
+++ b/oceanarray/report/_grid.py
@@ -148,7 +148,7 @@ _GRID_HTML_TEMPLATE = """\
 <!-- ══ Hydrography: T and S ══ -->
 {% if fig_hydro_b64 %}
 <h2 id="hydro">Hydrography</h2>
-<p class="note">Temperature and salinity. Vertically interpolated to regular pressure grid &bull; 20 discrete colour levels.</p>
+<p class="note">Temperature, salinity, dissolved oxygen, and O₂ saturation (when present). Vertically interpolated to regular pressure grid &bull; 20 discrete colour levels.</p>
 <details open><summary class="collapse-toggle">show / hide</summary>
 <img class="fig" src="data:image/png;base64,{{ fig_hydro_b64 }}" alt="Temperature and salinity">
 </details>
@@ -166,9 +166,9 @@ _GRID_HTML_TEMPLATE = """\
 <!-- ══ T-S diagram (before derived quantities) ══ -->
 {% if fig_ts_grid_b64 %}
 <h2 id="ts">T-S diagram</h2>
-<p class="note">All (pressure, time) grid points. Colour = log₁₀(count+1). QC-bad data excluded at the stack step before gridding.</p>
+<p class="note">Left: log₁₀(count+1) per T-S bin. Right (when O₂ present): median O₂ saturation per T-S bin — bins with &lt;5 samples masked. Colour scale: BrBG (brown=low, teal=high).</p>
 <details open><summary class="collapse-toggle">show / hide</summary>
-<img class="fig" style="width:45%;max-width:45%;" src="data:image/png;base64,{{ fig_ts_grid_b64 }}" alt="T-S diagram">
+<img class="fig" src="data:image/png;base64,{{ fig_ts_grid_b64 }}" alt="T-S diagram">
 </details>
 {% endif %}
 
@@ -391,8 +391,11 @@ def generate_grid_page(
         n_instr = ctx.get("n_instruments", "—")
         grid_history = _parse_history(ds.attrs.get("history", ""))
 
-        # Hydrography: stacked T + S
-        fig_hydro_b64 = _make_grid_hydro_b64(ds)
+        # T-S diagram first so its axis limits can be passed to the hydro panels.
+        fig_ts_grid_b64, _ts_bounds = _make_grid_ts_diagram(ds)
+
+        # Hydrography: stacked T + S (+ O2 sat) — shared axis limits from T-S diagram
+        fig_hydro_b64 = _make_grid_hydro_b64(ds, var_bounds=_ts_bounds)
 
         # Velocity: stacked E / N / Up
         fig_vel_stacked_b64 = _make_grid_velocity_stacked_b64(ds)
@@ -402,7 +405,6 @@ def generate_grid_page(
         fig_grid_hodograph_b64 = _make_grid_hodograph_b64(ds)
         fig_grid_traj_b64 = _make_grid_trajectory_b64(ds)
         fig_grid_ts_b64 = _make_grid_timeseries_b64(ds)
-        fig_ts_grid_b64 = _make_grid_ts_diagram(ds)
 
         _lat_n2 = 0.0
         for _lat_key in ("seabed_latitude", "deployment_latitude", "latitude"):

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -162,24 +162,25 @@ def _plot_aquadopp_quick(ds: "xr.Dataset") -> "plt.Figure":
 
 # Canonical variable order for all instrument plots.
 _CANONICAL_PANELS: List[Tuple] = [
-    ("pressure", "Pressure [dbar]", "tab:green", True),
-    ("pressure_1", "Pressure 1 [dbar]", "tab:green", True),
-    ("temperature", "Temperature [°C]", "tab:red", False),
-    ("conductivity", "Conductivity [mS/cm]", "tab:blue", False),
-    ("salinity", "Salinity [PSU]", "tab:cyan", False),
-    ("east_velocity", "East vel. [m/s]", "tab:blue", False),
-    ("north_velocity", "North vel. [m/s]", "tab:orange", False),
-    ("up_velocity", "Up vel. [m/s]", "tab:cyan", False),
-    ("velocity_beam1", "Beam 1 vel. [m/s]", "tab:blue", False),
-    ("velocity_beam2", "Beam 2 vel. [m/s]", "tab:orange", False),
-    ("velocity_beam3", "Beam 3 vel. [m/s]", "tab:cyan", False),
-    ("tilt", "Tilt [°]", "tab:red", False),
-    ("pitch", "Pitch [°]", "tab:purple", False),
-    ("roll", "Roll [°]", "#8B4513", False),
-    ("heading", "Heading [°]", "tab:gray", False),
-    ("speed_of_sound", "Sound speed [m/s]", "tab:olive", False),
+    ("pressure", "Pressure (dbar)", "tab:green", True),
+    ("pressure_1", "Pressure 1 (dbar)", "tab:green", True),
+    ("temperature", "Temperature (°C)", "tab:red", False),
+    ("conductivity", "Conductivity (mS cm⁻¹)", "tab:blue", False),
+    ("salinity", "Salinity (PSU)", "tab:cyan", False),
+    ("east_velocity", "East velocity (m s⁻¹)", "tab:blue", False),
+    ("north_velocity", "North velocity (m s⁻¹)", "tab:orange", False),
+    ("up_velocity", "Up velocity (m s⁻¹)", "tab:cyan", False),
+    ("velocity_beam1", "Beam 1 velocity (m s⁻¹)", "tab:blue", False),
+    ("velocity_beam2", "Beam 2 velocity (m s⁻¹)", "tab:orange", False),
+    ("velocity_beam3", "Beam 3 velocity (m s⁻¹)", "tab:cyan", False),
+    ("tilt", "Tilt (°)", "tab:red", False),
+    ("pitch", "Pitch (°)", "tab:purple", False),
+    ("roll", "Roll (°)", "#8B4513", False),
+    ("heading", "Heading (°)", "tab:gray", False),
+    ("speed_of_sound", "Sound speed (m s⁻¹)", "tab:olive", False),
     ("turbidity", "Turbidity (NTU)", "tab:brown", False),
-    ("battery_voltage", "Battery [V]", "tab:pink", False),
+    ("dissolved_oxygen", "Dissolved oxygen (µmol L⁻¹)", "steelblue", False),
+    ("battery_voltage", "Battery (V)", "tab:pink", False),
 ]
 
 _COMPACT_PANEL_VARS: frozenset = frozenset({"battery_voltage", "speed_of_sound"})
@@ -374,6 +375,17 @@ def _build_fig_from_ds(
                     ncol=3,
                     framealpha=0.8,
                 )
+
+        # Twin right y-axis: O2 % saturation alongside dissolved oxygen concentration.
+        # Uses in-situ seawater density for the µmol/L → µmol/kg conversion (see
+        # _derive_oxygen_saturation in stage3.py); error vs freshwater density ~2.5%.
+        if vname == "dissolved_oxygen" and "oxygen_saturation_pct" in ds.data_vars:
+            ax2 = ax.twinx()
+            sat = ds["oxygen_saturation_pct"].values.astype(float)
+            ax2.plot(time, sat, color="darkorange", linewidth=0.6, alpha=0.75, zorder=0)
+            ax2.set_ylabel("O₂ sat. (%)", color="darkorange")
+            ax2.tick_params(axis="y", labelcolor="darkorange")
+            ax2.axhline(100.0, color="darkorange", lw=0.5, ls="--", alpha=0.4)
 
     serial = (
         ds["serial_number"].item()
@@ -1037,11 +1049,13 @@ def _ts_heatmap_panel(
 
 
 def _make_ts_diagram(nc_path: Path) -> Optional[str]:
-    """Two-panel T-S diagram: scatter by pressure (left) and 2-D count heatmap (right)."""
+    """T-S diagram: scatter by pressure, 2-D count heatmap, and (when present) scatter by O2 saturation."""
     try:
+        import matplotlib.colors as mcolors
         import matplotlib.pyplot as plt
         import xarray as xr
         from .. import parameters as P
+        from ..utilities import _nice_colorbar_bounds
 
         plt.style.use(str(P.MPLSTYLE))
         ds = xr.open_dataset(nc_path, decode_timedelta=False).load()
@@ -1059,7 +1073,7 @@ def _make_ts_diagram(nc_path: Path) -> Optional[str]:
 
         if "pressure" in ds.data_vars:
             C = ds["pressure"].values.astype(float)
-            cbar_label = "Pressure [dbar]"
+            cbar_label = "Pressure (dbar)"
             cmap_sc = "viridis_r"
         else:
             C = np.arange(len(T), dtype=float)
@@ -1088,8 +1102,17 @@ def _make_ts_diagram(nc_path: Path) -> Optional[str]:
         sal_units = ds["salinity"].attrs.get("units", "PSU")
         tmp_units = ds["temperature"].attrs.get("units", "°C")
 
-        fig, (ax_l, ax_r) = plt.subplots(1, 2, figsize=(13, 5), constrained_layout=True)
+        has_sat = "oxygen_saturation_pct" in ds.data_vars
+        sat_data = ds["oxygen_saturation_pct"].values.astype(float) if has_sat else None
 
+        ncols = 3 if has_sat else 2
+        fig, axes = plt.subplots(
+            1, ncols, figsize=(5.5 * ncols, 4.5), constrained_layout=True
+        )
+        ax_l, ax_r = axes[0], axes[1]
+        ax_sat = axes[2] if has_sat else None
+
+        # Panel 1: T-S scatter coloured by pressure
         vmin = np.nanpercentile(C[finite], 5)
         vmax = np.nanpercentile(C[finite], 95)
         sc = ax_l.scatter(
@@ -1123,11 +1146,42 @@ def _make_ts_diagram(nc_path: Path) -> Optional[str]:
         if suspect_mask.any() or bad_mask.any():
             ax_l.legend(loc="best", framealpha=0.8)
         _add_sigma0_contours(ax_l, S[finite], T[finite])
-        ax_l.set_xlabel(f"Salinity [{sal_units}]")
-        ax_l.set_ylabel(f"Temperature [{tmp_units}]")
-        ax_l.set_title("T-S scatter (colour = pressure)")
+        ax_l.set_xlabel(f"Salinity ({sal_units})")
+        ax_l.set_ylabel(f"Temperature ({tmp_units})")
+        ax_l.set_title("T-S (colour = pressure)")
 
+        # Panel 2: count heatmap
         _ts_heatmap_panel(ax_r, fig, S[finite], T[finite])
+
+        # Panel 3: T-S scatter coloured by O2 saturation (when available)
+        if ax_sat is not None and sat_data is not None:
+            sat_finite = good_mask & np.isfinite(sat_data)
+            if sat_finite.any():
+                sv = sat_data[sat_finite]
+                bounds_s = _nice_colorbar_bounds(
+                    float(np.nanpercentile(sv, 2)),
+                    float(np.nanpercentile(sv, 98)),
+                    n=11,
+                )
+                norm_s = mcolors.BoundaryNorm(bounds_s, ncolors=256)
+                sc_s = ax_sat.scatter(
+                    S[sat_finite],
+                    T[sat_finite],
+                    c=sv,
+                    cmap="BrBG",
+                    norm=norm_s,
+                    s=4,
+                    linewidths=0,
+                    alpha=0.6,
+                    zorder=2,
+                    rasterized=True,
+                )
+                cb_s = fig.colorbar(sc_s, ax=ax_sat, ticks=bounds_s, pad=0.02)
+                cb_s.set_label("O₂ saturation (%)")
+                _add_sigma0_contours(ax_sat, S[sat_finite], T[sat_finite])
+            ax_sat.set_xlabel(f"Salinity ({sal_units})")
+            ax_sat.set_ylabel(f"Temperature ({tmp_units})")
+            ax_sat.set_title("T-S (colour = O₂ sat.)")
 
         b64 = _fig_to_base64(fig)
         plt.close(fig)
@@ -1648,7 +1702,10 @@ def _make_grid_fig_b64(
 # ---------------------------------------------------------------------------
 
 
-def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
+def _make_grid_hydro_b64(
+    ds: "xr.Dataset",
+    var_bounds: "Optional[dict]" = None,
+) -> Optional[str]:
     """Stacked temperature / salinity pcolormesh panels for the grid report.
 
     Both panels have pressure (dbar) on the Y-axis (inverted, surface at top).
@@ -1670,6 +1727,11 @@ def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
     ----------
     ds : xr.Dataset
         Gridded mooring dataset with dimensions ``(time, pressure)``.
+    var_bounds : dict, optional
+        Pre-computed colorbar limits keyed by variable name, e.g.
+        ``{"t_lim": (vmin, vmax), "s_lim": (vmin, vmax), "o2_lim": (vmin, vmax)}``.
+        When a key is present its limits are used instead of computing from the data.
+        Intended for passing the T-S diagram axis limits so both figures share scales.
 
     Returns
     -------
@@ -1684,8 +1746,15 @@ def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
     import xarray as _xr
     from .. import parameters as P
 
+    if var_bounds is None:
+        var_bounds = {}
+
     panels = []
-    for var, cmap in [("temperature", "RdYlBu_r"), ("salinity", "YlGnBu_r")]:
+    for var, cmap in [
+        ("temperature", "RdYlBu_r"),
+        ("salinity", "YlGnBu_r"),
+        ("oxygen_saturation_pct", "BrBG"),
+    ]:
         if var not in ds.data_vars:
             continue
         panels.append((var, cmap))
@@ -1734,9 +1803,19 @@ def _make_grid_hydro_b64(ds: "xr.Dataset") -> Optional[str]:
         # carries the full CF phrase "sea water temperature" which is verbose
         # for a plot heading.  The colorbar label keeps the full long_name.
         title = var.replace("_", " ").capitalize()
-        _vmin = float(np.nanpercentile(data, P.COLORBAR_PLOW))
-        _vmax = float(np.nanpercentile(data, P.COLORBAR_PHIGH))
-        bounds = _nice_colorbar_bounds(_vmin, _vmax, n=20)
+        _lim_key = {
+            "temperature": "t_lim",
+            "salinity": "s_lim",
+            "oxygen_saturation_pct": "o2_lim",
+        }.get(var)
+        _passed = var_bounds.get(_lim_key) if _lim_key else None
+        if _passed is not None:
+            _vmin, _vmax = _passed
+        else:
+            _vmin = float(np.nanpercentile(data, P.COLORBAR_PLOW))
+            _vmax = float(np.nanpercentile(data, P.COLORBAR_PHIGH))
+        _n = 11 if var == "oxygen_saturation_pct" else 20
+        bounds = _nice_colorbar_bounds(_vmin, _vmax, n=_n)
         norm = mcolors.BoundaryNorm(bounds, ncolors=256)
         pc = ax.pcolormesh(
             time, pressure, data, shading="nearest", cmap=cmap, norm=norm
@@ -2095,10 +2174,20 @@ def _make_instrument_rose_b64(nc_path: Path) -> Optional[str]:
 
 
 def _make_stack_ts_diagram(ds: "xr.Dataset") -> Optional[str]:
-    """Two-panel T-S diagram for a stacked dataset."""
+    """T-S diagram for a stacked dataset: scatter-by-pressure, count heatmap, and (when present) scatter-by-AOU.
+
+    Panels are arranged in a single row.  The AOU panel is included when
+    ``apparent_oxygen_utilization`` is present in *ds* (written by stage3 for
+    instruments with dissolved oxygen data).
+
+    QC masking: bad (flag 4) and missing (flag 9) excluded; interpolated
+    pressure (flag 8) is kept as usable colour data.
+    """
     try:
+        import matplotlib.colors as mcolors
         import matplotlib.pyplot as plt
         from .. import parameters as P
+        from ..utilities import _nice_colorbar_bounds
 
         if "temperature" not in ds.data_vars or "salinity" not in ds.data_vars:
             return None
@@ -2106,18 +2195,22 @@ def _make_stack_ts_diagram(ds: "xr.Dataset") -> Optional[str]:
         T_all = ds["temperature"].values.copy().astype(float)
         S_all = ds["salinity"].values.copy().astype(float)
         if "temperature_qc" in ds.data_vars:
-            T_all[ds["temperature_qc"].values >= 4] = np.nan
+            _tqc = ds["temperature_qc"].values.astype(float)
+            T_all[(_tqc == 4) | (_tqc == 9)] = np.nan
         if "salinity_qc" in ds.data_vars:
-            S_all[ds["salinity_qc"].values >= 4] = np.nan
+            _sqc = ds["salinity_qc"].values.astype(float)
+            S_all[(_sqc == 4) | (_sqc == 9)] = np.nan
 
         T_flat = T_all.ravel()
         S_flat = S_all.ravel()
 
+        # Pressure: keep flag 8 (interpolated) — only bad (4) and missing (9) excluded.
         P_flat: Optional[np.ndarray] = None
         if "pressure" in ds.data_vars:
             P_arr = ds["pressure"].values.astype(float)
             if "pressure_qc" in ds.data_vars:
-                P_arr[ds["pressure_qc"].values >= 4] = np.nan
+                _pqc = ds["pressure_qc"].values.astype(float)
+                P_arr[(_pqc == 4) | (_pqc == 9)] = np.nan
             P_flat = P_arr.ravel()
 
         finite = np.isfinite(T_flat) & np.isfinite(S_flat)
@@ -2126,28 +2219,45 @@ def _make_stack_ts_diagram(ds: "xr.Dataset") -> Optional[str]:
         if finite.sum() < 5:
             return None
 
-        plt.style.use(str(P.MPLSTYLE))
-        fig, (ax_l, ax_r) = plt.subplots(1, 2, figsize=(13, 5), constrained_layout=True)
+        # O2 saturation: optional third panel.
+        SAT_flat: Optional[np.ndarray] = None
+        if "oxygen_saturation_pct" in ds.data_vars:
+            SAT_flat = ds["oxygen_saturation_pct"].values.astype(float).ravel()
 
+        has_sat = SAT_flat is not None and np.isfinite(SAT_flat).any()
+        ncols = 3 if has_sat else 2
+        fig_w = 5.5 * ncols  # ~5.5 in per panel keeps them compact in a row
+        plt.style.use(str(P.MPLSTYLE))
+        fig, axes = plt.subplots(
+            1, ncols, figsize=(fig_w, 4.5), constrained_layout=True
+        )
+
+        ax_scatter, ax_heat = axes[0], axes[1]
+        ax_sat = axes[2] if has_sat else None
+
+        # --- Left panel: T-S scatter coloured by pressure ---
         if P_flat is not None:
-            vmin = np.nanpercentile(P_flat[finite], 5)
-            vmax = np.nanpercentile(P_flat[finite], 95)
-            sc = ax_l.scatter(
+            pv = P_flat[finite]
+            vmin = float(np.nanpercentile(pv, 2))
+            vmax = float(np.nanpercentile(pv, 98))
+            bounds_p = _nice_colorbar_bounds(vmin, vmax, n=20)
+            norm_p = mcolors.BoundaryNorm(bounds_p, ncolors=256)
+            sc_p = ax_scatter.scatter(
                 S_flat[finite],
                 T_flat[finite],
-                c=P_flat[finite],
+                c=pv,
                 cmap="viridis_r",
-                vmin=vmin,
-                vmax=vmax,
+                norm=norm_p,
                 s=2,
                 linewidths=0,
                 alpha=0.5,
                 zorder=2,
                 rasterized=True,
             )
-            fig.colorbar(sc, ax=ax_l, label="Pressure [dbar]", fraction=0.046, pad=0.04)
+            cb_p = fig.colorbar(sc_p, ax=ax_scatter, ticks=bounds_p, pad=0.02)
+            cb_p.set_label("Pressure (dbar)")
         else:
-            ax_l.scatter(
+            ax_scatter.scatter(
                 S_flat[finite],
                 T_flat[finite],
                 s=2,
@@ -2155,12 +2265,42 @@ def _make_stack_ts_diagram(ds: "xr.Dataset") -> Optional[str]:
                 alpha=0.4,
                 rasterized=True,
             )
-        _add_sigma0_contours(ax_l, S_flat[finite], T_flat[finite])
-        ax_l.set_xlabel("Practical salinity")
-        ax_l.set_ylabel("Temperature (°C)")
-        ax_l.set_title("T-S scatter (colour = pressure)")
+        _add_sigma0_contours(ax_scatter, S_flat[finite], T_flat[finite])
+        ax_scatter.set_xlabel("Practical salinity")
+        ax_scatter.set_ylabel("Temperature (°C)")
+        ax_scatter.set_title("T-S (colour = pressure)")
 
-        _ts_heatmap_panel(ax_r, fig, S_flat[finite], T_flat[finite])
+        # --- Middle panel: count heatmap ---
+        _ts_heatmap_panel(ax_heat, fig, S_flat[finite], T_flat[finite])
+
+        # --- Right panel: T-S scatter coloured by O2 saturation ---
+        if ax_sat is not None and SAT_flat is not None:
+            sat_finite = finite & np.isfinite(SAT_flat)
+            sat_v = SAT_flat[sat_finite]
+            bounds_s = _nice_colorbar_bounds(
+                float(np.nanpercentile(sat_v, 2)),
+                float(np.nanpercentile(sat_v, 98)),
+                n=11,
+            )
+            norm_s = mcolors.BoundaryNorm(bounds_s, ncolors=256)
+            sc_s = ax_sat.scatter(
+                S_flat[sat_finite],
+                T_flat[sat_finite],
+                c=sat_v,
+                cmap="YlGnBu",
+                norm=norm_s,
+                s=2,
+                linewidths=0,
+                alpha=0.5,
+                zorder=2,
+                rasterized=True,
+            )
+            cb_s = fig.colorbar(sc_s, ax=ax_sat, ticks=bounds_s, pad=0.02)
+            cb_s.set_label("O₂ saturation (%)")
+            _add_sigma0_contours(ax_sat, S_flat[sat_finite], T_flat[sat_finite])
+            ax_sat.set_xlabel("Practical salinity")
+            ax_sat.set_ylabel("Temperature (°C)")
+            ax_sat.set_title("T-S (colour = O₂ sat.)")
 
         b64 = _fig_to_base64(fig)
         plt.close(fig)
@@ -2169,30 +2309,128 @@ def _make_stack_ts_diagram(ds: "xr.Dataset") -> Optional[str]:
         return None
 
 
-def _make_grid_ts_diagram(ds: "xr.Dataset", n_bins: int = 80) -> Optional[str]:
-    """T-S heat map for a gridded dataset — half-page width."""
+def _make_grid_ts_diagram(
+    ds: "xr.Dataset", n_bins: int = 60
+) -> "tuple[Optional[str], dict]":
+    """T-S diagram for gridded mooring data.
+
+    Left panel: 2-D count heatmap (log₁₀ samples per T-S bin).
+    Right panel (when ``oxygen_saturation_pct`` is present): median O₂ saturation
+    per T-S bin, computed with ``scipy.stats.binned_statistic_2d``.  Bins with
+    fewer than 5 samples are masked white.
+
+    This lets you see which water masses (T-S combinations) are oxygen-rich vs
+    oxygen-depleted at this mooring — a compact water-mass characterisation.
+
+    Returns
+    -------
+    tuple of (b64_str or None, bounds_dict)
+        ``bounds_dict`` contains the axis/colorbar limits computed from the data so
+        the hydro pcolormesh panels can share the same scales:
+
+        - ``"t_lim"`` : (vmin, vmax) for temperature
+        - ``"s_lim"`` : (vmin, vmax) for salinity
+        - ``"o2_lim"`` : (vmin, vmax) for oxygen_saturation_pct, or None
+
+    """
     try:
+        import matplotlib.colors as mcolors
         import matplotlib.pyplot as plt
+        from scipy.stats import binned_statistic_2d
         from .. import parameters as P
+        from ..utilities import _nice_colorbar_bounds
 
         if "temperature" not in ds.data_vars or "salinity" not in ds.data_vars:
-            return None
+            return None, {}
 
         T = ds["temperature"].values.astype(float).ravel()
         S = ds["salinity"].values.astype(float).ravel()
         finite = np.isfinite(T) & np.isfinite(S)
         if finite.sum() < 10:
-            return None
+            return None, {}
 
+        # Axis limits from the data — returned to caller so hydro panels share scales.
+        s_lo = float(np.nanpercentile(S[finite], 0.01))
+        s_hi = float(np.nanpercentile(S[finite], 99.99))
+        t_lo = float(np.nanpercentile(T[finite], 0.01))
+        t_hi = float(np.nanpercentile(T[finite], 99.99))
+        ts_bounds = {"t_lim": (t_lo, t_hi), "s_lim": (s_lo, s_hi), "o2_lim": None}
+
+        has_o2 = "oxygen_saturation_pct" in ds.data_vars
+        O2 = (
+            ds["oxygen_saturation_pct"].values.astype(float).ravel() if has_o2 else None
+        )
+        o2_valid = (
+            finite & np.isfinite(O2) if (O2 is not None) else np.zeros_like(finite)
+        )
+        has_o2 = has_o2 and o2_valid.any()
+
+        ncols = 2 if has_o2 else 1
         plt.style.use(str(P.MPLSTYLE))
-        fig, ax = plt.subplots(figsize=(6, 5), constrained_layout=True)
-        _ts_heatmap_panel(ax, fig, S[finite], T[finite], n_bins=n_bins)
-        ax.set_title("T-S heat map (sample counts per bin)")
+        fig, axes = plt.subplots(
+            1, ncols, figsize=(6 * ncols, 5), constrained_layout=True
+        )
+        if ncols == 1:
+            axes = [axes]
+
+        # Panel 1: count heatmap
+        _ts_heatmap_panel(axes[0], fig, S[finite], T[finite], n_bins=n_bins)
+        axes[0].set_title("T-S count (log₁₀ samples per bin)")
+
+        # Panel 2: median O2 saturation per T-S bin
+        if has_o2 and O2 is not None:
+            s_edges = np.linspace(s_lo, s_hi, n_bins + 1)
+            t_edges = np.linspace(t_lo, t_hi, n_bins + 1)
+
+            o2_med, _, _, _ = binned_statistic_2d(
+                S[o2_valid],
+                T[o2_valid],
+                O2[o2_valid],
+                statistic="median",
+                bins=[s_edges, t_edges],
+            )
+            cnt, _, _, _ = binned_statistic_2d(
+                S[o2_valid],
+                T[o2_valid],
+                O2[o2_valid],
+                statistic="count",
+                bins=[s_edges, t_edges],
+            )
+            # o2_med shape is (n_s, n_t); transpose to (n_t, n_s) for pcolormesh
+            populated = cnt >= 5
+            o2_masked = np.ma.masked_where(~populated | ~np.isfinite(o2_med), o2_med)
+
+            valid_vals = o2_med[populated & np.isfinite(o2_med)]
+            if valid_vals.size:
+                o2_vmin = float(np.nanpercentile(valid_vals, 2))
+                o2_vmax = float(np.nanpercentile(valid_vals, 98))
+                ts_bounds["o2_lim"] = (o2_vmin, o2_vmax)
+                bounds = _nice_colorbar_bounds(o2_vmin, o2_vmax, n=11)
+                norm = mcolors.BoundaryNorm(bounds, ncolors=256)
+                cmap = plt.cm.BrBG.copy()
+                cmap.set_bad("white")
+                pc = axes[1].pcolormesh(
+                    s_edges,
+                    t_edges,
+                    o2_masked.T,
+                    cmap=cmap,
+                    norm=norm,
+                    shading="flat",
+                )
+                cb = fig.colorbar(pc, ax=axes[1], ticks=bounds, pad=0.02)
+                cb.set_label("Median O₂ saturation (%)")
+                _add_sigma0_contours(axes[1], S[o2_valid], T[o2_valid])
+                axes[1].set_xlim(s_lo, s_hi)
+                axes[1].set_ylim(t_lo, t_hi)
+            axes[1].set_xlabel("Practical salinity")
+            axes[1].set_ylabel("Temperature (°C)")
+            axes[1].set_title("Median O₂ saturation per T-S bin")
+
         b64 = _fig_to_base64(fig)
         plt.close(fig)
-        return b64
+        return b64, ts_bounds
     except Exception:
-        return None
+        return None, {}
 
 
 def _make_velocity_iqr_profile_b64(ds: "xr.Dataset") -> Optional[str]:

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -178,6 +178,12 @@ _STACK_HTML_TEMPLATE = """\
 <img class="fig" src="data:image/png;base64,{{ fig_sal_b64 }}" alt="Salinity time series">
 {% endif %}
 
+{% if fig_dissolved_oxygen_b64 %}
+<h2 id="dissolved-oxygen">Dissolved oxygen (all instruments)</h2>
+<p class="note">One line per instrument with dissolved oxygen data (SBE ODO sensor); QC flags &ge; 3 masked. Units: µmol L⁻¹. % saturation available in per-instrument reports.</p>
+<img class="fig" src="data:image/png;base64,{{ fig_dissolved_oxygen_b64 }}" alt="Dissolved oxygen time series">
+{% endif %}
+
 <!-- Velocity time series -->
 {% if fig_east_vel_b64 %}
 <h2 id="vel">East velocity (U)</h2>
@@ -262,7 +268,7 @@ _STACK_HTML_TEMPLATE = """\
 
 {% if fig_ts_stack_b64 %}
 <h2 id="ts">T-S diagram</h2>
-<p class="note">One colour per instrument. Bad-flagged samples (QC flag &ge; 4) excluded. Labels show serial number and height above bottom.</p>
+<p class="note">Left: scatter coloured by pressure. Middle: 2-D count heatmap. Right (when oxygen data present): scatter coloured by O₂ saturation (%). Bad (flag&nbsp;4) and missing (flag&nbsp;9) excluded; interpolated pressure (flag&nbsp;8) retained.</p>
 <img class="fig" src="data:image/png;base64,{{ fig_ts_stack_b64 }}" alt="T-S diagram">
 {% endif %}
 
@@ -711,6 +717,14 @@ def generate_stack_page(
             if "salinity" in ds
             else None
         )
+        fig_dissolved_oxygen_b64 = (
+            _ts_fig(
+                "dissolved_oxygen",
+                f"Dissolved oxygen ({ds['dissolved_oxygen'].attrs.get('units', 'µmol/L')})",
+            )
+            if "dissolved_oxygen" in ds
+            else None
+        )
         fig_east_vel_b64 = (
             _ts_fig("east_velocity", "U — East velocity (m/s)")
             if "east_velocity" in ds
@@ -866,6 +880,7 @@ def generate_stack_page(
             fig_north_vel_b64=fig_north_vel_b64,
             fig_up_vel_b64=fig_up_vel_b64,
             fig_turbidity_b64=fig_turbidity_b64,
+            fig_dissolved_oxygen_b64=fig_dissolved_oxygen_b64,
             fig_rose_grid_b64=fig_rose_grid_b64,
             rose_img_width=rose_img_width,
             rose_declination_note=rose_declination_note,

--- a/oceanarray/stage1.py
+++ b/oceanarray/stage1.py
@@ -1667,6 +1667,14 @@ class MooringProcessor:
         # Rename any remaining SBE CNV variable names that contain '/' (NetCDF-illegal)
         dataset = self._sanitize_slash_vars(dataset)
 
+        # SBE hex reader (seasenselib) outputs ODO oxygen as 'oxygen' (µmol/L) and
+        # 'oxygen_ml_l' (mL/L) — rename to canonical names so downstream stages and
+        # the report use a consistent variable name regardless of file type.
+        if "oxygen" in dataset.data_vars:
+            dataset = dataset.rename({"oxygen": "dissolved_oxygen"})
+        if "oxygen_ml_l" in dataset.data_vars:
+            dataset = dataset.rename({"oxygen_ml_l": "dissolved_oxygen_ml_l"})
+
         # SeaBird CNV files use "db" (decibars) instead of the CF-standard "dbar".
         for pvar in [
             v for v in dataset.data_vars if v == "pressure" or v.startswith("pressure")

--- a/oceanarray/stage3.py
+++ b/oceanarray/stage3.py
@@ -429,6 +429,25 @@ _CF_ATTRS: Dict[str, Dict[str, str]] = {
         "standard_name": "sea_water_turbidity",
         "long_name": "Turbidity",
     },
+    "dissolved_oxygen": {
+        "standard_name": "mole_concentration_of_dissolved_molecular_oxygen_in_sea_water",
+        "long_name": "Dissolved Oxygen",
+        "units": "umol/L",
+    },
+    "oxygen_saturation_pct": {
+        "long_name": "Dissolved Oxygen Percent Saturation",
+        "units": "%",
+    },
+    "apparent_oxygen_utilization": {
+        "standard_name": "apparent_oxygen_utilization",
+        "long_name": "Apparent Oxygen Utilization",
+        "units": "umol/kg",
+    },
+    "dissolved_oxygen_ml_l": {
+        "standard_name": "mole_concentration_of_dissolved_molecular_oxygen_in_sea_water",
+        "long_name": "Dissolved Oxygen",
+        "units": "mL/L",
+    },
 }
 
 
@@ -1001,7 +1020,9 @@ def _apply_enu_velocity_qc(
 
     Propagates up_velocity_qc (flag 3 or 4) to east_velocity_qc and
     north_velocity_qc: if vertical velocity is implausibly large the whole
-    3-D velocity measurement is suspect/bad.
+    3-D velocity measurement is suspect/bad.  Full bidirectional unification
+    (large east/north flags → up_velocity_qc) is done by _unify_velocity_qc,
+    which must be called after _apply_tilt_qc.
     """
     enu_gr = {
         k: v
@@ -1021,6 +1042,32 @@ def _apply_enu_velocity_qc(
                 ds[qc_varname] = xr.Variable(
                     ds[vel_var].dims, merged, attrs=dict(ds[qc_varname].attrs)
                 )
+    return ds
+
+
+def _unify_velocity_qc(ds: xr.Dataset) -> xr.Dataset:
+    """Unify ENU velocity QC flags so all three components share the worst flag.
+
+    After gross-range, up-velocity propagation, and tilt QC, each component may
+    carry different flags.  A large east/north velocity flags only that component;
+    tilt flags all three; up-velocity flags east and north but not itself from the
+    east/north gross-range test.  This function computes the element-wise worst flag
+    across east_velocity_qc, north_velocity_qc, and up_velocity_qc, then writes
+    that combined flag back to all three.  The result: masking on any single
+    component produces an identical, consistent velocity mask.
+    """
+    keys = [
+        v
+        for v in ("east_velocity_qc", "north_velocity_qc", "up_velocity_qc")
+        if v in ds.data_vars
+    ]
+    if not keys:
+        return ds
+    combined = np.ones(ds[keys[0]].shape, dtype=np.int8)
+    for k in keys:
+        combined = _merge_flags(combined, ds[k].values.astype(np.int8))
+    for k in keys:
+        ds[k] = xr.Variable(ds[k].dims, combined.copy(), attrs=dict(ds[k].attrs))
     return ds
 
 
@@ -1522,6 +1569,122 @@ def _apply_adcp_velocity_qc(
     return ds
 
 
+def _derive_oxygen_saturation(ds: "xr.Dataset") -> "xr.Dataset":
+    """Compute O2 % saturation and AOU from dissolved_oxygen, temperature, salinity, pressure.
+
+    Requires dissolved_oxygen (µmol/L), temperature (°C), salinity (PSU), and pressure
+    (dbar) all present in *ds*.  Returns *ds* unchanged when any variable is missing or
+    when gsw is unavailable.
+
+    Unit conversion uses in-situ **seawater** density from ``gsw.rho(SA, CT, p)``
+    (kg m⁻³) — NOT freshwater density (~1000 kg m⁻³).  Seawater density at typical
+    mooring conditions is ~1025–1028 kg m⁻³, giving a ~2.5 % correction relative to
+    freshwater.  This correction is oceanographically significant and must not be skipped.
+
+    lon/lat for ``gsw.SA_from_SP`` are taken from global attrs (default 0.0 if absent;
+    the SA error from a wrong position is typically < 0.05 g kg⁻¹ at open-ocean sites).
+
+    Derived variables stored
+    ------------------------
+    oxygen_saturation_pct : %
+        100 × O2_measured(µmol kg⁻¹) / O2sol(µmol kg⁻¹)
+        where O2sol is from ``gsw.O2sol_SP_pt(SP, pt)``.
+    apparent_oxygen_utilization : µmol kg⁻¹
+        O2sol − O2_measured (positive = oxygen-depleted water).
+    """
+    required = {"dissolved_oxygen", "temperature", "salinity", "pressure"}
+    if not required.issubset(ds.data_vars):
+        return ds
+    try:
+        import gsw
+    except ImportError:
+        return ds
+
+    O2_L = ds["dissolved_oxygen"].values.astype(float)
+    t = ds["temperature"].values.astype(float)
+    SP = ds["salinity"].values.astype(float)
+    p = ds["pressure"].values.astype(float)
+    try:
+        lon = float(ds.attrs.get("longitude", 0.0))
+    except (ValueError, TypeError):
+        lon = 0.0
+    try:
+        lat = float(ds.attrs.get("latitude", 0.0))
+    except (ValueError, TypeError):
+        lat = 0.0
+
+    # Mask already-flagged dissolved oxygen so bad values produce NaN saturation
+    # rather than spurious negative percentages that would then back-propagate.
+    if "dissolved_oxygen_qc" in ds.data_vars:
+        _do_qc = ds["dissolved_oxygen_qc"].values.astype(np.int8)
+        O2_L = O2_L.copy()
+        O2_L[np.isin(_do_qc, [4, 9])] = np.nan
+
+    SA = gsw.SA_from_SP(SP, p, lon, lat)
+    CT = gsw.CT_from_t(SA, t, p)
+    pt = gsw.pt0_from_t(SA, t, p)
+
+    O2sol = gsw.O2sol_SP_pt(SP, pt)  # µmol/kg at equilibrium
+    rho_sw = gsw.rho(SA, CT, p)  # kg/m³ in-situ seawater density
+    O2_kg = O2_L / (rho_sw / 1000.0)  # µmol/kg measured (divides by kg/L)
+
+    pct_sat = 100.0 * O2_kg / O2sol
+    aou = O2sol - O2_kg
+
+    # Back-flag: pct_sat < 0 is physically impossible (negative dissolved oxygen).
+    # Set saturation to NaN and flag the underlying dissolved_oxygen as bad (4).
+    neg_sat = np.isfinite(pct_sat) & (pct_sat < 0.0)
+    n_neg = int(np.sum(neg_sat))
+    if n_neg > 0:
+        pct_sat[neg_sat] = np.nan
+        aou[neg_sat] = np.nan
+        if "dissolved_oxygen_qc" in ds.data_vars:
+            do_qc = ds["dissolved_oxygen_qc"].values.astype(np.int8).copy()
+            do_qc[neg_sat] = np.int8(4)
+            ds["dissolved_oxygen_qc"] = xr.Variable(
+                ds["dissolved_oxygen_qc"].dims,
+                do_qc,
+                attrs=dict(ds["dissolved_oxygen_qc"].attrs),
+            )
+
+    ds = ds.assign(
+        oxygen_saturation_pct=xr.Variable(
+            "time",
+            pct_sat.astype(np.float32),
+            {
+                "long_name": "Dissolved Oxygen Percent Saturation",
+                "units": "%",
+                "comment": (
+                    "100 × O2_meas / O2sol. O2_meas converted from µmol/L to µmol/kg "
+                    "using in-situ seawater density gsw.rho(SA,CT,p); "
+                    "O2sol = gsw.O2sol_SP_pt(SP, pt0). "
+                    f"Back-flagged {n_neg} sample(s) where pct_sat < 0 as bad (flag 4)."
+                    if n_neg
+                    else (
+                        "100 × O2_meas / O2sol. O2_meas converted from µmol/L to µmol/kg "
+                        "using in-situ seawater density gsw.rho(SA,CT,p); "
+                        "O2sol = gsw.O2sol_SP_pt(SP, pt0)."
+                    )
+                ),
+            },
+        ),
+        apparent_oxygen_utilization=xr.Variable(
+            "time",
+            aou.astype(np.float32),
+            {
+                "long_name": "Apparent Oxygen Utilization",
+                "standard_name": "apparent_oxygen_utilization",
+                "units": "umol/kg",
+                "comment": (
+                    "AOU = O2sol - O2_meas (µmol/kg); positive = undersaturated "
+                    "(oxygen consumed). Uses in-situ seawater density for µmol/L → µmol/kg."
+                ),
+            },
+        ),
+    )
+    return ds
+
+
 class Stage3Processor:
     """Pressure interpolation + QARTOD QC for all mooring instruments."""
 
@@ -1908,6 +2071,65 @@ class Stage3Processor:
             else:
                 ds = _apply_qc_tests(ds, gr_cfg, sp_cfg, qc_attrs, flat_line=fl_cfg)
 
+            # ── Post-QC pressure check ─────────────────────────────────
+            # If QC (e.g. flat-line test) just flagged ALL pressure values as
+            # bad and this instrument was not already a pressure target, treat
+            # it as one now: interpolate from the other sources on the mooring.
+            # This catches stuck-sensor faults that only become visible after
+            # the flat-line / gross-range tests run — which is why the pre-scan
+            # source/target classification cannot catch them.
+            # Note: if this instrument was already used as a source for a
+            # previously processed target, those targets will have received bad
+            # pressure values.  To fix that, re-run stage 3 on the full mooring
+            # once this instrument's fault is known (e.g. add pressure_qc: 4 to
+            # the YAML so it is excluded from sources at the outset).
+            if (
+                not is_target
+                and "pressure_qc" in ds.data_vars
+                and "pressure" in ds.data_vars
+            ):
+                _pqc = ds["pressure_qc"].values.astype(np.int8)
+                _n_total = len(_pqc)
+                _n_bad = int(np.sum(np.isin(_pqc, [4, 9])))
+                _frac_bad = _n_bad / _n_total if _n_total > 0 else 0.0
+                # Trigger interpolation when > 70% of values are bad.  The flat-line
+                # test leaves the first fail_n samples as flag 1/3 (window startup),
+                # so strict all-bad checking would never fire for a fully stuck sensor.
+                if _frac_bad > 0.70:
+                    _other_sources = [s for s in sources if s["serial"] != serial]
+                    if _other_sources:
+                        self._log(
+                            f"  WARNING: {serial} — {_frac_bad:.0%} of pressure values "
+                            f"flagged bad by QC (flat-line or gross-range); replacing "
+                            f"entire pressure record with interpolation from "
+                            f"{len(_other_sources)} source(s). "
+                            f"Re-run stage 3 on the full mooring with "
+                            f"'pressure_qc: 4' in the YAML entry for {serial} "
+                            f"so it is excluded from sources from the start."
+                        )
+                        # Temporarily set YAML pressure flag to 4 so that
+                        # _interpolate_pressure stores pressure_orig_qc = 4
+                        # (the actual QC reason), not the YAML default of 0.
+                        info["qc_flags"]["pressure"] = 4
+                        ds, method = self._interpolate_pressure(
+                            ds,
+                            info,
+                            _other_sources,
+                            target_time,
+                            pressure_bad_flag=True,
+                            qc_attrs=qc_attrs,
+                        )
+                        history_notes.append(
+                            f"stage3 pressure interpolated post-QC "
+                            f"({_frac_bad:.0%} pressure_qc=4/9 after QC) — {method}"
+                        )
+                    else:
+                        self._log(
+                            f"  WARNING: {serial} — {_frac_bad:.0%} of pressure flagged "
+                            f"bad but no other pressure sources on this mooring; "
+                            f"pressure remains bad-flagged."
+                        )
+
             # ── Fold T/C/P parent QC into salinity_qc ─────────────────
             ds = _merge_salinity_parent_qc(ds, qc_attrs)
 
@@ -1982,6 +2204,16 @@ class Stage3Processor:
                         f"tilt≥{tilt_cfg['fail_threshold']}°→bad): "
                         f"suspect={n_tilt_susp}, bad={n_tilt_bad}"
                     )
+
+            # ── Unify ENU velocity QC ──────────────────────────────────
+            # After tilt + gross-range QC, combine worst flag across all three
+            # ENU components and write it back to all three so masking on any
+            # single component (east, north, or up) gives an identical result.
+            # This catches e.g. large east/north currents (>3 m/s suspect) that
+            # would otherwise leave up_velocity_qc unflagged.
+            if ds.attrs.get("coordinate_system") == "ENU":
+                ds = _unify_velocity_qc(ds)
+
             if ds.attrs.get("coordinate_system") == "ENU" and coord_sys_before != "ENU":
                 _ba = ds.attrs.get("nortek_beam_angle", "?")
                 _ba_src = ds.attrs.get("nortek_beam_angle_source", "")
@@ -2026,6 +2258,9 @@ class Stage3Processor:
             entry = f"{stamp}: " + " | ".join(history_notes)
             existing = ds.attrs.get("history", "")
             ds.attrs["history"] = f"{existing}; {entry}" if existing else entry
+
+            # Derive O2 % saturation and AOU when dissolved_oxygen + T/S/P are present.
+            ds = _derive_oxygen_saturation(ds)
 
             # Normalize CF standard_name and long_name for known physics variables.
             # Only fills in missing attrs — never overwrites values already set.


### PR DESCRIPTION
## Summary

- Pipes dissolved oxygen through the full processing chain (stage 1 → stage 3 → stack → grid → reports)
- Derives oxygen percent saturation and AOU in stage 3 using in-situ seawater density (GSW); back-flags raw DO as bad where saturation < 0
- Adds gross-range QC for dissolved oxygen and oxygen saturation
- Adds twin y-axis (% saturation) to the per-instrument dissolved oxygen panel
- Adds 3-panel T-S diagrams for microcats with oxygen (scatter-by-pressure, count heatmap, scatter-by-O₂-sat); all T-S colorbar and axis limits shared with the grid hydro panels
- Adds a T-S diagram to the grid report coloured by median O₂ saturation per T-S bin; grid hydro colorbars share the same T/S/O₂ bounds

## Fixes 

- Fixes velocity QC so tilt, up_velocity, and large east/north velocities all propagate symmetrically to every ENU component
- Fixes stage 3 pressure interpolation: instruments whose pressure is > 70% bad after QC (e.g. stuck sensor flat-lined by the QARTOD test) now retroactively receive interpolated pressure from neighbouring instruments


## Changes by file

### `oceanarray/stage1.py`
- Rename `oxygen` → `dissolved_oxygen` and `oxygen_ml_l` → `dissolved_oxygen_ml_l` for SBE hex readers (canonical name alignment with CNV reader path)

### `oceanarray/stage3.py`
- `_CF_ATTRS`: added entries for `dissolved_oxygen`, `oxygen_saturation_pct`, `apparent_oxygen_utilization`
- `_derive_oxygen_saturation` (new): computes `oxygen_saturation_pct` (%) and `apparent_oxygen_utilization` (µmol/kg) using in-situ seawater density `gsw.rho`; pre-masks already-bad DO before computing so bad values produce NaN not spurious negatives; back-flags `dissolved_oxygen_qc = 4` where saturation < 0 (physically impossible); records count in `comment` attr
- `_unify_velocity_qc` (new): after tilt QC and gross-range QC, takes the element-wise worst flag across all three ENU components and writes it back to all three — large east/north velocity now propagates to `up_velocity_qc` and vice versa
- `_process_instrument`: post-QC pressure rescue — if > 70% of `pressure_qc` values are 4 or 9 after flat-line or gross-range tests, retroactively interpolates pressure from other mooring sources; saves original stuck values as `pressure_orig`/`pressure_orig_qc`; sets `pressure_qc = 8` (interpolated); logs a warning to add `pressure_qc: 4` to the YAML entry so the next full mooring rerun excludes the bad instrument from sources at the outset

### `oceanarray/parameters.py`
- `QC_GROSS_RANGE`: added `dissolved_oxygen` (fail: 0–500 µmol/L, suspect: 0–450) and `oxygen_saturation_pct` (fail: 0–200 %, suspect: 0–150 %)

### `oceanarray/mooring_level.py`
- `STACK_VARS`: added `dissolved_oxygen`, `dissolved_oxygen_qc`, `oxygen_saturation_pct`, `apparent_oxygen_utilization`, `turbidity`, `turbidity_qc` so these variables propagate from stage 3 NC files through to the stack NC and subsequently the grid NC

### `oceanarray/report/_plots.py`
- Per-instrument dissolved oxygen panel: twin y-axis showing O₂ saturation (%) in darkorange with dashed 100 % reference line
- `_make_ts_diagram`: extended to 3 panels when `oxygen_saturation_pct` is present (scatter-by-pressure, count heatmap, scatter-by-O₂-sat); BrBG 11-class
- `_make_stack_ts_diagram`: 2 or 3 panels; third panel uses O₂ saturation (BrBG 11-class, not AOU); fixed pressure-QC masking to keep flag-8 (interpolated) points which were previously excluded
- `_make_grid_ts_diagram`: 2-panel layout (count heatmap + median O₂ sat per T-S bin via `scipy.stats.binned_statistic_2d`); bins with < 5 samples masked white; BrBG 11-class; returns computed T/S/O₂ axis limits to caller so hydro panels share the same scales
- `_make_grid_hydro_b64`: removed `dissolved_oxygen` concentration panel; added `oxygen_saturation_pct` panel (BrBG 11-class); accepts `var_bounds` dict from `_make_grid_ts_diagram` so T, S, and O₂ sat colorbars use the same limits as the T-S diagram axes
- All oxygen saturation colorbars: BrBG 11-class (brown = low O₂, blue-green = high O₂)

### `oceanarray/report/_stack.py`
- Dissolved oxygen time series moved to immediately after salinity (before turbidity and velocity)

### `oceanarray/report/_grid.py`
- `_make_grid_ts_diagram` called first; its bounds dict passed to `_make_grid_hydro_b64`
- Grid T-S image tag: removed fixed 45 % width so 2-panel layout renders at full width
