### PR TITLE
[FEAT] logsheet package + CLI subcommand + docs overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ setup.sh
 */_version.py
 
 # Data files — not stored in the repository
-data/
+# Anchored to repo root so oceanarray/logsheets/data/ (package data) is NOT excluded.
+/data/
 outputs/
 
 # Legacy individual exclusions (superseded by data/ above)

--- a/README.md
+++ b/README.md
@@ -12,14 +12,30 @@ OceanArray implements a multi-stage processing pipeline for mooring data, contro
 
 ## Installation
 
+### Using conda (recommended)
+
 ```bash
 git clone https://github.com/ocean-uhh/oceanarray.git
 cd oceanarray
-python -m venv venv
-source venv/bin/activate
+conda create -n oceanarray python=3.12
+conda activate oceanarray
 pip install -r requirements-dev.txt
 pip install -e .
 ```
+
+### Using pip + venv
+
+```bash
+git clone https://github.com/ocean-uhh/oceanarray.git
+cd oceanarray
+python3.12 -m venv venv
+source venv/bin/activate        # Windows: venv\Scripts\activate
+pip install -r requirements-dev.txt
+pip install -e .
+```
+
+> **Python version**: Python 3.10–3.12 is supported. Python 3.13+ has not been
+> tested with all dependencies and is not recommended.
 
 ## Quick start
 

--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -4,115 +4,18 @@
 CLI Reference
 ===================
 
-``oceanarray run`` is the recommended entry point for full pipeline processing
-once the YAML is set up and tested.  For initial processing and quality
-control, run stages individually with ``oceanarray process``.
+The typical workflow is: validate the YAML, run ``oceanarray process`` stage by
+stage, inspect with ``oceanarray report``, combine with ``oceanarray stack`` and
+``oceanarray grid``, then use ``oceanarray run`` to reproduce the full pipeline
+in one command.  ``oceanarray logsheet`` covers fieldwork logistics and is
+independent of the processing pipeline.
 
-All subcommands accept a mooring name as the first positional argument.
-The mooring name must match the ``name`` field in the YAML and is used to
-locate the YAML file at ``{proc_dir}/{mooring}/{mooring}.mooring.yaml``.
+All processing subcommands accept a mooring name as the first positional
+argument.  The mooring name is used to locate the YAML file at
+``{proc_dir}/{mooring}/{mooring}.mooring.yaml``.
 
 Without ``--force``, every subcommand skips any output file that already
 exists.  Add ``--force`` to overwrite.
-
-----
-
-``oceanarray list``
---------------------
-
-List the moorings found in the processed directory.  A quick way to confirm
-that ``--proc-dir`` is pointing at the right place.
-
-**Synopsis**
-
-.. code-block:: text
-
-   oceanarray list [--proc-dir DIR]
-
-**Example**
-
-.. code-block:: bash
-
-   oceanarray list --proc-dir /data/cruise2026/proc
-
-----
-
-``oceanarray run``
-------------------
-
-Run the complete processing pipeline in one command: stages 1, 2, and 3,
-followed by stack, grid, and all report pages.  Continues past individual
-instrument failures — check the processing logs in
-``{proc_dir}/{mooring}/processing_logs/`` for details.
-
-Use ``oceanarray run`` only after confirming that stage 1 can read all raw
-files and that the ``deployment_time`` / ``recovery_time`` values in the
-YAML produce the correct trim (verified with ``oceanarray process --stage 2``
-and a quick report inspection).
-
-**Synopsis**
-
-.. code-block:: text
-
-   oceanarray run MOORING [--raw-dir DIR] [--proc-dir DIR]
-                          [--dt SECONDS] [--dp DBAR]
-                          [--p-start DBAR] [--p-end DBAR]
-                          [--serial SN ...] [--force]
-
-**Flags**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 10 15 50
-
-   * - Flag
-     - Type
-     - Default
-     - Description
-   * - ``--raw-dir DIR``
-     - path
-     - (required)
-     - Cruise-level raw data directory.
-   * - ``--proc-dir DIR``
-     - path
-     - (required)
-     - Cruise-level processed data directory.
-   * - ``--dt SECONDS``
-     - integer
-     - 60
-     - Time step for the stack output (seconds).
-   * - ``--dp DBAR``
-     - number
-     - 20
-     - Pressure step for the grid output (dbar).
-   * - ``--p-start DBAR``
-     - number
-     - 200
-     - Shallowest pressure level in the grid (dbar).
-   * - ``--p-end DBAR``
-     - number
-     - 1000
-     - Deepest pressure level in the grid (dbar).
-   * - ``--serial SN``
-     - string (repeat)
-     - (all)
-     - Restrict processing and per-instrument reports to these serial numbers.
-   * - ``--force``
-     - flag
-     - off
-     - Overwrite existing output files at every stage.
-
-**Output created**
-
-All stage NC files, ``{mooring}_stack.nc``, ``{mooring}_grid.nc``,
-mooring summary report, stack report, grid report, and per-instrument
-reports.
-
-**Example**
-
-.. code-block:: bash
-
-   oceanarray run dsG3_1_2026 --raw-dir /data/raw --proc-dir /data/proc --force
 
 ----
 
@@ -240,6 +143,86 @@ Run all three stages:
 
 ----
 
+``oceanarray report``
+----------------------
+
+Generate HTML reports for a mooring.  Without any report-type flags,
+generates only the mooring summary page.  See :doc:`reports` for a
+description of what each report page contains.
+
+**Synopsis**
+
+.. code-block:: text
+
+   oceanarray report MOORING [--raw-dir DIR] [--proc-dir DIR]
+                             [-o DIR] [--instruments] [--stack]
+                             [--grid] [--serial SN ...] [--force]
+
+**Flags**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 10 10 55
+
+   * - Flag
+     - Type
+     - Default
+     - Description
+   * - ``--raw-dir DIR``
+     - path
+     - (required)
+     - Cruise-level raw data directory.
+   * - ``--proc-dir DIR``
+     - path
+     - (required)
+     - Cruise-level processed data directory.
+   * - ``-o DIR``
+     - path
+     - ``{proc_dir}/{mooring}/report/``
+     - Override the output directory for HTML files.
+   * - ``--instruments``
+     - flag
+     - off
+     - Generate per-instrument report pages (one per instrument in the YAML).
+   * - ``--stack``
+     - flag
+     - off
+     - Generate the stack report (requires ``_stack.nc``).
+   * - ``--grid``
+     - flag
+     - off
+     - Generate the grid report (requires ``_grid.nc``).
+   * - ``--serial SN``
+     - string (repeat)
+     - (all)
+     - Restrict per-instrument pages to specific serial numbers.
+   * - ``--force``
+     - flag
+     - off
+     - Regenerate reports even if HTML files already exist.
+
+**Output created**
+
+``{mooring}_report.html`` (always), plus optional
+``{mooring}_stack_report.html``, ``{mooring}_grid_report.html``, and
+``report/instrument/{mooring}_{serial}_report.html``.
+
+**Examples**
+
+Summary and per-instrument pages:
+
+.. code-block:: bash
+
+   oceanarray report dsG3_1_2026 --raw-dir /data/raw --proc-dir /data/proc --instruments
+
+All report types:
+
+.. code-block:: bash
+
+   oceanarray report dsG3_1_2026 --raw-dir /data/raw --proc-dir /data/proc --instruments --stack --grid
+
+----
+
 ``oceanarray stack``
 ---------------------
 
@@ -362,26 +345,33 @@ suspect or bad are treated the same as good data unless they are already NaN.
 
 ----
 
-``oceanarray report``
-----------------------
+``oceanarray run``
+------------------
 
-Generate HTML reports for a mooring.  Without any report-type flags,
-generates only the mooring summary page.  See :doc:`reports` for a
-description of what each report page contains.
+Run the complete processing pipeline in one command: stages 1, 2, and 3,
+followed by stack, grid, and all report pages.  Continues past individual
+instrument failures — check the processing logs in
+``{proc_dir}/{mooring}/processing_logs/`` for details.
+
+Use ``oceanarray run`` only after confirming that stage 1 can read all raw
+files and that the ``deployment_time`` / ``recovery_time`` values in the
+YAML produce the correct trim (verified with ``oceanarray process --stage 2``
+and a quick report inspection).
 
 **Synopsis**
 
 .. code-block:: text
 
-   oceanarray report MOORING [--raw-dir DIR] [--proc-dir DIR]
-                             [-o DIR] [--instruments] [--stack]
-                             [--grid] [--serial SN ...] [--force]
+   oceanarray run MOORING [--raw-dir DIR] [--proc-dir DIR]
+                          [--dt SECONDS] [--dp DBAR]
+                          [--p-start DBAR] [--p-end DBAR]
+                          [--serial SN ...] [--force]
 
 **Flags**
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 10 10 55
+   :widths: 25 10 15 50
 
    * - Flag
      - Type
@@ -395,50 +385,162 @@ description of what each report page contains.
      - path
      - (required)
      - Cruise-level processed data directory.
-   * - ``-o DIR``
-     - path
-     - ``{proc_dir}/{mooring}/report/``
-     - Override the output directory for HTML files.
-   * - ``--instruments``
-     - flag
-     - off
-     - Generate per-instrument report pages (one per instrument in the YAML).
-   * - ``--stack``
-     - flag
-     - off
-     - Generate the stack report (requires ``_stack.nc``).
-   * - ``--grid``
-     - flag
-     - off
-     - Generate the grid report (requires ``_grid.nc``).
+   * - ``--dt SECONDS``
+     - integer
+     - 60
+     - Time step for the stack output (seconds).
+   * - ``--dp DBAR``
+     - number
+     - 20
+     - Pressure step for the grid output (dbar).
+   * - ``--p-start DBAR``
+     - number
+     - 200
+     - Shallowest pressure level in the grid (dbar).
+   * - ``--p-end DBAR``
+     - number
+     - 1000
+     - Deepest pressure level in the grid (dbar).
    * - ``--serial SN``
      - string (repeat)
      - (all)
-     - Restrict per-instrument pages to specific serial numbers.
+     - Restrict processing and per-instrument reports to these serial numbers.
    * - ``--force``
      - flag
      - off
-     - Regenerate reports even if HTML files already exist.
+     - Overwrite existing output files at every stage.
 
 **Output created**
 
-``{mooring}_report.html`` (always), plus optional
-``{mooring}_stack_report.html``, ``{mooring}_grid_report.html``, and
-``report/instrument/{mooring}_{serial}_report.html``.
+All stage NC files, ``{mooring}_stack.nc``, ``{mooring}_grid.nc``,
+mooring summary report, stack report, grid report, and per-instrument
+reports.
+
+**Example**
+
+.. code-block:: bash
+
+   oceanarray run dsG3_1_2026 --raw-dir /data/raw --proc-dir /data/proc --force
+
+----
+
+``oceanarray logsheet``
+------------------------
+
+Generate PDF logsheets for mooring fieldwork and calibration-dip casts.
+See :doc:`logsheets` for a full description of sheet types and configuration.
+
+**Synopsis**
+
+.. code-block:: text
+
+   oceanarray logsheet [--type TYPE] [--mooring MOORING] [--cast CAST]
+                       [--config-dir DIR] [--inventory PATH]
+                       [--logsheet-config PATH]
+                       [--output-dir DIR] [--format {pdf,tex}]
+                       [--all]
+                       [--proc-dir DIR]
+
+**Flags**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 10 12 50
+
+   * - Flag
+     - Type
+     - Default
+     - Description
+   * - ``--type TYPE``
+     - string
+     - (required)
+     - Sheet type: ``caldip-setup``, ``caldip-download``, ``mooring-download``,
+       ``mooring-recovery``, or ``mooring-setup``.
+   * - ``--mooring MOORING``
+     - string
+     - —
+     - Mooring name (required for mooring sheet types).
+   * - ``--cast CAST``
+     - string
+     - —
+     - Cast name, e.g. ``B1`` (required for caldip sheet types).
+   * - ``--config-dir DIR``
+     - path
+     - ``$LOGSHEETS_CONFIG_DIR`` or ``./``
+     - Directory containing ``logsheet_config.yaml`` and
+       ``instrument_inventory.csv``.
+   * - ``--inventory PATH``
+     - path
+     - ``{config-dir}/instrument_inventory.csv``
+     - Explicit path to the instrument inventory CSV (overrides ``--config-dir``).
+   * - ``--logsheet-config PATH``
+     - path
+     - ``{config-dir}/logsheet_config.yaml``
+     - Explicit path to the logsheet YAML (overrides ``--config-dir``).
+   * - ``--output-dir DIR``
+     - path
+     - ``./logsheets/``
+     - Directory where PDF (or TeX) files are written.
+   * - ``--format {pdf,tex}``
+     - string
+     - ``pdf``
+     - Output format: compile to PDF (requires ``pdflatex``) or write LaTeX
+       source only.
+   * - ``--all``
+     - flag
+     - off
+     - Generate all sheet types for every cast and mooring listed in
+       ``logsheet_config.yaml``.
+   * - ``--proc-dir DIR``
+     - path
+     - (required for mooring sheets)
+     - Cruise-level processed data directory (used to locate mooring YAMLs).
 
 **Examples**
 
-Summary and per-instrument pages:
+Caldip setup sheet for cast B1:
 
 .. code-block:: bash
 
-   oceanarray report dsG3_1_2026 --raw-dir /data/raw --proc-dir /data/proc --instruments
+   oceanarray logsheet --type caldip-setup --cast B1 \
+       --config-dir config/ --proc-dir /data/proc
 
-All report types:
+Mooring recovery log:
 
 .. code-block:: bash
 
-   oceanarray report dsG3_1_2026 --raw-dir /data/raw --proc-dir /data/proc --instruments --stack --grid
+   oceanarray logsheet --type mooring-recovery --mooring dsG3_1_2026 \
+       --config-dir config/ --proc-dir /data/proc
+
+All sheets for every cast and mooring:
+
+.. code-block:: bash
+
+   oceanarray logsheet --all --config-dir config/ --proc-dir /data/proc
+
+----
+
+``oceanarray list``
+--------------------
+
+Print a reference table of allowed ``instrument:`` and ``file_type:`` values
+for mooring YAML configuration.  Use this to look up the correct reader name
+for a given instrument type, or to check which ``instrument:`` values are
+recognised.
+
+Does not require a mooring name, ``--raw-dir``, or ``--proc-dir``.
+
+**Synopsis**
+
+.. code-block:: text
+
+   oceanarray list
+
+**Example**
+
+.. code-block:: bash
+
+   oceanarray list
 
 ----
 

--- a/docs/source/directory_structure.rst
+++ b/docs/source/directory_structure.rst
@@ -129,35 +129,6 @@ for a full description of the YAML fields and a minimal working example.
 File naming conventions
 -----------------------
 
-All output files use the mooring name and, where applicable, the instrument
-serial number from the YAML.  The naming convention is:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 35 65
-
-   * - File
-     - Description
-   * - ``{mooring}_{serial}_stage1.nc``
-     - Raw-faithful CF-NetCDF; no QC applied
-   * - ``{mooring}_{serial}_stage2.nc``
-     - Trimmed to deployment window; clock correction applied
-   * - ``{mooring}_{serial}_stage3.nc``
-     - QC flags added; derived variables (e.g. salinity); Aquadopp velocity in
-       earth coordinates; magnetic declination correction applied
-   * - ``{mooring}_stack.nc``
-     - All instruments resampled onto a common 60-second time grid and stacked
-       into a single file with a depth dimension
-   * - ``{mooring}_grid.nc``
-     - Stack file interpolated onto a regular pressure grid
-   * - ``{mooring}_{timestamp}_{stage}.mooring.log``
-     - Processing log for one run of one stage; timestamp format is
-       ``YYYYMMDD_HHMMSS``
-   * - ``{mooring}_report.html``
-     - HTML summary report for the whole mooring
-   * - ``{mooring}_{serial}_report.html``
-     - Per-instrument HTML report
-
-The ``{serial}`` component uses the value of the ``serial`` field in the
-YAML instrument entry.  If the serial contains a trailing ``*`` (used in
-some instrument identifiers), the ``*`` is stripped from the filename.
+See :doc:`file_naming_conventions` for the full reference, including both raw
+instrument file names (mooring recovery vs calibration-dip conventions) and
+processed output file names (stage NC files, stack, grid, reports, logs).

--- a/docs/source/file_naming_conventions.rst
+++ b/docs/source/file_naming_conventions.rst
@@ -1,0 +1,126 @@
+.. _file_naming_conventions:
+
+==============================
+File Naming Conventions
+==============================
+
+This page covers two sets of naming conventions:
+
+1. **Raw instrument files** — files downloaded from the instruments at sea, whose
+   names are fixed (or conventionally chosen) at the time of download.
+2. **Processed output files** — NetCDF, log, and report files written by
+   ``oceanarray``.
+
+----
+
+Raw instrument files
+--------------------
+
+Instruments are downloaded twice per deployment cycle: once during a
+calibration-dip (caldip) cast and once at mooring recovery.  UHH uses the
+following filename conventions for the downloaded data files.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Context
+     - Filename pattern
+   * - Mooring recovery download
+     - ``{serial}_recovery.<ext>``
+   * - Caldip cast download
+     - ``{serial}_cal_dip_data.<ext>``
+
+where ``{serial}`` is the instrument serial number and ``<ext>`` depends on
+the instrument type and firmware:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Instrument
+     - Extension(s)
+     - Notes
+   * - SBE MicroCAT (old Seaterm)
+     - ``.asc``
+     - firmware below the ``microcat_firmware_sentinel`` in
+       ``logsheet_config.yaml``
+   * - SBE MicroCAT (SeatermV2)
+     - ``.xml``
+     - firmware at or above the sentinel, or any MicroCAT with dissolved oxygen
+   * - Nortek Aquadopp
+     - ``.aqd``, ``.hdr``, ``.sen``, ``.prf``
+     - all four files are downloaded together; ``filename:`` in the YAML
+       points to the ``.aqd`` file
+   * - RBR soloT / RBRduet
+     - ``.rsk``
+     - RSK SQLite database downloaded via Ruskin
+   * - RBR TR-1050
+     - ``.hex``
+     - hex format
+   * - RDI WorkHorse ADCP
+     - ``.000``, ``.001``, …
+     - binary raw files; ``filename:`` points to the first file
+
+These conventions are recorded in the ``filename_conventions:`` section of
+``logsheet_config.yaml`` and are used by ``oceanarray logsheet`` to pre-fill
+expected filenames on the download logsheets.
+
+----
+
+Processed output files
+----------------------
+
+All output files use the mooring name and, where applicable, the instrument
+serial number from the YAML.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 38 62
+
+   * - File
+     - Description
+   * - ``{mooring}_{serial}_stage1.nc``
+     - Raw-faithful CF-NetCDF; no QC applied
+   * - ``{mooring}_{serial}_stage2.nc``
+     - Trimmed to deployment window; clock correction applied
+   * - ``{mooring}_{serial}_stage3.nc``
+     - QC flags added; derived variables (e.g. salinity); Aquadopp velocity in
+       earth coordinates; magnetic declination correction applied
+   * - ``{mooring}_stack.nc``
+     - All instruments resampled onto a common time grid and stacked into a
+       single file ordered by depth
+   * - ``{mooring}_grid.nc``
+     - Stack file interpolated onto a regular pressure grid
+   * - ``{mooring}_{timestamp}_{stage}.mooring.log``
+     - Processing log for one run of one stage; timestamp format is
+       ``YYYYMMDD_HHMMSS``
+   * - ``{mooring}_report.html``
+     - HTML summary report for the whole mooring
+   * - ``{mooring}_stack_report.html``
+     - HTML report for the stacked dataset
+   * - ``{mooring}_grid_report.html``
+     - HTML report for the gridded dataset
+   * - ``{mooring}_{serial}_report.html``
+     - Per-instrument HTML report
+
+The ``{serial}`` component uses the value of the ``serial`` field in the
+YAML instrument entry.  If the serial contains a trailing ``*`` (used in
+some instrument identifiers), the ``*`` is stripped from the filename.
+
+The ``{mooring}`` component is the value of the ``name`` field at the top
+of the mooring YAML, which must also match the directory name under
+``{proc_dir}`` and the YAML filename itself::
+
+   {proc_dir}/{mooring}/{mooring}.mooring.yaml
+
+----
+
+See also
+--------
+
+- :doc:`directory_structure` — where these files live on disk
+- :doc:`yaml_configuration` — YAML fields that control filenames (``name:``,
+  ``serial:``, ``filename:``)
+- :doc:`logsheets` — how ``logsheet_config.yaml`` filename conventions connect
+  raw-file naming to the logsheet workflow

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,44 +28,50 @@ Contents
 
    quickstart
    installation <setup>
-   directory_structure
-   yaml_configuration
-   cli_reference
-   migration
-   reports
+
 
 .. toctree::
    :maxdepth: 2
    :caption: Processing framework
 
    processing_framework
+   reports
+   cli_reference
+   directory_structure
+   yaml_configuration
+   file_naming_conventions
 
 .. toctree::
    :maxdepth: 1
-   :caption: Methods — instruments
+   :caption: Stage 1 2 3 - Instrument
 
-   Data Acquisition <methods/acquisition>
-   Standardisation (Stage 1) <methods/standardisation>
-   Clock Offset Analysis <clock_offset>
-   Trim to Deployment (Stage 2) <methods/trimming>
-   Automatic QC (Stage 3) <methods/auto_qc>
-   Coordinate Transform (Nortek) <methods/nortek_coordinate_transform>
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Methods — moorings
-
-   Grid in Time (Stack) <methods/time_gridding>
-   Grid Vertically <methods/vertical_gridding>
+   0. Data Acquisition <methods/acquisition>
+   1. Standardisation <methods/standardisation>
+   2. Clock Offset Analysis (optional) <clock_offset>
+   2. Trim to Deployment   <methods/trimming>
+   3. Automatic QC  <methods/auto_qc>
+   3. Apply Calibration  <methods/calibration>
+   3. Coordinate Transform   <methods/nortek_coordinate_transform>
 
 .. toctree::
    :maxdepth: 1
-   :caption: Methods — planned
+   :caption: Stack & Grid - Moorings
 
-   Apply Calibration (Stage 3.5) <methods/calibration>
-   Convert to OceanSITES (Stage 4) <methods/conversion>
-   Combine Deployments <methods/concatenation>
-   Multi-site Merging <methods/multisite_merging>
+   Stack into one NetCDF <methods/time_gridding>
+   Grid onto pressure <methods/vertical_gridding>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Logsheets
+
+   Fieldwork Logsheets <logsheets>
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Caldips
+
+   Calibration dips <calibration_dips>
 
 .. toctree::
    :maxdepth: 1
@@ -73,13 +79,23 @@ Contents
 
    GitHub Repo <https://github.com/ocean-uhh/oceanarray>
    Python API <oceanarray>
+   project_structure
+   migration
+
+
    oceanarray_format
    OceanSITES manual <oceanSITES_manual>
-   Calibration dips <calibration_dips>
-   project_structure
-   style_guide
-   roadmap
    Legacy modules <legacy>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Development
+
+   roadmap
+   style_guide
+   Convert to OceanSITES (Stage 4) <methods/conversion>
+   Combine Deployments <methods/concatenation>
+   Multi-site Merging <methods/multisite_merging>
 
 
 Indices and Tables

--- a/docs/source/logsheets.rst
+++ b/docs/source/logsheets.rst
@@ -1,0 +1,223 @@
+
+Fieldwork Logsheets
+===================
+
+``logsheet`` generates PDF logsheets for mooring fieldwork operations.
+There are five sheet types covering two contexts:
+
+* **Mooring work** — setting up instruments before deployment, and downloading
+  data after recovery.
+* **Calibration-dip (caldip) casts** — setting up instruments on the CTD rosette
+  before a dip, and downloading data afterwards.
+
+Both contexts use the same instrument registry and the same command.
+
+.. note::
+
+   PDF output requires ``pdflatex`` to be installed (e.g. via TeX Live or MiKTeX).
+   Use ``--format tex`` to produce LaTeX source only if pdflatex is not available.
+
+----
+
+Sheet types
+-----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Type
+     - When it is used
+   * - ``caldip-setup``
+     - Per-instrument setup instructions for a calibration-dip cast: sampling
+       interval, firmware-specific commands (SeatermV2 vs old Seaterm), and a
+       column for recording the pre-cast clock offset.
+   * - ``caldip-download``
+     - Per-instrument download checklist for a calibration-dip cast: expected
+       filename, download steps by firmware group, and a column for recording
+       the post-cast clock offset.
+   * - ``mooring-download``
+     - Per-instrument download checklist for mooring recovery: expected filenames
+       (from filename conventions in ``logsheet_config.yaml``), download steps,
+       and a column for the clock offset and recovery notes.
+   * - ``mooring-recovery``
+     - Mooring recovery log: one row per instrument with serial number, HAB,
+       position, and columns for the operator to record clock times and
+       condition notes.
+   * - ``mooring-setup``
+     - Mooring deployment setup log: one row per instrument with serial number,
+       HAB, target position, and columns for the operator to record final
+       setup settings and clock synchronisation.
+
+----
+
+Configuration files
+-------------------
+
+Two user-supplied YAML files are required.  Point to the directory containing
+both with ``--config-dir``.
+
+``logsheet_config.yaml``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cruise-level settings: ship name, paths, filename conventions, and the lists of
+casts and moorings to process.  A minimal example::
+
+    cruise: OdB2026
+    ship: Odon de Buen
+    cast_prefix: B
+
+    paths:
+      caldip_data: ~/data/proc_calib
+      raw_data: ~/data/raw
+
+    microcat_firmware_sentinel: "3.0d"
+
+    filename_conventions:
+      microcat:
+        caldip_old_seaterm:   "{default_filename}_cal_dip_data.asc"
+        caldip_seaterm_v2:    "{default_filename}_cal_dip_data.xml"
+        download_old_seaterm: "{default_filename}_recovery.asc"
+        download_seaterm_v2:  "{default_filename}_recovery.xml"
+      aquadopp:
+        caldip:   "{default_filename}_cal_dip_data.*"
+        download: "{default_filename}_recovery.*"
+
+    casts:
+      B1:
+        microcat_serials:    [26269, 5367, 2942, 3026, 2941, 7507, 25586]
+        aquadopp_serials:    [14321, 14284, 9920]
+        rbrsolo_serials:     [240231, 240230, 240234]
+        tr1050_serials:      []
+
+    moorings_to_recover:    [dsG3_1_2026, dsK3_1_2026]
+    moorings_to_deploy:     [dsG3_2_2026, dsK3_2_2026]
+
+**Firmware sentinel** (``microcat_firmware_sentinel``): MicroCATs with firmware
+version strictly below this string use the old Seaterm (9600 baud, ``.asc``
+output); those at or above it use SeatermV2 (38400 baud, ``.xml`` output).
+Version strings like ``"3.0h"`` compare correctly.  MicroCATs with an oxygen
+sensor (``odo: true``) always use the SeatermV2 path regardless of firmware.
+
+**Filename conventions**: ``{default_filename}`` is replaced with the default
+filename the instrument uses (serial-based); ``{serial}`` is the integer serial
+number.
+
+``instrument_inventory.csv``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lab instrument registry: one row per instrument, with columns for type, serial,
+model, firmware, and capability flags::
+
+    type,serial,model,owner,firmware,file_type,pumped,pressure,odo,depth_rating_m,sint_s
+    microcat,26269,SBE37SMP-p,UHH,6.3.2,sbe-hex,true,true,false,7000,
+    microcat,2941,SBE37SM,UHH,2.6b,sbe-ascii,false,false,false,7000,
+    aquadopp,9920,Aquadopp,UHH,,nortek-ascii,,,,,
+    rbrsolo,240231,RBRsolo³ T,UHH,,,,,,,2
+
+The ``type`` column values (``microcat``, ``aquadopp``, ``rbrsolo``,
+``tr1050``, ``adcp``) match the ``instrument:`` field in mooring YAMLs.
+
+The ``file_type`` column records the seasenselib reader used by ``oceanarray
+process --stage 1``:
+
+- ``sbe-ascii`` — SBE MicroCAT with firmware < 6000 (old Seaterm)
+- ``sbe-hex`` — SBE MicroCAT with firmware ≥ 6000 (SeatermV2 hex output)
+- ``nortek-ascii`` — Aquadopp serial < 400000
+- ``nortek-csv`` — Aquadopp serial ≥ 400000 (newer firmware)
+- ``rbr-rsk`` — RBR soloT (rbrsolo)
+- ``rbr-hex`` — RBR TR-1050 (tr1050)
+- ``rdi-raw`` — RDI WorkHorse ADCP
+
+Missing serials are flagged with a red warning box printed at the top of the
+logsheet so the operator does not miss them.
+
+----
+
+Usage
+-----
+
+Generate a single sheet type::
+
+    # Cal-dip setup for cast B1
+    oceanarray logsheet --type caldip-setup --cast B1 \
+        --config-dir config/ \
+        --proc-dir /data/proc
+
+    # Cal-dip download for cast B1
+    oceanarray logsheet --type caldip-download --cast B1 \
+        --config-dir config/
+
+    # Mooring recovery download sheet
+    oceanarray logsheet --type mooring-download --mooring dsG3_1_2026 \
+        --config-dir config/ \
+        --proc-dir /data/proc
+
+    # Mooring recovery log
+    oceanarray logsheet --type mooring-recovery --mooring dsG3_1_2026 \
+        --config-dir config/ \
+        --proc-dir /data/proc
+
+    # Mooring deployment setup
+    oceanarray logsheet --type mooring-setup --mooring dsG3_2_2026 \
+        --config-dir config/ \
+        --proc-dir /data/proc
+
+Generate all sheets for every cast and mooring listed in ``logsheet_config.yaml``::
+
+    oceanarray logsheet --all --config-dir config/ --proc-dir /data/proc
+
+Output goes to ``./logsheets/`` by default.  Change with ``--output-dir``::
+
+    oceanarray logsheet --type mooring-recovery --mooring dsG3_1_2026 \
+        --config-dir config/ \
+        --proc-dir /data/proc \
+        --output-dir /data/fieldwork/logsheets/
+
+Produce LaTeX source instead of compiling to PDF::
+
+    oceanarray logsheet --type caldip-setup --cast B1 \
+        --config-dir config/ \
+        --format tex
+
+----
+
+Directory layout
+----------------
+
+A typical cruise config directory::
+
+    config/
+    ├── logsheet_config.yaml        # ship, paths, casts, moorings
+    └── instrument_inventory.csv    # lab instrument registry
+
+PDFs are written alongside the processed data::
+
+    logsheets/
+    ├── dsG3_1_2026_recovery.pdf
+    ├── dsG3_1_2026_mooring_download.pdf
+    ├── castB1_caldip_setup.pdf
+    └── castB1_caldip_download.pdf
+
+----
+
+Mooring YAML requirement
+------------------------
+
+For mooring sheets (``mooring-recovery``, ``mooring-download``, ``mooring-setup``),
+the mooring YAML must exist at::
+
+    {proc-dir}/{mooring}/{mooring}.mooring.yaml
+
+This is the standard location written by ``oceanarray process``.  The logsheet
+builder reads the instrument list (``clamp:`` section) from this file to
+populate the sheet rows.
+
+----
+
+See also
+--------
+
+- :doc:`yaml_configuration` — mooring YAML format reference
+- :doc:`calibration_dips` — caldip processing workflow
+- :doc:`cli_reference` — full CLI flag reference

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -2,7 +2,8 @@
 
 ## Requirements
 
-Python 3.10 or later is required.
+Python 3.10–3.12 is recommended.  Python 3.13+ has not been tested with all
+dependencies and is not recommended for production use.
 
 ## Install oceanarray
 

--- a/oceanarray/__init__.py
+++ b/oceanarray/__init__.py
@@ -7,6 +7,7 @@ of oceanographic time series data from moorings and instruments.
 __all__ = [
     "clock_offset",
     "detect_deployment_window",
+    "logsheets",
     "plotters",
     "readers",
     "stage1",

--- a/oceanarray/cli.py
+++ b/oceanarray/cli.py
@@ -640,6 +640,92 @@ def cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_logsheet(args: "argparse.Namespace") -> int:
+    """Generate fieldwork logsheet PDFs for a mooring or cal-dip cast.
+
+    Reads ``cruise_config.yaml`` and ``instruments.yaml`` from ``--config-dir``,
+    or supply paths directly via ``--logsheet-config`` and ``--inventory``.
+    Mooring YAMLs are located via ``--proc-dir`` or ``mooring_yaml_map`` in
+    ``cruise_config.yaml``.
+    """
+    import sys
+    from pathlib import Path
+    from .logsheets import (
+        build_caldip_setup,
+        build_caldip_download,
+        build_recovery,
+        build_mooring_download,
+        build_deployment_setup,
+    )
+    from .logsheets._config import resolve_config, load_yaml
+
+    config_dir = Path(args.logsheet_config_dir) if args.logsheet_config_dir else None
+    inventory_path = Path(args.logsheet_inventory) if args.logsheet_inventory else None
+    logsheet_config_path = Path(args.logsheet_config) if args.logsheet_config else None
+    output_dir = Path(args.logsheet_output_dir)
+    _, proc_root, _ = _parse_dirs(args)
+
+    cfg = resolve_config(
+        config_dir=config_dir,
+        inventory_path=inventory_path,
+        logsheet_config_path=logsheet_config_path,
+        output_dir=output_dir,
+        proc_dir=proc_root,
+    )
+    fmt = args.logsheet_format
+
+    if args.logsheet_all:
+        if not cfg.cruise_config_path.exists():
+            print(
+                "Error: --all requires cruise_config.yaml; "
+                "provide --logsheet-config or --config-dir",
+                file=sys.stderr,
+            )
+            return 1
+        cruise_cfg = load_yaml(cfg.cruise_config_path)
+        for cast_id in cruise_cfg.get("casts", {}):
+            _status("section", f"caldip-setup {cast_id}")
+            build_caldip_setup(cast_id, cfg, fmt=fmt)
+            _status("section", f"caldip-download {cast_id}")
+            build_caldip_download(cast_id, cfg, fmt=fmt)
+        for mooring in cruise_cfg.get("moorings_to_recover", []):
+            _status("section", f"mooring-download {mooring}")
+            build_mooring_download(mooring, cfg, fmt=fmt)
+            _status("section", f"mooring-recovery {mooring}")
+            build_recovery(mooring, cfg, fmt=fmt)
+        for mooring in cruise_cfg.get("moorings_to_deploy", []):
+            _status("section", f"mooring-setup {mooring}")
+            build_deployment_setup(mooring, cfg, fmt=fmt)
+        return 0
+
+    ltype = args.logsheet_type
+    if not ltype:
+        print("Error: --type is required (or use --all)", file=sys.stderr)
+        return 1
+
+    if ltype in ("caldip-setup", "caldip-download"):
+        if not args.logsheet_cast:
+            print(f"Error: --cast is required for --type {ltype}", file=sys.stderr)
+            return 1
+        if ltype == "caldip-setup":
+            build_caldip_setup(args.logsheet_cast, cfg, fmt=fmt)
+        else:
+            build_caldip_download(args.logsheet_cast, cfg, fmt=fmt)
+
+    elif ltype in ("mooring-download", "mooring-recovery", "mooring-setup"):
+        if not args.logsheet_mooring:
+            print(f"Error: --mooring is required for --type {ltype}", file=sys.stderr)
+            return 1
+        if ltype == "mooring-download":
+            build_mooring_download(args.logsheet_mooring, cfg, fmt=fmt)
+        elif ltype == "mooring-recovery":
+            build_recovery(args.logsheet_mooring, cfg, fmt=fmt)
+        else:
+            build_deployment_setup(args.logsheet_mooring, cfg, fmt=fmt)
+
+    return 0
+
+
 def _add_dir_args(p: "argparse.ArgumentParser", raw_needed: bool = True) -> None:
     """Add directory arguments to a subparser.
 
@@ -1081,6 +1167,92 @@ def build_parser() -> argparse.ArgumentParser:
         help="Filter output: 'instruments' or 'file-types' (default: show both).",
     )
     p_list.set_defaults(func=cmd_list)
+
+    p_logsheet = sub.add_parser(
+        "logsheet",
+        help="Generate fieldwork logsheet PDFs (recovery, download, deployment, cal-dip).",
+        description=(
+            "Generate PDF or LaTeX logsheets for mooring fieldwork operations. "
+            "Supply --config-dir (pointing to a directory with cruise_config.yaml "
+            "and instruments.yaml), or pass --logsheet-config and --inventory directly. "
+            "LaTeX templates and column definitions are bundled with the package."
+        ),
+    )
+    p_logsheet.add_argument(
+        "--type",
+        dest="logsheet_type",
+        metavar="TYPE",
+        choices=[
+            "caldip-setup",
+            "caldip-download",
+            "mooring-download",
+            "mooring-recovery",
+            "mooring-setup",
+        ],
+        help=(
+            "Sheet type: caldip-setup, caldip-download, mooring-download, "
+            "mooring-recovery, mooring-setup."
+        ),
+    )
+    p_logsheet.add_argument(
+        "--mooring",
+        dest="logsheet_mooring",
+        metavar="MOORING",
+        help="Mooring name, e.g. dsG3_1_2026 (required for mooring sheet types).",
+    )
+    p_logsheet.add_argument(
+        "--cast",
+        dest="logsheet_cast",
+        metavar="CAST",
+        help="Cast ID, e.g. B1 (required for caldip sheet types).",
+    )
+    p_logsheet.add_argument(
+        "--config-dir",
+        dest="logsheet_config_dir",
+        metavar="DIR",
+        help=(
+            "Directory containing cruise_config.yaml and instruments.yaml. "
+            "Shorthand for --logsheet-config DIR/cruise_config.yaml "
+            "--inventory DIR/instruments.yaml."
+        ),
+    )
+    p_logsheet.add_argument(
+        "--inventory",
+        dest="logsheet_inventory",
+        metavar="PATH",
+        help="Path to instruments.yaml (or instrument_inventory.csv).",
+    )
+    p_logsheet.add_argument(
+        "--logsheet-config",
+        dest="logsheet_config",
+        metavar="PATH",
+        help=(
+            "Path to cruise_config.yaml. Optional; paths/filenames left blank "
+            "on the sheet if absent."
+        ),
+    )
+    p_logsheet.add_argument(
+        "--output-dir",
+        dest="logsheet_output_dir",
+        metavar="DIR",
+        default="logsheets",
+        help="Directory where PDFs are written (default: ./logsheets/).",
+    )
+    p_logsheet.add_argument(
+        "--format",
+        dest="logsheet_format",
+        choices=["pdf", "tex"],
+        default="pdf",
+        help="Output format: pdf (compile via pdflatex) or tex (LaTeX source only).",
+    )
+    p_logsheet.add_argument(
+        "--all",
+        action="store_true",
+        dest="logsheet_all",
+        help="Generate all sheet types for every cast and mooring in cruise_config.yaml.",
+    )
+    _add_dir_args(p_logsheet, raw_needed=False)
+    p_logsheet.set_defaults(func=cmd_logsheet)
 
     return parser
 

--- a/oceanarray/cli.py
+++ b/oceanarray/cli.py
@@ -663,7 +663,9 @@ def cmd_logsheet(args: "argparse.Namespace") -> int:
     inventory_path = Path(args.logsheet_inventory) if args.logsheet_inventory else None
     logsheet_config_path = Path(args.logsheet_config) if args.logsheet_config else None
     output_dir = Path(args.logsheet_output_dir)
-    _, proc_root, _ = _parse_dirs(args)
+    # proc_dir is optional for logsheets — caldip sheets don't need it
+    _pd = getattr(args, "proc_dir", None)
+    proc_root = Path(_pd) if _pd else None
 
     cfg = resolve_config(
         config_dir=config_dir,
@@ -698,30 +700,45 @@ def cmd_logsheet(args: "argparse.Namespace") -> int:
             build_deployment_setup(mooring, cfg, fmt=fmt)
         return 0
 
-    ltype = args.logsheet_type
-    if not ltype:
+    ltypes: list[str] = args.logsheet_type or []
+    if not ltypes:
         print("Error: --type is required (or use --all)", file=sys.stderr)
         return 1
 
-    if ltype in ("caldip-setup", "caldip-download"):
-        if not args.logsheet_cast:
-            print(f"Error: --cast is required for --type {ltype}", file=sys.stderr)
+    # Resolve caldip YAML once for all caldip sheet types in this call.
+    caldip_yaml = None
+    cast_val = args.logsheet_cast or ""
+    if any(t in ("caldip-setup", "caldip-download") for t in ltypes):
+        if not cast_val:
+            print("Error: --cast is required for caldip sheet types", file=sys.stderr)
             return 1
-        if ltype == "caldip-setup":
-            build_caldip_setup(args.logsheet_cast, cfg, fmt=fmt)
-        else:
-            build_caldip_download(args.logsheet_cast, cfg, fmt=fmt)
+        cast_path = Path(cast_val)
+        if cast_path.suffix.lower() == ".yaml":
+            if not cast_path.exists():
+                print(f"Error: caldip YAML not found: {cast_val}", file=sys.stderr)
+                return 1
+            caldip_yaml = load_yaml(cast_path)
 
-    elif ltype in ("mooring-download", "mooring-recovery", "mooring-setup"):
-        if not args.logsheet_mooring:
-            print(f"Error: --mooring is required for --type {ltype}", file=sys.stderr)
-            return 1
-        if ltype == "mooring-download":
-            build_mooring_download(args.logsheet_mooring, cfg, fmt=fmt)
-        elif ltype == "mooring-recovery":
-            build_recovery(args.logsheet_mooring, cfg, fmt=fmt)
-        else:
-            build_deployment_setup(args.logsheet_mooring, cfg, fmt=fmt)
+    for ltype in ltypes:
+        if ltype in ("caldip-setup", "caldip-download"):
+            if ltype == "caldip-setup":
+                build_caldip_setup(cast_val, cfg, fmt=fmt, caldip_yaml=caldip_yaml)
+            else:
+                build_caldip_download(cast_val, cfg, fmt=fmt, caldip_yaml=caldip_yaml)
+
+        elif ltype in ("mooring-download", "mooring-recovery", "mooring-setup"):
+            if not args.logsheet_mooring:
+                print(
+                    f"Error: --mooring is required for --type {ltype}",
+                    file=sys.stderr,
+                )
+                return 1
+            if ltype == "mooring-download":
+                build_mooring_download(args.logsheet_mooring, cfg, fmt=fmt)
+            elif ltype == "mooring-recovery":
+                build_recovery(args.logsheet_mooring, cfg, fmt=fmt)
+            else:
+                build_deployment_setup(args.logsheet_mooring, cfg, fmt=fmt)
 
     return 0
 
@@ -1182,6 +1199,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--type",
         dest="logsheet_type",
         metavar="TYPE",
+        nargs="+",
         choices=[
             "caldip-setup",
             "caldip-download",
@@ -1190,8 +1208,9 @@ def build_parser() -> argparse.ArgumentParser:
             "mooring-setup",
         ],
         help=(
-            "Sheet type: caldip-setup, caldip-download, mooring-download, "
-            "mooring-recovery, mooring-setup."
+            "Sheet type(s): caldip-setup, caldip-download, mooring-download, "
+            "mooring-recovery, mooring-setup.  Pass multiple values to generate "
+            "several sheets in one call, e.g. --type caldip-setup caldip-download."
         ),
     )
     p_logsheet.add_argument(

--- a/oceanarray/logsheets/__init__.py
+++ b/oceanarray/logsheets/__init__.py
@@ -1,0 +1,60 @@
+"""oceanarray.logsheets
+=====================
+Generate fieldwork logsheet PDFs from mooring YAML configuration files.
+
+Bundled defaults
+----------------
+``column_defs.yaml`` and LaTeX templates are bundled with the package.
+Users do **not** need to supply these.
+
+User-supplied config (``--config-dir``)
+----------------------------------------
+- ``cruise_config.yaml`` — cruise metadata, casts list, moorings to recover/deploy,
+  filename conventions, paths.
+- ``instruments.yaml`` — lab instrument registry (serial → model, firmware, owner).
+
+Optionally, place a ``column_defs.yaml`` or ``latex_templates/`` directory in
+``--config-dir`` to override the bundled defaults.
+
+Mooring YAMLs
+-------------
+Each builder looks up the mooring YAML via:
+
+1. ``cruise_config.yaml → mooring_yaml_map`` (explicit path mapping), then
+2. ``{proc_dir}/{mooring}/{mooring}.mooring.yaml`` (oceanarray convention).
+
+Example:
+-------
+::
+
+    from oceanarray.logsheets import build_recovery
+    from oceanarray.logsheets._config import resolve_config
+    from pathlib import Path
+
+    cfg = resolve_config(
+        config_dir=Path("/data/OdB2026/logsheets_config"),
+        output_dir=Path("/data/OdB2026/logsheets_output"),
+        proc_dir=Path("/data/OdB2026/proc"),
+    )
+    build_recovery("dsG3_1_2026", cfg, fmt="tex")
+
+"""
+
+from ._config import LogsheetsConfig, resolve_config
+from .builders import (
+    build_caldip_setup,
+    build_caldip_download,
+    build_recovery,
+    build_mooring_download,
+    build_deployment_setup,
+)
+
+__all__ = [
+    "LogsheetsConfig",
+    "resolve_config",
+    "build_caldip_setup",
+    "build_caldip_download",
+    "build_recovery",
+    "build_mooring_download",
+    "build_deployment_setup",
+]

--- a/oceanarray/logsheets/_columns.py
+++ b/oceanarray/logsheets/_columns.py
@@ -1,0 +1,97 @@
+"""oceanarray.logsheets._columns
+================================
+Column resolution from the ``column_library``, download-convention
+substitution, and data-path note formatting.
+"""
+
+from ._latex import tex_safe
+
+
+def resolve_columns(col_list: list, col_library: dict) -> list[dict]:
+    """Resolve a raw column list from ``column_defs.yaml`` into full column dicts.
+
+    Each item in *col_list* may be:
+
+    - **plain string** — a key in *col_library*, used as-is.
+    - **{key: {overrides}}** — library key with field overrides.
+    - **{header: …, width: …, input: …}** — inline full definition.
+
+    Parameters
+    ----------
+    col_list:
+        Raw list loaded directly from YAML.
+    col_library:
+        The ``column_library`` section from ``column_defs.yaml``.
+
+    """
+    result = []
+    for item in col_list:
+        if isinstance(item, str):
+            col = col_library.get(item, {}).copy()
+            if not col:
+                print(f"  Warning: column key '{item}' not in column_library")
+            result.append(col)
+        elif isinstance(item, dict):
+            if "header" in item:
+                result.append(item.copy())
+            else:
+                key = next(iter(item))
+                overrides = item[key] or {}
+                col = col_library.get(key, {}).copy()
+                if not col:
+                    print(f"  Warning: column key '{key}' not in column_library")
+                if overrides:
+                    col.update(overrides)
+                result.append(col)
+    return result
+
+
+def apply_download_convention(cols: list[dict], convention: str) -> list[dict]:
+    """Return a copy of *cols* with ``{download_convention}`` in headers replaced."""
+    result = []
+    for col in cols:
+        col = col.copy()
+        if "{download_convention}" in col.get("header", ""):
+            col["header"] = col["header"].replace("{download_convention}", convention)
+        result.append(col)
+    return result
+
+
+def format_data_path_note(
+    note_raw: str,
+    raw_data: str = "",
+    mooring: str = "",
+    caldip_data: str = "",
+    cast_label: str = "",
+    instrument: str = "",
+    download_convention: str = "",
+) -> list[str]:
+    """Substitute path placeholders in a ``data_path_note`` string.
+
+    ``{instrument}`` and ``{mooring}`` are rendered bold in the PDF.
+
+    Returns
+    -------
+    list[str]
+        One LaTeX-escaped string per non-blank line.
+
+    """
+    if not note_raw:
+        return []
+    s = note_raw.strip()
+    s = s.replace("{raw_data}", raw_data)
+    s = s.replace("{caldip_data}", caldip_data)
+    s = s.replace("{cast_label}", cast_label)
+    s = s.replace("{download_convention}", download_convention)
+
+    _B_MOORING = "\x00MOORING\x00"
+    _B_INSTRUMENT = "\x00INSTRUMENT\x00"
+    s = s.replace("{mooring}", _B_MOORING)
+    s = s.replace("{instrument}", _B_INSTRUMENT)
+
+    s = tex_safe(s)
+
+    s = s.replace(_B_MOORING, r"\textbf{" + tex_safe(mooring) + r"}")
+    s = s.replace(_B_INSTRUMENT, r"\textbf{" + tex_safe(instrument) + r"}")
+
+    return [ln for ln in s.split("\n") if ln.strip()]

--- a/oceanarray/logsheets/_config.py
+++ b/oceanarray/logsheets/_config.py
@@ -17,6 +17,7 @@ Mooring YAMLs are resolved from the oceanarray proc directory
 
 from __future__ import annotations
 
+import csv
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -131,18 +132,62 @@ def load_yaml(path: Path) -> dict:
         return yaml.safe_load(fh)
 
 
+def _parse_csv_value(val: str) -> object:
+    """Convert a raw CSV string to a Python scalar.
+
+    * ``"true"`` / ``"false"`` (case-insensitive) → ``bool``
+    * Empty string → ``None``
+    * Anything else → left as ``str``
+
+    Integers and floats are intentionally left as strings so that firmware
+    version strings like ``"3.0h"`` or serial suffixes are never miscast.
+    """
+    stripped = val.strip()
+    lower = stripped.lower()
+    if lower == "true":
+        return True
+    if lower == "false":
+        return False
+    if lower == "":
+        return None
+    return stripped
+
+
 def load_instruments(cfg: LogsheetsConfig) -> dict:
     """Return the instrument registry keyed by ``(type_str, serial_int)``.
 
-    Reads ``instrument_inventory.csv`` (or legacy ``instruments.yaml``) from
-    the user-supplied config directory.  Example key: ``("microcat", 7507)``.
+    Reads ``instrument_inventory.csv`` or legacy ``instruments.yaml``.
+    CSV files are detected by a ``.csv`` suffix; everything else is treated as
+    YAML.  Boolean-string fields (``"true"``/``"false"``) in CSV rows are
+    converted to Python ``bool`` so that checks like ``entry.get("odo")``
+    behave correctly.  Example key: ``("microcat", 7507)``.
     """
-    raw = load_yaml(cfg.instruments_path)
+    path = cfg.instruments_path
     lookup = {}
-    for itype, entries in raw.items():
-        for entry in entries:
-            sn = entry["serial"]
-            lookup[(itype, sn)] = entry
+    if path.suffix.lower() == ".csv":
+        with open(path, newline="") as fh:
+            for row in csv.DictReader(fh):
+                itype = row.get("type", "").strip()
+                serial_str = row.get("serial", "").strip()
+                if not itype or not serial_str:
+                    continue
+                try:
+                    sn = int(serial_str)
+                except ValueError:
+                    continue
+                entry = {
+                    k: _parse_csv_value(v)
+                    for k, v in row.items()
+                    if k not in ("type", "serial")
+                }
+                entry["serial"] = sn
+                lookup[(itype, sn)] = entry
+    else:
+        raw = load_yaml(path)
+        for itype, entries in raw.items():
+            for entry in entries:
+                sn = entry["serial"]
+                lookup[(itype, sn)] = entry
     return lookup
 
 
@@ -167,7 +212,7 @@ def sn_to_entry(instruments: dict, sn: int) -> tuple[str, dict]:
         If the serial number is not found in any type.
 
     """
-    for itype in ("microcat", "aquadopp", "tr1050", "rbrsolo", "adcp"):
+    for itype in ("microcat", "aquadopp", "tr1050", "rbrsolo", "rbrduet", "adcp"):
         if (itype, sn) in instruments:
             return itype, instruments[(itype, sn)]
     raise KeyError(f"SN {sn} not found in instrument_inventory.csv")

--- a/oceanarray/logsheets/_config.py
+++ b/oceanarray/logsheets/_config.py
@@ -1,0 +1,200 @@
+"""oceanarray.logsheets._config
+=============================
+Path resolution, YAML loading helpers, and instrument registry access.
+
+Two categories of config files:
+
+* **Bundled** (installed with the package, in ``data/``):
+  ``column_defs.yaml`` and ``latex_templates/``.
+
+* **User-supplied** (via ``--config-dir`` or ``LOGSHEETS_CONFIG_DIR`` env var):
+  ``logsheet_config.yaml`` and ``instrument_inventory.csv``.
+
+Mooring YAMLs are resolved from the oceanarray proc directory
+(``{proc_dir}/{mooring}/{mooring}.mooring.yaml``), with an optional
+``mooring_yaml_map`` override in ``logsheet_config.yaml``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Bundled package data
+# ---------------------------------------------------------------------------
+
+_DATA = Path(__file__).parent / "data"
+DEFAULT_COLUMN_DEFS: Path = _DATA / "column_defs.yaml"
+DEFAULT_TEMPLATES_DIR: Path = _DATA / "latex_templates"
+
+
+# ---------------------------------------------------------------------------
+# Config container
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LogsheetsConfig:
+    """Resolved paths for a logsheet generation run."""
+
+    cruise_config_path: Path
+    instruments_path: Path
+    column_defs_path: Path
+    templates_dir: Path
+    output_dir: Path
+    proc_dir: Optional[Path]
+
+
+def resolve_config(
+    config_dir: Optional[Path] = None,
+    inventory_path: Optional[Path] = None,
+    logsheet_config_path: Optional[Path] = None,
+    output_dir: Optional[Path] = None,
+    proc_dir: Optional[Path] = None,
+) -> LogsheetsConfig:
+    """Build a :class:`LogsheetsConfig` from user-supplied paths.
+
+    Parameters
+    ----------
+    config_dir:
+        Shorthand: directory containing ``logsheet_config.yaml`` and
+        ``instrument_inventory.csv``.  Ignored for any path supplied explicitly
+        via *inventory_path* or *logsheet_config_path*.  Falls back to the
+        ``LOGSHEETS_CONFIG_DIR`` env var, then the current working directory.
+    inventory_path:
+        Explicit path to ``instrument_inventory.csv``.
+        Takes precedence over ``config_dir / instrument_inventory.csv``.
+    logsheet_config_path:
+        Explicit path to ``logsheet_config.yaml``.  Takes precedence over
+        ``config_dir / logsheet_config.yaml``.  Optional; if the file does not
+        exist, path/filename fields are left blank on the sheet.
+    output_dir:
+        Where PDFs are written.  Defaults to ``./logsheets/``.
+    proc_dir:
+        Oceanarray proc directory (parent of per-mooring subdirs).  Used to
+        locate mooring YAMLs when not found via ``mooring_yaml_map``.
+
+    """
+    if config_dir is None and inventory_path is None and logsheet_config_path is None:
+        env = os.environ.get("LOGSHEETS_CONFIG_DIR")
+        config_dir = Path(env) if env else Path.cwd()
+
+    # Resolve cruise_config and instruments from explicit paths or config_dir
+    resolved_cruise = logsheet_config_path or (
+        (config_dir / "cruise_config.yaml")
+        if config_dir
+        else Path("cruise_config.yaml")
+    )
+    resolved_inventory = inventory_path or (
+        (config_dir / "instruments.yaml") if config_dir else Path("instruments.yaml")
+    )
+
+    # Allow user to override bundled column_defs.yaml by placing one in config_dir
+    user_col_defs = (config_dir / "column_defs.yaml") if config_dir else None
+    col_defs_path = (
+        user_col_defs
+        if (user_col_defs and user_col_defs.exists())
+        else DEFAULT_COLUMN_DEFS
+    )
+
+    # Similarly allow a custom templates/ dir alongside cruise_config
+    user_templates = (config_dir / "latex_templates") if config_dir else None
+    templates_dir = (
+        user_templates
+        if (user_templates and user_templates.is_dir())
+        else DEFAULT_TEMPLATES_DIR
+    )
+
+    return LogsheetsConfig(
+        cruise_config_path=resolved_cruise,
+        instruments_path=resolved_inventory,
+        column_defs_path=col_defs_path,
+        templates_dir=templates_dir,
+        output_dir=output_dir or Path("logsheets"),
+        proc_dir=proc_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# YAML helpers
+# ---------------------------------------------------------------------------
+
+
+def load_yaml(path: Path) -> dict:
+    """Load and return a YAML file as a dict."""
+    with open(path) as fh:
+        return yaml.safe_load(fh)
+
+
+def load_instruments(cfg: LogsheetsConfig) -> dict:
+    """Return the instrument registry keyed by ``(type_str, serial_int)``.
+
+    Reads ``instrument_inventory.csv`` (or legacy ``instruments.yaml``) from
+    the user-supplied config directory.  Example key: ``("microcat", 7507)``.
+    """
+    raw = load_yaml(cfg.instruments_path)
+    lookup = {}
+    for itype, entries in raw.items():
+        for entry in entries:
+            sn = entry["serial"]
+            lookup[(itype, sn)] = entry
+    return lookup
+
+
+def sn_to_entry(instruments: dict, sn: int) -> tuple[str, dict]:
+    """Look up a serial number across all instrument types.
+
+    Parameters
+    ----------
+    instruments:
+        Registry returned by :func:`load_instruments`.
+    sn:
+        Serial number to look up.
+
+    Returns
+    -------
+    tuple[str, dict]
+        ``(instrument_type, entry_dict)``.
+
+    Raises
+    ------
+    KeyError
+        If the serial number is not found in any type.
+
+    """
+    for itype in ("microcat", "aquadopp", "tr1050", "rbrsolo", "adcp"):
+        if (itype, sn) in instruments:
+            return itype, instruments[(itype, sn)]
+    raise KeyError(f"SN {sn} not found in instrument_inventory.csv")
+
+
+def resolve_mooring_yaml(
+    mooring: str, cfg: LogsheetsConfig, mooring_yaml_map: dict
+) -> Optional[Path]:
+    """Find the mooring YAML path, trying two strategies in order.
+
+    1. ``mooring_yaml_map`` in ``logsheet_config.yaml`` (relative paths are
+       resolved relative to ``logsheet_config.yaml``'s parent directory).
+    2. Oceanarray convention: ``{proc_dir}/{mooring}/{mooring}.mooring.yaml``.
+
+    Returns ``None`` if neither strategy finds a readable file.
+    """
+    if mooring in mooring_yaml_map:
+        rel = mooring_yaml_map[mooring]
+        p = Path(rel)
+        if not p.is_absolute():
+            p = cfg.cruise_config_path.parent / rel
+        if p.exists():
+            return p
+
+    if cfg.proc_dir is not None:
+        candidate = cfg.proc_dir / mooring / f"{mooring}.mooring.yaml"
+        if candidate.exists():
+            return candidate
+
+    return None

--- a/oceanarray/logsheets/_firmware.py
+++ b/oceanarray/logsheets/_firmware.py
@@ -1,0 +1,43 @@
+"""oceanarray.logsheets._firmware
+================================
+MicroCAT firmware group detection and display labels.
+"""
+
+from packaging.version import Version
+
+#: Section-title strings used in generated logsheets.
+FW_GROUP_LABELS: dict[str, str] = {
+    "old_seaterm": r"MicroCAT --- Firmware $<$ 3.0d (Seaterm v1, 9600 baud)",
+    "seaterm_v2": r"MicroCAT --- Firmware $\geq$ 3.0d (SeatermV2, 38400 baud)",
+    "seaterm_v2_odo": r"MicroCAT --- Firmware $\geq$ 3.0d + ODO (SeatermV2, 38400 baud)",
+}
+
+
+def fw_group(entry: dict, sentinel_str: str = "3.0d") -> str:
+    """Determine the firmware group for a MicroCAT instrument entry.
+
+    Parameters
+    ----------
+    entry:
+        Instrument entry from ``instruments.yaml``.
+    sentinel_str:
+        Version string separating old_seaterm from seaterm_v2
+        (from ``cruise_config.yaml → microcat_firmware_sentinel``).
+
+    Returns
+    -------
+    str
+        One of ``"old_seaterm"``, ``"seaterm_v2"``, ``"seaterm_v2_odo"``.
+
+    """
+    if entry.get("odo"):
+        return "seaterm_v2_odo"
+    fw = entry.get("firmware")
+    if fw is None:
+        return "seaterm_v2"
+    try:
+        if Version(fw) < Version(sentinel_str):
+            return "old_seaterm"
+        return "seaterm_v2"
+    except Exception:  # noqa: BLE001
+        return "old_seaterm" if fw < sentinel_str else "seaterm_v2"

--- a/oceanarray/logsheets/_latex.py
+++ b/oceanarray/logsheets/_latex.py
@@ -1,0 +1,128 @@
+"""oceanarray.logsheets._latex
+============================
+LaTeX escaping, column-spec building, and row-rendering helpers.
+"""
+
+_TEX_SPECIAL: dict[str, str] = {
+    "&": r"\&",
+    "%": r"\%",
+    "$": r"\$",
+    "#": r"\#",
+    "_": r"\_",
+    "{": r"\{",
+    "}": r"\}",
+    "~": r"\textasciitilde{}",
+    "^": r"\^{}",
+    "\\": r"\textbackslash{}",
+}
+
+
+def tex_safe(s: str) -> str:
+    """Escape a plain string that contains no LaTeX commands."""
+    if s is None:
+        return ""
+    return "".join(_TEX_SPECIAL.get(ch, ch) for ch in str(s))
+
+
+def colspec_from_cols(cols: list[dict]) -> str:
+    """Build a LaTeX tabular column-spec string from a resolved column list.
+
+    Column ``width`` values are relative weights normalised to fill
+    ``\\linewidth``.
+    """
+    total = sum(c["width"] for c in cols)
+    parts = ["|"]
+    for col in cols:
+        frac = col["width"] / total
+        col_type = "p" if col.get("align") == "left" else "C"
+        parts.append(
+            f"{col_type}{{\\dimexpr {frac:.5f}\\linewidth-2\\tabcolsep\\relax}}|"
+        )
+    return "".join(parts)
+
+
+def header_row(cols: list[dict]) -> str:
+    """Build the grey, bold LaTeX header row."""
+    cells = []
+    for col in cols:
+        text = " ".join(col["header"].split("\n"))
+        text = (
+            text.replace("_", r"\_")
+            .replace("{", r"\{")
+            .replace("}", r"\}")
+            .replace("&", r"\&")
+            .replace("#", r"\#")
+        )
+        cells.append(r"\cellcolor{hdrgray}{\bfseries\small " + text + r"}")
+    return " & ".join(cells)
+
+
+def example_data_row(cols: list[dict]) -> str:
+    """Build the shaded example row from the ``example`` field on each column."""
+    cells = []
+    for col in cols:
+        ex = str(col.get("example", ""))
+        if not ex:
+            cells.append("")
+            continue
+        ex_tex = ex if ex.startswith("\\") else tex_safe(ex)
+        cells.append(r"\textit{\small " + ex_tex + r"}")
+    return " & ".join(cells)
+
+
+def data_row(
+    cols: list[dict],
+    sn: int | None = None,
+    prefills: dict | None = None,
+    extra_readonly: dict | None = None,
+    prefilled_extra: dict | None = None,
+) -> str:
+    """Build a single instrument data row.
+
+    Parameters
+    ----------
+    cols:
+        Resolved column dicts.
+    sn:
+        Serial number; rendered in ``readonly`` SN columns.
+        ``0`` or ``None`` renders a blank SN cell.
+    prefills:
+        ``{key: value}`` map for pre-filled dynamic values (e.g. ``"sint"``).
+    extra_readonly:
+        ``{col_index: text}`` to force-fill specific columns as readonly text.
+    prefilled_extra:
+        ``{col_index: text}`` to force-fill specific columns with ``\\pre{}``
+        styling (grey).  Takes priority over all other logic for the matched column.
+
+    """
+    cells = []
+    if prefills is None:
+        prefills = {}
+    if extra_readonly is None:
+        extra_readonly = {}
+    if prefilled_extra is None:
+        prefilled_extra = {}
+
+    for i, col in enumerate(cols):
+        inp = col.get("input", "free")
+        default = col.get("default")
+
+        if i in prefilled_extra:
+            cells.append(r"\pre{" + tex_safe(str(prefilled_extra[i])) + r"}")
+        elif i in extra_readonly:
+            cells.append(r"\small " + tex_safe(str(extra_readonly[i])))
+        elif inp == "readonly" and col["header"].strip().startswith("SN"):
+            cells.append(r"\small " + tex_safe(str(sn)) if sn else "")
+        elif inp == "readonly":
+            cells.append("")
+        elif inp == "tick":
+            cells.append("")
+        elif inp == "prefilled" and default:
+            cells.append(r"\pre{" + tex_safe(default) + r"}")
+        elif inp == "prefilled" and sn and "{sint}" in col["header"]:
+            val = prefills.get("sint", "")
+            cells.append(r"\pre{" + tex_safe(str(val)) + r"}")
+        else:
+            cells.append("")
+
+    return " & ".join(cells)

--- a/oceanarray/logsheets/_render.py
+++ b/oceanarray/logsheets/_render.py
@@ -1,0 +1,126 @@
+"""oceanarray.logsheets._render
+==============================
+Jinja2 environment factory and PDF compilation helper.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def make_jinja_env(templates_dir: Path) -> Environment:
+    """Return a Jinja2 :class:`~jinja2.Environment` configured for LaTeX templates.
+
+    Uses custom delimiters to avoid clashing with LaTeX ``{}``:
+
+    - blocks:    ``(% … %)``
+    - variables: ``(( … ))``
+    - comments:  ``(# … #)``
+
+    Parameters
+    ----------
+    templates_dir:
+        Directory containing the ``.tex.j2`` template files.  Pass
+        ``cfg.templates_dir`` (which defaults to the bundled package data).
+
+    """
+    return Environment(
+        loader=FileSystemLoader(str(templates_dir)),
+        block_start_string="(%",
+        block_end_string="%)",
+        variable_start_string="((",
+        variable_end_string="))",
+        comment_start_string="(#",
+        comment_end_string="#)",
+        keep_trailing_newline=True,
+    )
+
+
+def compile_pdf(
+    tex_source: str,
+    out_pdf: Path,
+    out_tex: Path | None = None,
+) -> Path:
+    """Compile a LaTeX source string to PDF via ``pdflatex``.
+
+    Parameters
+    ----------
+    tex_source:
+        Complete LaTeX document source.
+    out_pdf:
+        Destination path for the compiled PDF.
+    out_tex:
+        If given, also write the ``.tex`` source alongside the PDF.
+
+    Raises
+    ------
+    RuntimeError
+        If ``pdflatex`` fails to produce a PDF.
+
+    """
+    if out_tex is not None:
+        out_tex.write_text(tex_source, encoding="utf-8")
+        print(f"  Written: {out_tex}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tex_file = Path(tmpdir) / "sheet.tex"
+        tex_file.write_text(tex_source, encoding="utf-8")
+        result = subprocess.run(
+            [
+                "pdflatex",
+                "-interaction=nonstopmode",
+                "-output-directory",
+                tmpdir,
+                str(tex_file),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        pdf_tmp = Path(tmpdir) / "sheet.pdf"
+        if pdf_tmp.exists():
+            shutil.copy(pdf_tmp, out_pdf)
+            print(f"  Written: {out_pdf}")
+        else:
+            print("LaTeX compilation failed. Log:")
+            print(result.stdout[-3000:])
+            raise RuntimeError(f"pdflatex failed for {out_pdf.name}")
+
+    return out_pdf
+
+
+def render_sheet(
+    tex_source: str,
+    out_dir: Path,
+    stem: str,
+    fmt: str = "pdf",
+) -> Path:
+    """Write a rendered LaTeX sheet to ``out_dir`` in the requested format.
+
+    Parameters
+    ----------
+    tex_source:
+        Complete LaTeX document source.
+    out_dir:
+        Output directory (created by caller).
+    stem:
+        Filename stem (no extension), e.g. ``"castN1_setup"``.
+    fmt:
+        ``"pdf"`` — compile via pdflatex (also writes ``.tex`` alongside).
+        ``"tex"`` — write ``.tex`` only; skip pdflatex.
+
+    Raises
+    ------
+    RuntimeError
+        If ``fmt="pdf"`` and pdflatex fails.
+
+    """
+    if fmt == "tex":
+        out_path = out_dir / f"{stem}.tex"
+        out_path.write_text(tex_source, encoding="utf-8")
+        print(f"  Written: {out_path}")
+        return out_path
+    return compile_pdf(tex_source, out_dir / f"{stem}.pdf", out_dir / f"{stem}.tex")

--- a/oceanarray/logsheets/builders/__init__.py
+++ b/oceanarray/logsheets/builders/__init__.py
@@ -1,0 +1,13 @@
+from .caldip_setup import build_caldip_setup
+from .caldip_download import build_caldip_download
+from .recovery import build_recovery
+from .mooring_download import build_mooring_download
+from .deployment_setup import build_deployment_setup
+
+__all__ = [
+    "build_caldip_setup",
+    "build_caldip_download",
+    "build_recovery",
+    "build_mooring_download",
+    "build_deployment_setup",
+]

--- a/oceanarray/logsheets/builders/caldip_download.py
+++ b/oceanarray/logsheets/builders/caldip_download.py
@@ -12,7 +12,6 @@ from .._config import (
     load_yaml,
     load_instruments,
     sn_to_entry,
-    resolve_mooring_yaml,
 )
 from .._firmware import fw_group, FW_GROUP_LABELS
 from .._latex import colspec_from_cols, header_row, data_row, example_data_row
@@ -20,38 +19,62 @@ from .._columns import resolve_columns, format_data_path_note
 from .._render import make_jinja_env, render_sheet
 
 
-def build_caldip_download(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> Path:
+def build_caldip_download(
+    cast_id: str,
+    cfg: LogsheetsConfig,
+    fmt: str = "pdf",
+    caldip_yaml: "dict | None" = None,
+) -> Path:
     """Build the caldip-download PDF for a given cast.
 
     Parameters
     ----------
     cast_id:
-        Cast key from ``cruise_config.yaml → casts``, e.g. ``"N1"``.
+        File path string (used for the output filename fallback when
+        *caldip_yaml* is provided) or a cast key in a legacy
+        ``cruise_config.yaml → casts`` dict.
     cfg:
         Resolved logsheets configuration from :func:`~._config.resolve_config`.
     fmt:
         ``"pdf"`` or ``"tex"``.
+    caldip_yaml:
+        Pre-loaded caldip YAML dict.  The canonical format is a dict with a
+        top-level ``instruments:`` list; each entry has at minimum ``serial``
+        (int) and ``instrument`` (type string).  When provided, cast info is
+        taken directly from this dict.
 
     """
-    cruise_cfg = load_yaml(cfg.cruise_config_path)
     col_defs = load_yaml(cfg.column_defs_path)
     col_library = col_defs.get("column_library", {})
     instruments = load_instruments(cfg)
 
-    cast_cfg = cruise_cfg["casts"].get(cast_id)
-    if cast_cfg is None:
-        sys.exit(f"Cast {cast_id} not found in cruise_config.yaml")
+    # Global settings from logsheet_config.yaml (with safe fallback).
+    lsconf: dict = {}
+    if cfg.cruise_config_path.exists():
+        lsconf = load_yaml(cfg.cruise_config_path)
 
-    cast_label = cast_cfg["label"]
-    sentinel = cruise_cfg.get("microcat_firmware_sentinel", "3.0d")
-    caldip_data = cruise_cfg.get("paths", {}).get("caldip_data", "")
-    cruise = cruise_cfg["cruise"]
-    mooring_yaml_map = cruise_cfg.get("mooring_yaml_map", {})
+    sentinel = lsconf.get("microcat_firmware_sentinel", "3.0d")
+    caldip_data = lsconf.get("paths", {}).get("caldip_data", "")
 
-    mcat_filter = cast_cfg.get("microcat_filter")
-    aq_override = cast_cfg.get("aquadopps_override")
-    tr_filter = cast_cfg.get("rbr_tr1050_filter")
-    solot_filter = cast_cfg.get("rbr_solot_filter")
+    # Cast config: from explicit caldip_yaml, or looked up in legacy casts dict.
+    if caldip_yaml is not None:
+        cast_cfg = caldip_yaml
+    else:
+        cast_cfg = lsconf.get("casts", {}).get(cast_id)
+        if cast_cfg is None:
+            sys.exit(f"Cast {cast_id} not found in {cfg.cruise_config_path}")
+
+    # cruise may live in the caldip YAML itself or in logsheet_config.yaml.
+    cruise = cast_cfg.get("cruise") or lsconf.get("cruise", "")
+
+    # Label: try common key names, fall back to file stem.
+    cast_label = (
+        cast_cfg.get("label")
+        or cast_cfg.get("cast_label")
+        or cast_cfg.get("name")
+        or cast_cfg.get("cast")
+        or Path(cast_id).name.split(".")[0]
+    )
 
     all_mcats_by_group: dict[str, list[dict]] = {
         "old_seaterm": [],
@@ -59,37 +82,29 @@ def build_caldip_download(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") 
         "seaterm_v2_odo": [],
     }
     all_aquadopps: list[dict] = []
+    rbr_tr1050_entries: list[dict] = []
+    rbr_solot_entries: list[dict] = []
+    seapoint_entries: list[dict] = []
     sheet_warnings: list[str] = []
 
-    if mcat_filter is not None:
-        for sn in mcat_filter:
+    # Canonical caldip YAML format: top-level instruments: list.
+    for item in cast_cfg.get("instruments", []):
+        sn = int(item["serial"])
+        try:
             itype, entry = sn_to_entry(instruments, sn)
-            if itype == "microcat":
-                all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
-    else:
-        for mooring in cast_cfg.get("moorings", []):
-            yaml_path = resolve_mooring_yaml(mooring, cfg, mooring_yaml_map)
-            if yaml_path is None:
-                print(f"  Warning: no YAML for {mooring}")
-                continue
-            moor_data = load_yaml(yaml_path)
-            for clamp in moor_data.get("clamp", []):
-                sn = int(str(clamp["serial"]).rstrip("*"))
-                try:
-                    itype, entry = sn_to_entry(instruments, sn)
-                except KeyError:
-                    sheet_warnings.append(f"SN {sn} not found in instruments.yaml")
-                    continue
-                if itype == "microcat":
-                    all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
-
-    if aq_override is not None:
-        for sn in aq_override:
-            _, entry = sn_to_entry(instruments, sn)
+        except KeyError:
+            sheet_warnings.append(f"SN {sn} not found in inventory -- skipped")
+            continue
+        if itype == "microcat":
+            all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
+        elif itype == "aquadopp":
             all_aquadopps.append(entry)
-
-    rbr_tr1050_entries = [sn_to_entry(instruments, sn)[1] for sn in (tr_filter or [])]
-    rbr_solot_entries = [sn_to_entry(instruments, sn)[1] for sn in (solot_filter or [])]
+        elif itype in ("rbrsolo", "rbrduet"):
+            rbr_solot_entries.append(entry)
+        elif itype == "tr1050":
+            rbr_tr1050_entries.append(entry)
+        elif itype == "seapoint":
+            seapoint_entries.append(entry)
 
     sections = []
 
@@ -134,7 +149,7 @@ def build_caldip_download(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") 
             }
         )
 
-    def _rbr_section(def_key, entries):
+    def _rbr_section(def_key: str, entries: list[dict]) -> dict:
         defn = col_defs[def_key]
         cols = resolve_columns(defn["columns"], col_library)
         note_lines = format_data_path_note(
@@ -156,6 +171,8 @@ def build_caldip_download(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") 
         sections.append(_rbr_section("rbr_tr1050_download_caldip", rbr_tr1050_entries))
     if rbr_solot_entries:
         sections.append(_rbr_section("rbr_solot_download_caldip", rbr_solot_entries))
+    if seapoint_entries:
+        sections.append(_rbr_section("rbr_solot_download_caldip", seapoint_entries))
 
     tex_source = (
         make_jinja_env(cfg.templates_dir)

--- a/oceanarray/logsheets/builders/caldip_download.py
+++ b/oceanarray/logsheets/builders/caldip_download.py
@@ -1,0 +1,178 @@
+"""oceanarray.logsheets.builders.caldip_download
+===============================================
+Build caldip-download PDF logsheets.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .._config import (
+    LogsheetsConfig,
+    load_yaml,
+    load_instruments,
+    sn_to_entry,
+    resolve_mooring_yaml,
+)
+from .._firmware import fw_group, FW_GROUP_LABELS
+from .._latex import colspec_from_cols, header_row, data_row, example_data_row
+from .._columns import resolve_columns, format_data_path_note
+from .._render import make_jinja_env, render_sheet
+
+
+def build_caldip_download(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> Path:
+    """Build the caldip-download PDF for a given cast.
+
+    Parameters
+    ----------
+    cast_id:
+        Cast key from ``cruise_config.yaml → casts``, e.g. ``"N1"``.
+    cfg:
+        Resolved logsheets configuration from :func:`~._config.resolve_config`.
+    fmt:
+        ``"pdf"`` or ``"tex"``.
+
+    """
+    cruise_cfg = load_yaml(cfg.cruise_config_path)
+    col_defs = load_yaml(cfg.column_defs_path)
+    col_library = col_defs.get("column_library", {})
+    instruments = load_instruments(cfg)
+
+    cast_cfg = cruise_cfg["casts"].get(cast_id)
+    if cast_cfg is None:
+        sys.exit(f"Cast {cast_id} not found in cruise_config.yaml")
+
+    cast_label = cast_cfg["label"]
+    sentinel = cruise_cfg.get("microcat_firmware_sentinel", "3.0d")
+    caldip_data = cruise_cfg.get("paths", {}).get("caldip_data", "")
+    cruise = cruise_cfg["cruise"]
+    mooring_yaml_map = cruise_cfg.get("mooring_yaml_map", {})
+
+    mcat_filter = cast_cfg.get("microcat_filter")
+    aq_override = cast_cfg.get("aquadopps_override")
+    tr_filter = cast_cfg.get("rbr_tr1050_filter")
+    solot_filter = cast_cfg.get("rbr_solot_filter")
+
+    all_mcats_by_group: dict[str, list[dict]] = {
+        "old_seaterm": [],
+        "seaterm_v2": [],
+        "seaterm_v2_odo": [],
+    }
+    all_aquadopps: list[dict] = []
+    sheet_warnings: list[str] = []
+
+    if mcat_filter is not None:
+        for sn in mcat_filter:
+            itype, entry = sn_to_entry(instruments, sn)
+            if itype == "microcat":
+                all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
+    else:
+        for mooring in cast_cfg.get("moorings", []):
+            yaml_path = resolve_mooring_yaml(mooring, cfg, mooring_yaml_map)
+            if yaml_path is None:
+                print(f"  Warning: no YAML for {mooring}")
+                continue
+            moor_data = load_yaml(yaml_path)
+            for clamp in moor_data.get("clamp", []):
+                sn = int(str(clamp["serial"]).rstrip("*"))
+                try:
+                    itype, entry = sn_to_entry(instruments, sn)
+                except KeyError:
+                    sheet_warnings.append(f"SN {sn} not found in instruments.yaml")
+                    continue
+                if itype == "microcat":
+                    all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
+
+    if aq_override is not None:
+        for sn in aq_override:
+            _, entry = sn_to_entry(instruments, sn)
+            all_aquadopps.append(entry)
+
+    rbr_tr1050_entries = [sn_to_entry(instruments, sn)[1] for sn in (tr_filter or [])]
+    rbr_solot_entries = [sn_to_entry(instruments, sn)[1] for sn in (solot_filter or [])]
+
+    sections = []
+
+    mcat_def = col_defs["microcat_download_caldip"]
+    mcat_note_raw = mcat_def.get("data_path_note", "")
+
+    for grp, entries in all_mcats_by_group.items():
+        if not entries:
+            continue
+        cols = resolve_columns(mcat_def[f"columns_{grp}"], col_library)
+        note_lines = format_data_path_note(
+            mcat_note_raw, caldip_data=caldip_data, cast_label=cast_label
+        )
+        sections.append(
+            {
+                "title": FW_GROUP_LABELS[grp],
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "note_lines": note_lines,
+                "data_rows": [data_row(cols, sn=e["serial"]) for e in entries],
+                "ncols": len(cols),
+            }
+        )
+
+    if all_aquadopps:
+        aq_def = col_defs["aquadopp_download_caldip"]
+        cols = resolve_columns(aq_def["columns"], col_library)
+        sections.append(
+            {
+                "title": aq_def.get("section_title", "Aquadopp Cal Dip Download"),
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "note_lines": format_data_path_note(
+                    aq_def.get("data_path_note", ""),
+                    caldip_data=caldip_data,
+                    cast_label=cast_label,
+                ),
+                "data_rows": [data_row(cols, sn=e["serial"]) for e in all_aquadopps],
+                "ncols": len(cols),
+            }
+        )
+
+    def _rbr_section(def_key, entries):
+        defn = col_defs[def_key]
+        cols = resolve_columns(defn["columns"], col_library)
+        note_lines = format_data_path_note(
+            defn.get("data_path_note", ""),
+            caldip_data=caldip_data,
+            cast_label=cast_label,
+        )
+        return {
+            "title": defn.get("section_title", def_key),
+            "colspec": colspec_from_cols(cols),
+            "header_row": header_row(cols),
+            "example_row": example_data_row(cols),
+            "note_lines": note_lines,
+            "data_rows": [data_row(cols, sn=e["serial"]) for e in entries],
+            "ncols": len(cols),
+        }
+
+    if rbr_tr1050_entries:
+        sections.append(_rbr_section("rbr_tr1050_download_caldip", rbr_tr1050_entries))
+    if rbr_solot_entries:
+        sections.append(_rbr_section("rbr_solot_download_caldip", rbr_solot_entries))
+
+    tex_source = (
+        make_jinja_env(cfg.templates_dir)
+        .get_template("caldip_download.tex.j2")
+        .render(
+            cruise=cruise,
+            cast_label=cast_label,
+            sections=sections,
+            sheet_warnings=sheet_warnings,
+            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        )
+    )
+
+    out_dir = cfg.output_dir / "caldip-download"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{cast_label}_download"
+    try:
+        return render_sheet(tex_source, out_dir, stem, fmt)
+    except RuntimeError:
+        sys.exit(1)

--- a/oceanarray/logsheets/builders/caldip_setup.py
+++ b/oceanarray/logsheets/builders/caldip_setup.py
@@ -1,0 +1,172 @@
+"""oceanarray.logsheets.builders.caldip_setup
+============================================
+Build caldip-setup PDF logsheets.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .._config import (
+    LogsheetsConfig,
+    load_yaml,
+    load_instruments,
+    sn_to_entry,
+    resolve_mooring_yaml,
+)
+from .._firmware import fw_group, FW_GROUP_LABELS
+from .._latex import colspec_from_cols, header_row, data_row, example_data_row
+from .._columns import resolve_columns
+from .._render import make_jinja_env, render_sheet
+
+
+def build_caldip_setup(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> Path:
+    """Build the caldip-setup PDF for a given cast.
+
+    Parameters
+    ----------
+    cast_id:
+        Cast key from ``cruise_config.yaml → casts``, e.g. ``"N1"``.
+    cfg:
+        Resolved logsheets configuration from :func:`~._config.resolve_config`.
+    fmt:
+        ``"pdf"`` or ``"tex"``.
+
+    """
+    cruise_cfg = load_yaml(cfg.cruise_config_path)
+    col_defs = load_yaml(cfg.column_defs_path)
+    col_library = col_defs.get("column_library", {})
+    instruments = load_instruments(cfg)
+
+    cast_cfg = cruise_cfg["casts"].get(cast_id)
+    if cast_cfg is None:
+        sys.exit(f"Cast {cast_id} not found in cruise_config.yaml")
+
+    cast_label = cast_cfg["label"]
+    post_dep = cast_cfg.get("post_deployment", False)
+    sentinel = cruise_cfg.get("microcat_firmware_sentinel", "3.0d")
+    caldip_data = cruise_cfg.get("paths", {}).get("caldip_data", "")
+    cruise = cruise_cfg["cruise"]
+    mooring_yaml_map = cruise_cfg.get("mooring_yaml_map", {})
+
+    mcat_filter = cast_cfg.get("microcat_filter")
+    aq_override = cast_cfg.get("aquadopps_override")
+    tr_filter = cast_cfg.get("rbr_tr1050_filter")
+    solot_filter = cast_cfg.get("rbr_solot_filter")
+
+    all_mcats_by_group: dict[str, list[dict]] = {
+        "old_seaterm": [],
+        "seaterm_v2": [],
+        "seaterm_v2_odo": [],
+    }
+    all_aquadopps: list[dict] = []
+    sheet_warnings: list[str] = []
+
+    if mcat_filter is not None:
+        for sn in mcat_filter:
+            itype, entry = sn_to_entry(instruments, sn)
+            if itype == "microcat":
+                all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
+    else:
+        for mooring in cast_cfg.get("moorings", []):
+            yaml_path = resolve_mooring_yaml(mooring, cfg, mooring_yaml_map)
+            if yaml_path is None:
+                print(f"  Warning: no YAML for {mooring}")
+                continue
+            moor_data = load_yaml(yaml_path)
+            for clamp in moor_data.get("clamp", []):
+                sn = int(str(clamp["serial"]).rstrip("*"))
+                try:
+                    itype, entry = sn_to_entry(instruments, sn)
+                except KeyError:
+                    sheet_warnings.append(f"SN {sn} not found in instruments.yaml")
+                    continue
+                if itype == "microcat":
+                    all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
+
+    if aq_override is not None:
+        for sn in aq_override:
+            _, entry = sn_to_entry(instruments, sn)
+            all_aquadopps.append(entry)
+
+    rbr_tr1050_entries = [sn_to_entry(instruments, sn)[1] for sn in (tr_filter or [])]
+    rbr_solot_entries = [sn_to_entry(instruments, sn)[1] for sn in (solot_filter or [])]
+
+    sections = []
+
+    mcat_def = col_defs["microcat_setup_caldip"]
+    for grp, entries in all_mcats_by_group.items():
+        if not entries:
+            continue
+        cols = resolve_columns(mcat_def[f"columns_{grp}"], col_library)
+        sections.append(
+            {
+                "title": FW_GROUP_LABELS[grp],
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "data_rows": [data_row(cols, sn=e["serial"]) for e in entries],
+                "post_deployment": post_dep,
+                "ncols": len(cols),
+            }
+        )
+
+    if all_aquadopps:
+        cols = resolve_columns(
+            col_defs["aquadopp_setup_caldip"]["columns"], col_library
+        )
+        sections.append(
+            {
+                "title": "Aquadopp",
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "data_rows": [data_row(cols, sn=e["serial"]) for e in all_aquadopps],
+                "post_deployment": False,
+                "ncols": len(cols),
+            }
+        )
+
+    def _rbr_section(entries, title):
+        cols = resolve_columns(col_defs["rbr_setup_caldip"]["columns"], col_library)
+        return {
+            "title": title,
+            "colspec": colspec_from_cols(cols),
+            "header_row": header_row(cols),
+            "example_row": example_data_row(cols),
+            "data_rows": [data_row(cols, sn=e["serial"]) for e in entries],
+            "post_deployment": False,
+            "ncols": len(cols),
+        }
+
+    if rbr_tr1050_entries:
+        sections.append(_rbr_section(rbr_tr1050_entries, "RBR TR-1050 Thermistors"))
+    if rbr_solot_entries:
+        sections.append(_rbr_section(rbr_solot_entries, "RBR soloT Thermistors"))
+
+    caldip_data_tex = caldip_data.replace("~", r"\textasciitilde{}").replace("_", r"\_")
+    moorings_str = ", ".join(
+        m.replace("_", r"\_") for m in cast_cfg.get("moorings", [])
+    )
+
+    tex_source = (
+        make_jinja_env(cfg.templates_dir)
+        .get_template("caldip_setup.tex.j2")
+        .render(
+            cruise=cruise,
+            cast_label=cast_label,
+            moorings_str=moorings_str,
+            caldip_data=caldip_data_tex,
+            sections=sections,
+            sheet_warnings=sheet_warnings,
+            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        )
+    )
+
+    out_dir = cfg.output_dir / "caldip-setup"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{cast_label}_setup"
+    try:
+        return render_sheet(tex_source, out_dir, stem, fmt)
+    except RuntimeError:
+        sys.exit(1)

--- a/oceanarray/logsheets/builders/caldip_setup.py
+++ b/oceanarray/logsheets/builders/caldip_setup.py
@@ -12,7 +12,6 @@ from .._config import (
     load_yaml,
     load_instruments,
     sn_to_entry,
-    resolve_mooring_yaml,
 )
 from .._firmware import fw_group, FW_GROUP_LABELS
 from .._latex import colspec_from_cols, header_row, data_row, example_data_row
@@ -20,39 +19,63 @@ from .._columns import resolve_columns
 from .._render import make_jinja_env, render_sheet
 
 
-def build_caldip_setup(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> Path:
+def build_caldip_setup(
+    cast_id: str,
+    cfg: LogsheetsConfig,
+    fmt: str = "pdf",
+    caldip_yaml: "dict | None" = None,
+) -> Path:
     """Build the caldip-setup PDF for a given cast.
 
     Parameters
     ----------
     cast_id:
-        Cast key from ``cruise_config.yaml → casts``, e.g. ``"N1"``.
+        File path string (used for the output filename fallback when
+        *caldip_yaml* is provided) or a cast key in a legacy
+        ``cruise_config.yaml → casts`` dict.
     cfg:
         Resolved logsheets configuration from :func:`~._config.resolve_config`.
     fmt:
         ``"pdf"`` or ``"tex"``.
+    caldip_yaml:
+        Pre-loaded caldip YAML dict.  The canonical format is a dict with a
+        top-level ``instruments:`` list; each entry has at minimum ``serial``
+        (int) and ``instrument`` (type string).  When provided, cast info is
+        taken directly from this dict.
 
     """
-    cruise_cfg = load_yaml(cfg.cruise_config_path)
     col_defs = load_yaml(cfg.column_defs_path)
     col_library = col_defs.get("column_library", {})
     instruments = load_instruments(cfg)
 
-    cast_cfg = cruise_cfg["casts"].get(cast_id)
-    if cast_cfg is None:
-        sys.exit(f"Cast {cast_id} not found in cruise_config.yaml")
+    # Global settings from logsheet_config.yaml (with safe fallback).
+    lsconf: dict = {}
+    if cfg.cruise_config_path.exists():
+        lsconf = load_yaml(cfg.cruise_config_path)
 
-    cast_label = cast_cfg["label"]
+    sentinel = lsconf.get("microcat_firmware_sentinel", "3.0d")
+    caldip_data = lsconf.get("paths", {}).get("caldip_data", "")
+
+    # Cast config: from explicit caldip_yaml, or looked up in legacy casts dict.
+    if caldip_yaml is not None:
+        cast_cfg = caldip_yaml
+    else:
+        cast_cfg = lsconf.get("casts", {}).get(cast_id)
+        if cast_cfg is None:
+            sys.exit(f"Cast {cast_id} not found in {cfg.cruise_config_path}")
+
+    # cruise may live in the caldip YAML itself or in logsheet_config.yaml.
+    cruise = cast_cfg.get("cruise") or lsconf.get("cruise", "")
+
+    # Label: try common key names, fall back to file stem.
+    cast_label = (
+        cast_cfg.get("label")
+        or cast_cfg.get("cast_label")
+        or cast_cfg.get("name")
+        or cast_cfg.get("cast")
+        or Path(cast_id).name.split(".")[0]
+    )
     post_dep = cast_cfg.get("post_deployment", False)
-    sentinel = cruise_cfg.get("microcat_firmware_sentinel", "3.0d")
-    caldip_data = cruise_cfg.get("paths", {}).get("caldip_data", "")
-    cruise = cruise_cfg["cruise"]
-    mooring_yaml_map = cruise_cfg.get("mooring_yaml_map", {})
-
-    mcat_filter = cast_cfg.get("microcat_filter")
-    aq_override = cast_cfg.get("aquadopps_override")
-    tr_filter = cast_cfg.get("rbr_tr1050_filter")
-    solot_filter = cast_cfg.get("rbr_solot_filter")
 
     all_mcats_by_group: dict[str, list[dict]] = {
         "old_seaterm": [],
@@ -60,37 +83,31 @@ def build_caldip_setup(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> 
         "seaterm_v2_odo": [],
     }
     all_aquadopps: list[dict] = []
+    rbr_tr1050_entries: list[dict] = []
+    rbr_solot_entries: list[dict] = []
+    seapoint_entries: list[dict] = []
     sheet_warnings: list[str] = []
 
-    if mcat_filter is not None:
-        for sn in mcat_filter:
+    # Canonical caldip YAML format: top-level instruments: list.
+    # Each entry has serial (int) and instrument (type string).
+    # Classify each entry by looking up the serial in the inventory.
+    for item in cast_cfg.get("instruments", []):
+        sn = int(item["serial"])
+        try:
             itype, entry = sn_to_entry(instruments, sn)
-            if itype == "microcat":
-                all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
-    else:
-        for mooring in cast_cfg.get("moorings", []):
-            yaml_path = resolve_mooring_yaml(mooring, cfg, mooring_yaml_map)
-            if yaml_path is None:
-                print(f"  Warning: no YAML for {mooring}")
-                continue
-            moor_data = load_yaml(yaml_path)
-            for clamp in moor_data.get("clamp", []):
-                sn = int(str(clamp["serial"]).rstrip("*"))
-                try:
-                    itype, entry = sn_to_entry(instruments, sn)
-                except KeyError:
-                    sheet_warnings.append(f"SN {sn} not found in instruments.yaml")
-                    continue
-                if itype == "microcat":
-                    all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
-
-    if aq_override is not None:
-        for sn in aq_override:
-            _, entry = sn_to_entry(instruments, sn)
+        except KeyError:
+            sheet_warnings.append(f"SN {sn} not found in inventory -- skipped")
+            continue
+        if itype == "microcat":
+            all_mcats_by_group[fw_group(entry, sentinel)].append(entry)
+        elif itype == "aquadopp":
             all_aquadopps.append(entry)
-
-    rbr_tr1050_entries = [sn_to_entry(instruments, sn)[1] for sn in (tr_filter or [])]
-    rbr_solot_entries = [sn_to_entry(instruments, sn)[1] for sn in (solot_filter or [])]
+        elif itype in ("rbrsolo", "rbrduet"):
+            rbr_solot_entries.append(entry)
+        elif itype == "tr1050":
+            rbr_tr1050_entries.append(entry)
+        elif itype == "seapoint":
+            seapoint_entries.append(entry)
 
     sections = []
 
@@ -127,7 +144,7 @@ def build_caldip_setup(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> 
             }
         )
 
-    def _rbr_section(entries, title):
+    def _rbr_section(entries: list[dict], title: str) -> dict:
         cols = resolve_columns(col_defs["rbr_setup_caldip"]["columns"], col_library)
         return {
             "title": title,
@@ -143,11 +160,10 @@ def build_caldip_setup(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> 
         sections.append(_rbr_section(rbr_tr1050_entries, "RBR TR-1050 Thermistors"))
     if rbr_solot_entries:
         sections.append(_rbr_section(rbr_solot_entries, "RBR soloT Thermistors"))
+    if seapoint_entries:
+        sections.append(_rbr_section(seapoint_entries, "Seapoint Turbidity"))
 
     caldip_data_tex = caldip_data.replace("~", r"\textasciitilde{}").replace("_", r"\_")
-    moorings_str = ", ".join(
-        m.replace("_", r"\_") for m in cast_cfg.get("moorings", [])
-    )
 
     tex_source = (
         make_jinja_env(cfg.templates_dir)
@@ -155,7 +171,7 @@ def build_caldip_setup(cast_id: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> 
         .render(
             cruise=cruise,
             cast_label=cast_label,
-            moorings_str=moorings_str,
+            moorings_str="",
             caldip_data=caldip_data_tex,
             sections=sections,
             sheet_warnings=sheet_warnings,

--- a/oceanarray/logsheets/builders/deployment_setup.py
+++ b/oceanarray/logsheets/builders/deployment_setup.py
@@ -1,0 +1,218 @@
+"""oceanarray.logsheets.builders.deployment_setup
+================================================
+Build setup-deployment PDF logsheets.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .._config import (
+    LogsheetsConfig,
+    load_yaml,
+    load_instruments,
+    sn_to_entry,
+    resolve_mooring_yaml,
+)
+from .._firmware import fw_group, FW_GROUP_LABELS
+from .._latex import colspec_from_cols, header_row, data_row, example_data_row
+from .._columns import resolve_columns, format_data_path_note
+from .._render import make_jinja_env, render_sheet
+
+
+def build_deployment_setup(
+    mooring: str, cfg: LogsheetsConfig, fmt: str = "pdf"
+) -> Path:
+    """Build the setup-deployment PDF for a given mooring.
+
+    Parameters
+    ----------
+    mooring:
+        Mooring name, e.g. ``"dsG3_1_2026"``.
+    cfg:
+        Resolved logsheets configuration from :func:`~._config.resolve_config`.
+    fmt:
+        ``"pdf"`` or ``"tex"``.
+
+    """
+    cruise_cfg = load_yaml(cfg.cruise_config_path)
+    col_defs = load_yaml(cfg.column_defs_path)
+    col_library = col_defs.get("column_library", {})
+    instruments = load_instruments(cfg)
+
+    sentinel = cruise_cfg.get("microcat_firmware_sentinel", "3.0d")
+    cruise = cruise_cfg["cruise"]
+    raw_data = cruise_cfg.get("paths", {}).get("raw_data", "")
+    mooring_yaml_map = cruise_cfg.get("mooring_yaml_map", {})
+
+    yaml_path = resolve_mooring_yaml(mooring, cfg, mooring_yaml_map)
+    if yaml_path is None:
+        sys.exit(f"Mooring {mooring} not found — checked mooring_yaml_map and proc_dir")
+    moor_data = load_yaml(yaml_path)
+
+    mcats_by_group: dict[str, list[dict]] = {
+        "old_seaterm": [],
+        "seaterm_v2": [],
+        "seaterm_v2_odo": [],
+    }
+    aquadopps: list[dict] = []
+    rbr_solot: list[dict] = []
+    sheet_warnings: list[str] = []
+
+    for clamp in moor_data.get("clamp", []):
+        sn = int(str(clamp["serial"]).rstrip("*"))
+        sint = clamp.get("sample_interval_seconds")
+        if sn == 0:
+            instr = str(clamp.get("instrument", "")).lower()
+            label = str(clamp.get("label", "")).lower()
+            if "sbe37" in instr or "microcat" in instr or "microcat" in label:
+                placeholder = {"serial": 0, "model": "SBE37", "firmware": None}
+                mcats_by_group["old_seaterm"].append(
+                    {"entry": placeholder, "sint": sint}
+                )
+                mcats_by_group["seaterm_v2"].append(
+                    {"entry": placeholder, "sint": sint}
+                )
+                continue
+            elif "aquadopp" in instr or "aquadopp" in label:
+                itype, entry = "aquadopp", {"serial": 0, "model": "Aquadopp"}
+            elif "solot" in instr or "solot" in label:
+                itype, entry = "rbr_solot", {"serial": 0, "model": "RBR soloT"}
+            else:
+                print(
+                    f"  Warning: SN 0 with unknown type (label={clamp.get('label', '')}) -- skipped"
+                )
+                continue
+        else:
+            try:
+                itype, entry = sn_to_entry(instruments, sn)
+            except KeyError:
+                sheet_warnings.append(f"SN {sn} not found in instruments.yaml")
+                continue
+
+        item = {"entry": entry, "sint": sint}
+        if itype == "microcat":
+            mcats_by_group[fw_group(entry, sentinel)].append(item)
+        elif itype == "aquadopp":
+            aquadopps.append(item)
+        elif itype == "rbr_solot":
+            rbr_solot.append(item)
+
+    sections = []
+
+    def _note(defn, instrument):
+        return format_data_path_note(
+            defn.get("data_path_note", ""),
+            raw_data=raw_data,
+            mooring=mooring,
+            instrument=instrument,
+        )
+
+    def _sint_prefill(cols, sint):
+        if sint is None:
+            return {}
+        for i, c in enumerate(cols):
+            h = c.get("header", "").lower()
+            if "interval" in h and "average" not in h:
+                return {i: str(sint)}
+        return {}
+
+    mcat_def = col_defs["microcat_setup_deployment"]
+    for grp, items in mcats_by_group.items():
+        if not items:
+            continue
+        cols = resolve_columns(mcat_def[f"columns_{grp}"], col_library)
+        sections.append(
+            {
+                "title": FW_GROUP_LABELS[grp],
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "note_lines": _note(mcat_def, "microcat"),
+                "data_rows": [
+                    data_row(
+                        cols,
+                        sn=it["entry"]["serial"],
+                        prefilled_extra=_sint_prefill(cols, it["sint"]),
+                    )
+                    for it in items
+                ],
+                "ncols": len(cols),
+            }
+        )
+
+    if aquadopps:
+        aq_def = col_defs["aquadopp_setup_deployment"]
+        cols = resolve_columns(aq_def["columns"], col_library)
+        sections.append(
+            {
+                "title": aq_def.get("section_title", "Aquadopp Deployment Setup"),
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "note_lines": _note(aq_def, "aquadopp"),
+                "data_rows": [
+                    data_row(
+                        cols,
+                        sn=it["entry"]["serial"],
+                        prefilled_extra=_sint_prefill(cols, it["sint"]),
+                    )
+                    for it in aquadopps
+                ],
+                "ncols": len(cols),
+            }
+        )
+
+    if rbr_solot:
+        rbr_def = col_defs["rbr_solot_setup_deployment"]
+        cols = resolve_columns(rbr_def["columns"], col_library)
+        model_idx = next(
+            (j for j, c in enumerate(cols) if c["header"].strip() == "Model"), None
+        )
+        drows = []
+        for it in rbr_solot:
+            entry = it["entry"]
+            extra = (
+                {model_idx: entry.get("model", "RBR soloT")}
+                if model_idx is not None
+                else {}
+            )
+            drows.append(
+                data_row(
+                    cols,
+                    sn=entry["serial"],
+                    extra_readonly=extra,
+                    prefilled_extra=_sint_prefill(cols, it["sint"]),
+                )
+            )
+        sections.append(
+            {
+                "title": rbr_def.get("section_title", "RBR soloT Deployment Setup"),
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "note_lines": _note(rbr_def, "rbr"),
+                "data_rows": drows,
+                "ncols": len(cols),
+            }
+        )
+
+    tex_source = (
+        make_jinja_env(cfg.templates_dir)
+        .get_template("deployment_setup.tex.j2")
+        .render(
+            cruise=cruise,
+            mooring_tex=mooring.replace("_", r"\_"),
+            sections=sections,
+            sheet_warnings=sheet_warnings,
+            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        )
+    )
+
+    out_dir = cfg.output_dir / "setup-deployment"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{mooring}_setup"
+    try:
+        return render_sheet(tex_source, out_dir, stem, fmt)
+    except RuntimeError:
+        sys.exit(1)

--- a/oceanarray/logsheets/builders/mooring_download.py
+++ b/oceanarray/logsheets/builders/mooring_download.py
@@ -1,0 +1,243 @@
+"""oceanarray.logsheets.builders.mooring_download
+================================================
+Build mooring-download PDF logsheets (all instrument types).
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .._config import (
+    LogsheetsConfig,
+    load_yaml,
+    load_instruments,
+    sn_to_entry,
+    resolve_mooring_yaml,
+)
+from .._firmware import fw_group, FW_GROUP_LABELS
+from .._latex import colspec_from_cols, header_row, data_row, example_data_row
+from .._columns import resolve_columns, apply_download_convention, format_data_path_note
+from .._render import make_jinja_env, render_sheet
+
+_FW_CONV_KEY: dict[str, str] = {
+    "old_seaterm": "download_old_seaterm",
+    "seaterm_v2": "download_seaterm_v2",
+    "seaterm_v2_odo": "download_seaterm_v2",
+}
+
+
+def _collect_instruments(
+    moor_data: dict, instruments: dict, sentinel: str, sheet_warnings: list
+) -> dict:
+    """Walk the mooring YAML and separate instruments into typed buckets."""
+    mcats_by_group: dict[str, list[dict]] = {
+        "old_seaterm": [],
+        "seaterm_v2": [],
+        "seaterm_v2_odo": [],
+    }
+    aquadopps: list[dict] = []
+    rbr_tr1050: list[dict] = []
+    rbr_solot: list[dict] = []
+    adcp_items: list[dict] = []
+
+    for clamp in moor_data.get("clamp", []):
+        sn = int(str(clamp["serial"]).rstrip("*"))
+        hab = clamp.get("hab", "")
+
+        if sn == 0:
+            instr = str(clamp.get("instrument", "")).lower()
+            label = str(clamp.get("label", "")).lower()
+            if "microcat" in instr or "microcat" in label or "sbe37" in instr:
+                placeholder = {"serial": 0, "model": "SBE37", "hab": hab}
+                mcats_by_group["old_seaterm"].append(placeholder)
+                mcats_by_group["seaterm_v2"].append(placeholder)
+            elif "aquadopp" in instr or "aquadopp" in label:
+                aquadopps.append({"serial": 0, "model": "Aquadopp", "hab": hab})
+            continue
+
+        try:
+            itype, entry = sn_to_entry(instruments, sn)
+        except KeyError:
+            sheet_warnings.append(f"SN {sn} not found in instruments.yaml")
+            continue
+
+        entry = dict(entry, hab=hab)
+        if itype == "microcat":
+            mcats_by_group[fw_group(entry, sentinel)].append(entry)
+        elif itype == "aquadopp":
+            aquadopps.append(entry)
+        elif itype == "rbr_tr1050":
+            rbr_tr1050.append(entry)
+        elif itype == "rbr_solot":
+            rbr_solot.append(entry)
+
+    for item in moor_data.get("inline", []):
+        raw_serial = str(item.get("serial", "0"))
+        sn = int(raw_serial.split(",")[0].strip())
+        if item.get("instrument", "").lower() in ("adcp",) or item.get(
+            "file_type", ""
+        ).startswith("rdi"):
+            try:
+                itype, entry = sn_to_entry(instruments, sn)
+            except KeyError:
+                entry = {"serial": sn, "model": "ADCP"}
+            adcp_items.append(
+                dict(entry, hab=item.get("hab_bottom") or item.get("hab_top") or "")
+            )
+
+    return {
+        "mcats_by_group": mcats_by_group,
+        "aquadopps": aquadopps,
+        "rbr_tr1050": rbr_tr1050,
+        "rbr_solot": rbr_solot,
+        "adcp": adcp_items,
+    }
+
+
+def build_mooring_download(
+    mooring: str, cfg: LogsheetsConfig, fmt: str = "pdf"
+) -> Path:
+    """Build mooring-download PDF logsheets for all instrument types.
+
+    Parameters
+    ----------
+    mooring:
+        Mooring name, e.g. ``"dsG3_1_2026"``.
+    cfg:
+        Resolved logsheets configuration from :func:`~._config.resolve_config`.
+    fmt:
+        ``"pdf"`` or ``"tex"``.
+
+    """
+    cruise_cfg = load_yaml(cfg.cruise_config_path)
+    col_defs = load_yaml(cfg.column_defs_path)
+    col_library = col_defs.get("column_library", {})
+    instruments = load_instruments(cfg)
+
+    sentinel = cruise_cfg.get("microcat_firmware_sentinel", "3.0d")
+    cruise = cruise_cfg["cruise"]
+    raw_data = cruise_cfg.get("paths", {}).get("raw_data", "")
+    fn_conventions = cruise_cfg.get("filename_conventions", {})
+
+    mooring_yaml_map = cruise_cfg.get("mooring_yaml_map", {})
+    yaml_path = resolve_mooring_yaml(mooring, cfg, mooring_yaml_map)
+    if yaml_path:
+        moor_data = load_yaml(yaml_path)
+    else:
+        print(
+            f"  Warning: no mooring YAML found for {mooring} — using empty instrument list"
+        )
+        moor_data = {"clamp": [], "inline": []}
+
+    sheet_warnings: list[str] = []
+    buckets = _collect_instruments(moor_data, instruments, sentinel, sheet_warnings)
+    sections = []
+
+    # ── MicroCAT sections ─────────────────────────────────────────────────────
+    mcat_def = col_defs.get(
+        "microcat_download_mooring", col_defs.get("microcat_download", {})
+    )
+    mcat_note_raw = mcat_def.get("data_path_note", "")
+
+    for grp, entries in buckets["mcats_by_group"].items():
+        if not entries:
+            continue
+        conv_key = _FW_CONV_KEY.get(grp, "download_seaterm_v2")
+        convention = fn_conventions.get("microcat", {}).get(conv_key, "")
+        col_key = f"columns_{grp}"
+        cols_raw = mcat_def.get(col_key, mcat_def.get("columns", []))
+        cols = resolve_columns(cols_raw, col_library)
+        cols = apply_download_convention(cols, convention)
+        note_lines = format_data_path_note(
+            mcat_note_raw,
+            raw_data=raw_data,
+            mooring=mooring,
+            download_convention=convention,
+        )
+        sections.append(
+            {
+                "title": FW_GROUP_LABELS[grp],
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "note_lines": note_lines,
+                "data_rows": [data_row(cols, sn=e["serial"]) for e in entries],
+                "ncols": len(cols),
+            }
+        )
+
+    # ── Aquadopp section ──────────────────────────────────────────────────────
+    if buckets["aquadopps"]:
+        aq_def = col_defs.get(
+            "aquadopp_download_mooring", col_defs.get("aquadopp_download", {})
+        )
+        cols = resolve_columns(aq_def.get("columns", []), col_library)
+        convention = fn_conventions.get("aquadopp", {}).get("download", "")
+        cols = apply_download_convention(cols, convention)
+        note_lines = format_data_path_note(
+            aq_def.get("data_path_note", ""),
+            raw_data=raw_data,
+            mooring=mooring,
+            instrument="aquadopp",
+        )
+        sections.append(
+            {
+                "title": aq_def.get("section_title", "Aquadopp Download"),
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "note_lines": note_lines,
+                "data_rows": [
+                    data_row(cols, sn=e["serial"]) for e in buckets["aquadopps"]
+                ],
+                "ncols": len(cols),
+            }
+        )
+
+    # ── RBR sections ──────────────────────────────────────────────────────────
+    for bucket_key, def_key, title_default in [
+        ("rbr_tr1050", "rbr_tr1050_download_mooring", "RBR TR-1050 Download"),
+        ("rbr_solot", "rbr_solot_download_mooring", "RBR soloT Download"),
+    ]:
+        entries = buckets[bucket_key]
+        if not entries:
+            continue
+        defn = col_defs.get(def_key, {})
+        cols = resolve_columns(defn.get("columns", []), col_library)
+        note_lines = format_data_path_note(
+            defn.get("data_path_note", ""),
+            raw_data=raw_data,
+            mooring=mooring,
+        )
+        sections.append(
+            {
+                "title": defn.get("section_title", title_default),
+                "colspec": colspec_from_cols(cols),
+                "header_row": header_row(cols),
+                "example_row": example_data_row(cols),
+                "note_lines": note_lines,
+                "data_rows": [data_row(cols, sn=e["serial"]) for e in entries],
+                "ncols": len(cols),
+            }
+        )
+
+    tex_source = (
+        make_jinja_env(cfg.templates_dir)
+        .get_template("mooring_download.tex.j2")
+        .render(
+            cruise=cruise,
+            mooring=mooring,
+            mooring_tex=mooring.replace("_", r"\_"),
+            sections=sections,
+            sheet_warnings=sheet_warnings,
+            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        )
+    )
+
+    out_dir = cfg.output_dir / "mooring-download"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{mooring}_download"
+    try:
+        return render_sheet(tex_source, out_dir, stem, fmt)
+    except RuntimeError:
+        sys.exit(1)

--- a/oceanarray/logsheets/builders/recovery.py
+++ b/oceanarray/logsheets/builders/recovery.py
@@ -1,0 +1,157 @@
+"""oceanarray.logsheets.builders.recovery
+=========================================
+Build mooring-recovery logsheet PDFs.
+"""
+
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .._config import (
+    LogsheetsConfig,
+    load_yaml,
+    load_instruments,
+    sn_to_entry,
+    resolve_mooring_yaml,
+)
+from .._latex import colspec_from_cols, header_row, tex_safe
+from .._render import make_jinja_env, render_sheet
+
+_RECOVERY_HW_TYPES = {"float", "release"}
+
+
+def _group_inline_floats(inline_items: list[dict]) -> list[dict]:
+    """Collapse consecutive float entries sharing the same component_id into one."""
+    result = []
+    i = 0
+    while i < len(inline_items):
+        item = inline_items[i]
+        cid = item.get("component_id")
+        if item.get("hardware_type") != "float" or not cid:
+            result.append(item)
+            i += 1
+            continue
+        run = [item]
+        j = i + 1
+        while j < len(inline_items):
+            nxt = inline_items[j]
+            if nxt.get("hardware_type") == "float" and nxt.get("component_id") == cid:
+                run.append(nxt)
+                j += 1
+            else:
+                break
+        total = sum(g.get("repeat", 1) for g in run)
+        raw_label = next(
+            (g["label"] for g in run if g.get("label") and str(g["label"]) != "null"),
+            None,
+        )
+        base = re.sub(r"^\d+\s+", "", raw_label) if raw_label else "float"
+        combined = dict(run[0])
+        combined["label"] = f"{total} {base}" if total > 1 else base
+        combined["repeat"] = total
+        result.append(combined)
+        i = j
+    return result
+
+
+def build_recovery(mooring: str, cfg: LogsheetsConfig, fmt: str = "pdf") -> Path:
+    """Build the mooring-recovery PDF for a given mooring.
+
+    Parameters
+    ----------
+    mooring:
+        Mooring name, e.g. ``"dsG3_1_2026"``.
+    cfg:
+        Resolved logsheets configuration from :func:`~._config.resolve_config`.
+    fmt:
+        ``"pdf"`` or ``"tex"``.
+
+    """
+    cruise_cfg = load_yaml(cfg.cruise_config_path)
+    col_defs = load_yaml(cfg.column_defs_path)
+    instruments = load_instruments(cfg)
+    cruise = cruise_cfg["cruise"]
+
+    rec_def = col_defs["recovery"]
+    comp_cols = rec_def["columns_component"]
+    rang_cols = rec_def["columns_ranging"]
+
+    rows = []
+    sheet_warnings: list[str] = []
+    waterdepth = ""
+
+    mooring_yaml_map = cruise_cfg.get("mooring_yaml_map", {})
+    yaml_path = resolve_mooring_yaml(mooring, cfg, mooring_yaml_map)
+    if yaml_path:
+        moor_data = load_yaml(yaml_path)
+        waterdepth = str(moor_data.get("waterdepth", ""))
+
+        for clamp in moor_data.get("clamp", []):
+            sn = int(str(clamp["serial"]).rstrip("*"))
+            hab = clamp.get("hab") or 0
+            try:
+                itype, entry = sn_to_entry(instruments, sn)
+                model = entry.get("model", "")
+                item_str = {
+                    "microcat": "MicroCAT",
+                    "aquadopp": "Aquadopp",
+                    "rbr_tr1050": "RBR TR-1050",
+                    "rbr_solot": "RBR soloT",
+                    "adcp": f"ADCP {model}",
+                }.get(itype, itype)
+            except KeyError:
+                item_str = clamp.get("label", "?")
+                sheet_warnings.append(f"SN {sn} not found in instruments.yaml")
+            rows.append((hab, item_str, str(sn) if sn else ""))
+
+        for item in _group_inline_floats(moor_data.get("inline", [])):
+            if item.get("hardware_type") not in _RECOVERY_HW_TYPES:
+                continue
+            hab = item.get("hab_top") or item.get("hab_bottom") or 0
+            label = item.get("label") or item.get("hardware_type", "")
+            serial = item.get("serial", "")
+            sn_str = (
+                str(serial) if serial and str(serial) not in ("None", "null") else ""
+            )
+            rows.append((hab, label, sn_str))
+    else:
+        print(f"  Warning: no mooring YAML found for {mooring}")
+
+    rows.sort(key=lambda r: r[0], reverse=True)
+
+    n_comp = len(comp_cols)
+    trail = (" & " + " & ".join([""] * (n_comp - 2))) if n_comp > 2 else ""
+    comp_rows = [tex_safe(item) + " & " + tex_safe(sn) + trail for _, item, sn in rows]
+
+    mooring_tex = mooring.replace("_", r"\_")
+    waterdepth_tex = (waterdepth + r"\,m") if waterdepth else "?"
+    n_rang = len(rang_cols)
+    rang_rows = [" & ".join([""] * n_rang)] * 18
+
+    tex_source = (
+        make_jinja_env(cfg.templates_dir)
+        .get_template("recovery.tex.j2")
+        .render(
+            cruise=cruise,
+            mooring=mooring,
+            mooring_tex=mooring_tex,
+            waterdepth_tex=waterdepth_tex,
+            comp_colspec=colspec_from_cols(comp_cols),
+            comp_header_row=header_row(comp_cols),
+            comp_rows=comp_rows,
+            rang_colspec=colspec_from_cols(rang_cols),
+            rang_header_row=header_row(rang_cols),
+            rang_rows=rang_rows,
+            sheet_warnings=sheet_warnings,
+            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        )
+    )
+
+    out_dir = cfg.output_dir / "mooring-recovery"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{mooring}_recovery"
+    try:
+        return render_sheet(tex_source, out_dir, stem, fmt)
+    except RuntimeError:
+        sys.exit(1)

--- a/oceanarray/logsheets/data/column_defs.yaml
+++ b/oceanarray/logsheets/data/column_defs.yaml
@@ -1,0 +1,686 @@
+# column_defs.yaml
+# Column definitions for each logsheet type x instrument type.
+# Read by sheet_builder.py.
+#
+# COLUMN LIBRARY (top section)
+# ─────────────────────────────
+# All named columns with their default header, width, input type and (where
+# appropriate) example value.  Each sheet type below references columns by
+# key.  Lists may contain:
+#   - plain string    : use library entry as-is
+#   - {key: {overrides}}: use library entry with field overrides (e.g. width,
+#                         example, header)
+#   - {header: ..., width: ..., input: ...}: inline full definition (bypasses
+#                         the library entirely; used only where a column is
+#                         unique to one sheet)
+#
+# width values are RELATIVE weights — sheet_builder.py normalises them to
+# fill A4 landscape text width.  Rough scale: 1.0 ≈ normal, 0.7 ≈ narrow
+# tick column, 2.0+ ≈ wide text/date column.
+
+# ===========================================================================
+# COLUMN LIBRARY
+# ===========================================================================
+
+column_library:
+
+  # ── Universal ─────────────────────────────────────────────────────────────
+  sn:
+    header: "SN"
+    width: 0.6
+    input: readonly
+  pc_used:
+    header: "PC used"
+    width: 0.8
+    input: free
+    example: "ifm23-w01"
+  transfer_to_server:
+    header: "Transfer to server?"
+    width: 0.7
+    input: tick
+    example: "\\checkmark"
+  date_time_ok:
+    header: "Date & time ok?"
+    width: 0.6
+    input: tick
+    example: "\\checkmark"
+  startlater:
+    header: "STARTLATER sent?"
+    width: 0.85
+    input: tick
+    example: "\\checkmark"
+
+  # ── Download shared ────────────────────────────────────────────────────────
+  visible_defects:
+    header: "Visible defects?"
+    width: 1.2
+    input: free
+    example: "--"
+  stopped_ok:
+    header: "Stopped ok?"
+    width: 0.7
+    input: tick
+    example: "\\checkmark"
+  last_sample_num:
+    header: "Last sample #"
+    width: 1.0
+    input: free
+  scan_range:
+    header: "Scan range (from-to)"
+    width: 1.2
+    input: free
+  download_complete:
+    header: "Download complete?"
+    width: 0.8
+    input: tick
+    example: "\\checkmark"
+  filename_convention:
+    header: "Filename ({download_convention})"
+    width: 1.5
+    input: free
+  convert_to_cnv:
+    header: "Convert to CNV?"
+    width: 0.7
+    input: tick
+    example: "\\checkmark"
+  convert_to_csv:
+    header: "Convert to CSV?"
+    width: 0.7
+    input: tick
+    example: "\\checkmark"
+  convert_hex_matlab:
+    header: "Convert hex to legacy Matlab (Ruskin)?"
+    width: 1.0
+    input: tick
+    example: "\\checkmark"
+  file_size_mb:
+    header: "File size (MB)"
+    width: 0.8
+    input: free
+
+  # ── Status/clock timing ───────────────────────────────────────────────────
+  computer_time_at_ds:
+    header: "Computer time at ds"
+    width: 0.7
+    input: free
+    example: "10:23:00"
+  instrument_time_at_ds:
+    header: "Instrument time at ds"
+    width: 0.7
+    input: free
+    example: "10:23:17"
+  computer_time_at_status:
+    header: "Computer time at status"
+    width: 0.7
+    input: free
+    example: "10:23:00"
+  instrument_time_at_status:
+    header: "Instrument time at status"
+    width: 0.7
+    input: free
+    example: "10:23:17"
+
+  # ── MicroCAT old_seaterm commands ─────────────────────────────────────────
+  interval_10s:
+    header: "INTERVAL= (10)"
+    width: .8
+    input: free
+  samplenum_no_reset:
+    header: "SAMPLENUM= (do NOT reset)"
+    width: 1.4
+    input: free
+  samplenum_reset_0:
+    header: "SAMPLENUM=0 sent?"
+    width: 1.0
+    input: tick
+    example: "\\checkmark"
+  storetime_y:
+    header: "STORETIME= (y)"
+    width: 0.85
+    input: free
+  navg_1:
+    header: "NAVG= (1)"
+    width: 0.8
+    input: free
+  start_ddmmyyyy:
+    header: "START [DDMMYYYY]"
+    width: 1.8
+    input: free
+  start_hhmmss:
+    header: "START [hhmmss]"
+    width: 1.8
+    input: free
+  start_datetime:
+    header: "Start date/time"
+    width: 2.0
+    input: free
+
+  # ── MicroCAT seaterm_v2 commands ──────────────────────────────────────────
+  sampleinterval_10s:
+    header: "SAMPLEINTERVAL =(10)"
+    width: 1.15
+    input: free
+  output_settings_v2:
+    header: "OutputExecutedTag=n Outputformat=3 BaudRate=38400"
+    width: 1.4
+    input: tick
+  txrealtime_Y:
+    header: "TXREALTIME = ?"
+    width: 0.85
+    input: free
+  txrealtime_N:
+    header: "TXREALTIME =(N)"
+    width: 0.7
+    input: free
+  samplenumber_no_reset:
+    header: "SAMPLENUMBER= (do NOT reset)"
+    width: 1.1
+    input: free
+  samplenumber_reset_0:
+    header: "SAMPLENUMBER =0 sent?"
+    width: 1.0
+    input: tick
+    example: "\\checkmark"
+  startdatetime:
+    header: "STARTDATETIME= [MMDDYYYY][hhmmss]"
+    width: 1.8
+    input: free
+
+  # ── MicroCAT seaterm_v2_odo extras ────────────────────────────────────────
+  oxntau_1:
+    header: "OXNTAU= (1)"
+    width: 0.7
+    input: free
+  oxntau_7:
+    header: "OXNTAU= (7)"
+    width: 0.7
+    input: free
+  oxtau20_55:
+    header: "OXTAU20= (5.5)"
+    width: 0.7
+    input: free
+  adaptivepump_N:
+    header: "ADAPTIVEPUMP CONTROL=N"
+    width: 0.8
+    input: free
+  adaptivepump_Y:
+    header: "ADAPTIVEPUMP CONTROL=Y"
+    width: 0.8
+    input: free
+
+  # ── Aquadopp ──────────────────────────────────────────────────────────────
+  sampling_interval:
+    header: "Sampling interval (s)"
+    width: .8
+    input: free
+  average_interval:
+    header: "Average interval (s)"
+    width: .8
+    input: free
+  blanking_dist:
+    header: "Blanking dist (m)"
+    width: 0.8
+    input: free
+  capture_file:
+    header: "Capture file"
+    width: .5
+    input: free
+  compass_update:
+    header: "Compass update (s)"
+    width: 0.8
+    input: free
+  coordinate_system:
+    header: "Coordinate system"
+    width: 0.8
+    input: free
+  diag_interval:
+    header: "Diag interval"
+    width: 0.5
+    input: free
+  diag_samples:
+    header: "Diag samples"
+    width: 0.7
+    input: free
+  start_datetime_aq:
+    header: "Start date/time [DDMMYYYY hhmmss]"
+    width: 2.0
+    input: free
+  screenshot_file:
+    header: "Screenshot file"
+    width: 1.5
+    input: free
+  sos_measured_or_fixed:
+    header: "Speed of sound: measured | fixed"
+    width: 1.0
+    input: free
+  sos_fixed:
+    header: "Speed of sound measured"
+    width: 1.0
+    input: free
+  sos_salinity:
+    header: "If measured, salinity"
+    width: 1.0
+    input: free
+
+  # ── RBR ───────────────────────────────────────────────────────────────────
+  rbr_model:
+    header: "Model"
+    width: 1.2
+    input: readonly
+  sample_interval:
+    header: "Sample interval (s)"
+    width: 0.8
+    input: free
+  enabled:
+    header: "Enabled?"
+    width: 0.7
+    input: tick
+
+# ===========================================================================
+# CALDIP SETUP
+# ===========================================================================
+
+microcat_setup_caldip:
+  data_path_note: |
+    Data path: {caldip_data}/cal_dip/{cast_label}/
+    Firmware < 3.0d: {default_filename}_cal_dip_data.asc
+    Firmware >= 3.0d: {default_filename}_cal_dip_data.xml -> Convert XML -> .cnv
+
+  columns_old_seaterm:
+    - sn
+    - date_time_ok
+    - interval_10s: {example: "10"}
+    - samplenum_no_reset: {example: "NO"}
+    - storetime_y: {example: "--"}
+    - navg_1: {example: "1"}
+    - start_ddmmyyyy
+    - start_hhmmss
+    - startlater
+    - transfer_to_server
+
+  columns_seaterm_v2:
+    - sn
+    - date_time_ok: {width: 0.55}
+    #- output_settings_v2: {example: "\\checkmark"}
+    - sampleinterval_10s: {example: "10"}
+    - txrealtime_Y: {example: "N"}
+    - samplenumber_no_reset: {example: "NO"}
+    - startdatetime
+    - startlater
+    - transfer_to_server
+
+  columns_seaterm_v2_odo:
+    - sn
+    - date_time_ok: {width: 0.7}
+    - sampleinterval_10s: {width: 1.0, example: "10"}
+    - oxntau_1
+    - oxtau20_55
+    - adaptivepump_N
+#    - output_settings_v2: {width: 1.2, example: "\\checkmark"}
+    - txrealtime_Y: {width: 0.7, example: "N"}
+    - samplenumber_no_reset: {width: 1.3, example: "--"}
+    - startdatetime: {width: 2.5}
+    - startlater
+    - transfer_to_server
+
+aquadopp_setup_caldip:
+  section_title: "Aquadopp Calibration Dip Setup"
+  columns:
+    - sn
+    - sampling_interval
+    - average_interval
+    - blanking_dist
+    - compass_update
+    - coordinate_system
+    - diag_interval
+    - start_datetime_aq
+    - transfer_to_server
+
+rbr_setup_caldip:
+  section_title: "RBR Thermistor Calibration Dip Setup"
+  columns:
+    - sn
+    - date_time_ok: {width: 0.7}
+    - sample_interval: {example: "1"}
+    - start_ddmmyyyy: {width: 1.6, header: "START [DD/MM/YYYY]", example: "10/07/2026"}
+    - start_hhmmss: {width: 1.4, header: "START [hh:mm:ss]"}
+    - enabled: {example: "\\checkmark"}
+    - screenshot_file: {header: "Screenshot?", width: 0.8, input: tick, example: "\\checkmark"}
+    - transfer_to_server
+
+# ===========================================================================
+# CALDIP DOWNLOAD
+# ===========================================================================
+
+microcat_download_caldip:
+  data_path_note: |
+    Data path: {caldip_data}/cal_dip/{cast_label}/
+    Firmware < 3.0d: {default_filename}_cal_dip_data.asc
+    Firmware >= 3.0d: {default_filename}_cal_dip_data.xml -> Convert XML -> .cnv
+
+  columns_old_seaterm:
+    - sn
+    - visible_defects
+    - pc_used
+    - date_time_ok
+    - stopped_ok
+    - last_sample_num
+    - filename_convention: {header: "Filename ({default_filename}_cal_dip_data.asc)", width: 2.0}
+    - scan_range: {width: 1.5}
+    - file_size_mb
+    - transfer_to_server
+
+  columns_seaterm_v2:
+    - sn
+    - visible_defects
+    - pc_used
+    - date_time_ok
+    - stopped_ok
+    - last_sample_num
+    - filename_convention: {header: "Filename ({default_filename}_cal_dip_data.xml)", width: 2.0}
+    - scan_range: {width: 1.5}
+    - file_size_mb
+    - transfer_to_server
+
+  columns_seaterm_v2_odo:
+    - sn
+    - visible_defects
+    - pc_used
+    - date_time_ok
+    - stopped_ok: {width: .5}
+    - last_sample_num
+    - filename_convention: {header: "Filename ({default_filename}_cal_dip_data.xml)", width: 2.5}
+    - scan_range: {width: 1.0}
+    - file_size_mb: {width: .5}
+    - transfer_to_server
+
+aquadopp_download_caldip:
+  section_title: "Aquadopp Calibration Dip Download"
+  data_path_note: |
+    Data path: {caldip_data}/cal_dip/{cast_label}/
+    Note: only Aquadopps with a .prf file need converting to csv; others can be transferred as-is.
+  columns:
+    - sn
+    - visible_defects
+    - pc_used
+    - stopped_ok
+    - filename_convention: {header: "Filename ({default_filename}_cal_dip_data)", width: 2.5}
+    - download_complete
+    - convert_to_csv
+    - file_size_mb
+    - transfer_to_server
+
+rbr_solot_download_caldip:
+  section_title: "RBR soloT Calibration Dip Download"
+  data_path_note: |
+    Data path: {caldip_data}/cal_dip/{cast_label}/
+  columns:
+    - sn: {example: "101645"}
+    - visible_defects: {example: "--"}
+    - pc_used
+    - stopped_ok
+    - download_complete
+    - filename_convention: {example: "_cal_dip_data.rsk"}
+    - file_size_mb
+    - transfer_to_server
+
+rbr_tr1050_download_caldip:
+  section_title: "RBR TR-1050 Calibration Dip Download"
+  data_path_note: |
+    Data path: {caldip_data}/cal_dip/{cast_label}/
+    Download .hex via Ruskin; convert hex to legacy Matlab before uploading.
+  columns:
+    - sn: {example: "15576"}
+    - visible_defects: {example: "bent thermistor"}
+    - pc_used
+    - stopped_ok
+    - filename_convention: {example: "_cal_dip_data.hex"}
+    - download_complete
+    - convert_hex_matlab
+    - file_size_mb
+    - transfer_to_server
+
+# ===========================================================================
+# MOORING DOWNLOAD (post-deployment, raw data)
+# ===========================================================================
+
+microcat_download_mooring:
+  data_path_note: |
+    Data path: {raw_data}/{instrument}/{mooring}/
+    Filename: {download_convention}
+
+  columns_old_seaterm:
+    - sn: {example: "2941"}
+    - visible_defects: {example: "missing cage"}
+    - pc_used
+    - stopped_ok: {width: 0.6}
+    - last_sample_num: {example: "23724"}
+    - computer_time_at_ds
+    - instrument_time_at_ds
+    - scan_range: {example: "0--23724"}
+    - filename_convention: {example: "_recovery.asc"}
+    - file_size_mb
+    - transfer_to_server
+
+  columns_seaterm_v2:
+    - sn: {example: "7507"}
+    - visible_defects: {example: "--"}
+    - pc_used
+    - stopped_ok
+    - computer_time_at_ds
+    - instrument_time_at_ds
+    - last_sample_num: {example: "23724"}
+    - filename_convention: {example: "_recovery.xml"}
+    - scan_range: {example: "0--23724", width: 1.5}
+    - convert_to_cnv
+    - file_size_mb
+    - transfer_to_server
+
+  columns_seaterm_v2_odo:
+    - sn: {example: "13995"}
+    - visible_defects: {example: "--"}
+    - pc_used
+    - computer_time_at_ds
+    - instrument_time_at_ds
+    - stopped_ok
+    - last_sample_num: {example: "23724"}
+    - scan_range: {example: "23000--23724", width: 1.0}
+    - filename_convention: {example: "_recovery.xml"}
+    - convert_to_cnv
+    - file_size_mb
+    - transfer_to_server
+
+aquadopp_download_mooring:
+  section_title: "Aquadopp Download"
+  data_path_note: |
+    Data path: {raw_data}/{instrument}/{mooring}/
+    Filename: {download_convention} (instrument-generated name; rename to this convention)
+  columns:
+    - sn: {example: "400125"}
+    - visible_defects: {example: "--"}
+    - pc_used
+    - computer_time_at_status
+    - instrument_time_at_status
+    - download_complete
+    - filename_convention: {example: "A400125002_400125_recovery.zip"}
+    - convert_to_csv
+    - file_size_mb
+    - transfer_to_server
+
+rbr_tr1050_download_mooring:
+  section_title: "RBR TR-1050 Download"
+  data_path_note: |
+    Data path: {raw_data}/{instrument}/{mooring}/
+    Download .hex via Ruskin; convert hex to legacy Matlab before uploading.
+  columns:
+    - sn: {example: "15576"}
+    - visible_defects: {example: "--"}
+    - pc_used
+    - computer_time_at_status
+    - instrument_time_at_status
+    - download_complete
+    - filename_convention: {example: "_recovery.hex"}
+    - convert_hex_matlab
+    - file_size_mb
+    - transfer_to_server
+
+rbr_solot_download_mooring:
+  section_title: "RBR soloT Download"
+  data_path_note: |
+    Data path: {raw_data}/{instrument}/{mooring}/
+    Filename: {download_convention}
+  columns:
+    - sn: {example: "101645"}
+    - visible_defects: {example: "--"}
+    - pc_used
+    - computer_time_at_status
+    - instrument_time_at_status
+    - download_complete
+    - filename_convention: {example: "_recovery.rsk"}
+    - file_size_mb
+    - transfer_to_server
+
+adcp_download_mooring:
+  section_title: "ADCP Download"
+  data_path_note: |
+    Data path: {raw_data}/{instrument}/{mooring}/
+    Download via TRDI software; confirm file size before disconnecting.
+  columns:
+    - sn: {example: "16430"}
+    - download_complete
+    - filename_convention: {header: "Filename", example: "16430_recovery.000"}
+    - file_size_mb: {example: "142"}
+    - pc_used
+    - transfer_to_server
+
+# ===========================================================================
+# DEPLOYMENT SETUP
+# ===========================================================================
+
+microcat_setup_deployment:
+  section_title: "SeaBird SBE37 Deployment Setup"
+  data_path_note: |
+    Capture files: {raw_data}/{instrument}/{mooring}/
+
+  columns_old_seaterm:
+    - sn: {example: "2941"}
+    - pc_used
+    - date_time_ok
+    - interval_10s: {header: "INTERVAL= {sint}", example: "30"}
+    - samplenum_reset_0
+    - storetime_y
+    - navg_1
+    - start_ddmmyyyy: {example: "07102026"}
+    - start_hhmmss: {example: "230000"}
+    - startlater
+    - transfer_to_server
+
+  columns_seaterm_v2:
+    - sn: {example: "7507"}
+    - pc_used
+    - date_time_ok: {width: .5}
+#    - output_settings_v2: {width: 1.2}
+    - sampleinterval_10s: {header: "SAMPLEINTERVAL= {sint}", example: "30"}
+    - txrealtime_N: {example: "N"}
+    - samplenumber_reset_0
+    - startdatetime: {width: 1.8, example: "07102026230000"}
+    - startlater: {width: .7}
+    - transfer_to_server
+
+  columns_seaterm_v2_odo:
+    - sn: {example: "13995"}
+    - pc_used
+    - date_time_ok
+    - sint_s
+    - sampleinterval_10s: {header: "SAMPLEINTERVAL= {sint}", example: "30"}
+    - oxntau_7
+    - oxtau20_55
+    - adaptivepump_Y
+    #- output_settings_v2: {width: 1.2}
+    - txrealtime_N: {example: "N"}
+    - samplenumber_reset_0
+    - startdatetime: {width: 2.5, example: "07102026230000"}
+    - startlater
+    - transfer_to_server
+
+aquadopp_setup_deployment:
+  section_title: "Aquadopp Deployment Setup"
+  data_path_note: |
+    Capture files: {raw_data}/{instrument}/{mooring}/
+  columns:
+    - sn: {example: "10145"}
+    - pc_used
+    - date_time_ok
+    - sampling_interval: {example: "120"}
+    - average_interval: {example: "3"}
+    - blanking_dist: {example: "0.5"}
+    - compass_update: {example: "5s"}
+    - sos_measured_or_fixed: {example: "measured"}
+    - sos_salinity: {example: "35.0"}
+    - coordinate_system: {example: "beam"}
+    - diag_interval: {example: "720"}
+    - diag_samples: {example: "enable"}
+    - start_datetime_aq
+    - capture_file
+    - transfer_to_server
+
+rbr_solot_setup_deployment:
+  section_title: "RBR soloT Deployment Setup"
+  data_path_note: |
+    Capture files: {raw_data}/{instrument}/{mooring}/
+  columns:
+    - sn: {example: "10145"}
+    - pc_used
+    - date_time_ok: {width: 0.7}
+    - sample_interval: {example: "1sec"}
+    - start_datetime
+    - enabled: {example: "\\checkmark"}
+    - screenshot_file: {header: "Screenshot?", width: 0.8, input: tick, example: "\\checkmark"}
+    - transfer_to_server
+
+# ===========================================================================
+# RECOVERY
+# ===========================================================================
+
+recovery:
+  section_title: "Mooring Recovery Log"
+  # Header block fields (not table columns -- rendered as form fields)
+  header_fields:
+  - label: "Mooring"
+    width: 2.5
+  - label: "Cruise"
+    width: 2.5
+  - label: "Date"
+    width: 2.5
+  - label: "Site arrival time"
+    width: 2.5
+  - label: "Time of first ranging"
+    width: 2.5
+
+  # Component table: inline defs (unique to this sheet)
+  columns_component:
+  - header: "ITEM"
+    width: 2.0
+    input: free
+    align: left
+  - header: "SER NO"
+    width: 1.5
+    input: free
+  - header: "COMMENT"
+    width: 5.0
+    input: free
+  - header: "TIME"
+    width: 1.5
+    input: free
+
+  # Ranging table: inline defs
+  columns_ranging:
+  - header: "Time"
+    width: 1.5
+    input: free
+  - header: "Range 1"
+    width: 1
+    input: free
+  - header: "Command / comment"
+    width: 9.0
+    input: free

--- a/oceanarray/logsheets/data/latex_templates/_base_instrument.tex.j2
+++ b/oceanarray/logsheets/data/latex_templates/_base_instrument.tex.j2
@@ -1,0 +1,42 @@
+\documentclass[a4paper,landscape]{article}
+\usepackage[top=30mm,bottom=20mm,left=18mm,right=18mm]{geometry}
+\usepackage{array}
+\usepackage{colortbl}
+\newcolumntype{C}[1]{>{\centering\arraybackslash}p{#1}}
+\usepackage{longtable}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{helvet}
+\renewcommand{\familydefault}{\sfdefault}
+\usepackage{microtype}
+\usepackage{xcolor}
+\usepackage{amssymb}
+\usepackage{parskip}
+\usepackage{fancyhdr}
+
+\setlength{\parindent}{0pt}
+\setlength{\tabcolsep}{4pt}
+\setlength{\parskip}{0pt}
+
+\definecolor{hdrgray}{gray}{0.82}
+\definecolor{prefill}{gray}{0.55}
+\definecolor{exrow}{RGB}{220,235,255}
+\definecolor{warnred}{RGB}{180,0,0}
+
+\renewcommand{\arraystretch}{1.3}
+
+\newcommand{\pre}[1]{{\color{prefill}\small #1}}
+\newcommand{\datastrut}{\rule[-5pt]{0pt}{20pt}}
+
+\pagestyle{fancy}
+\fancyhf{}
+\renewcommand{\headrulewidth}{0.4pt}
+\renewcommand{\footrulewidth}{0.4pt}
+\lhead{(% block lhead %)(% endblock %)}
+\rhead{(% block rhead %)(% endblock %)}
+\lfoot{\small (( cruise ))}
+\rfoot{\small (( timestamp ))}
+
+\begin{document}
+(% block body %)(% endblock %)
+\end{document}

--- a/oceanarray/logsheets/data/latex_templates/caldip_download.tex.j2
+++ b/oceanarray/logsheets/data/latex_templates/caldip_download.tex.j2
@@ -1,0 +1,47 @@
+(% extends "_base_instrument.tex.j2" %)
+
+(% block lhead %)\large\textbf{Cal Dip Download}(% endblock %)
+(% block rhead %)\large\textbf{(( cast_label ))}(% endblock %)
+
+(% block body %)
+(% if sheet_warnings %)
+\noindent\colorbox{red!10}{\parbox{\dimexpr\linewidth-2\fboxsep\relax}{%
+  {\color{warnred}\bfseries $\bigtriangleup$\ MISSING FROM instruments.yaml --- these serials were not found and are omitted from this sheet:}\\[4pt]
+  (% for w in sheet_warnings %)
+  {\color{warnred}\small \textbullet\ (( w ))}\\
+  (% endfor %)
+}}
+\bigskip
+(% endif %)
+(% for section in sections %)
+\begin{longtable}{(( section.colspec ))}
+%% ---- title + note rows (first page) ----------------------------------------
+\multicolumn{(( section.ncols ))}{l}{\textbf{\small (( section.title ))}}\\
+(% for line in section.note_lines %)
+\multicolumn{(( section.ncols ))}{l}{{\small (( line ))}}\\
+(% endfor %)
+\hline
+(( section.header_row ))\\
+\hline
+\endfirsthead
+%% ---- continuation header (subsequent pages) --------------------------------
+\multicolumn{(( section.ncols ))}{l}{\textbf{\small (( section.title ))} {\small (continued)}}\\
+\hline
+(( section.header_row ))\\
+\hline
+\endhead
+%% ---- footer ----------------------------------------------------------------
+\hline
+\endfoot
+%% ---- example row (compact) -------------------------------------------------
+\rowcolor{exrow}
+(( section.example_row ))\\
+\hline
+%% ---- data rows (tall via \datastrut) ---------------------------------------
+(% for row in section.data_rows %)
+\datastrut (( row ))\\
+\hline
+(% endfor %)
+\end{longtable}
+(% endfor %)
+(% endblock %)

--- a/oceanarray/logsheets/data/latex_templates/caldip_setup.tex.j2
+++ b/oceanarray/logsheets/data/latex_templates/caldip_setup.tex.j2
@@ -1,0 +1,70 @@
+(% extends "_base_instrument.tex.j2" %)
+
+(% block lhead %)\large\textbf{Cal Dip Setup}(% endblock %)
+(% block rhead %)\large\textbf{(( cast_label ))}(% endblock %)
+
+(% block body %)
+(% if sheet_warnings %)
+\noindent\colorbox{red!10}{\parbox{\dimexpr\linewidth-2\fboxsep\relax}{%
+  {\color{warnred}\bfseries $\bigtriangleup$\ MISSING FROM instruments.yaml --- these serials were not found and are omitted from this sheet:}\\[4pt]
+  (% for w in sheet_warnings %)
+  {\color{warnred}\small \textbullet\ (( w ))}\\
+  (% endfor %)
+}}
+\bigskip
+(% endif %)
+\begin{tabular}{lllll}
+  \textbf{Moorings:} & (( moorings_str )) & &
+  \textbf{CTD cast \#:} & \underline{\hspace{2cm}} \\[2pt]
+  \textbf{Cast depth:} & \underline{\hspace{2cm}} m & &
+  \textbf{Date:} & \underline{\hspace{3cm}} \\
+\end{tabular}
+
+\smallskip
+{\small
+\textbf{Data path:} \texttt{(( caldip_data ))/cal\_dip/(( cast_label ))/}\\[2pt]
+\textbf{Firmware $<$ 3.0d:}\enspace\texttt{\string{default\_filename\string}\_cal\_dip\_data.asc}\\[1pt]
+\textbf{Firmware $\geq$ 3.0d:}\enspace\texttt{\string{default\_filename\string}\_cal\_dip\_data.xml $\to$ Convert XML $\to$ .cnv}
+}
+
+\smallskip
+%% UTC clock sync reminder
+{\color{warnred}\textbf{\small $\bigstar$~Confirm: laptop clock synced to UTC before setting instrument clocks.}}
+
+(% for section in sections %)
+
+\bigskip
+\begin{longtable}{(( section.colspec ))}
+%% ---- title row (first page) -----------------------------------------------
+\multicolumn{(( section.ncols ))}{l}{%
+  \textbf{\small (( section.title ))}%
+  (% if section.post_deployment %)
+  {\color{red}\small \quad --- POST-DEPLOYMENT: do \textbf{NOT} reset SAMPLENUMBER/SAMPLENUM}%
+  (% endif %)}\\
+\hline
+(( section.header_row ))\\
+\hline
+\endfirsthead
+%% ---- continuation header (subsequent pages) --------------------------------
+\multicolumn{(( section.ncols ))}{l}{%
+  \textbf{\small (( section.title ))} {\small (continued)}}\\
+\hline
+(( section.header_row ))\\
+\hline
+\endhead
+%% ---- footer ----------------------------------------------------------------
+\hline
+\endfoot
+%% ---- example row -----------------------------------------------------------
+\rowcolor{exrow}
+(( section.example_row ))\\
+\hline
+%% ---- data rows -------------------------------------------------------------
+(% for row in section.data_rows %)
+\datastrut (( row ))\\
+\hline
+(% endfor %)
+\end{longtable}
+
+(% endfor %)
+(% endblock %)

--- a/oceanarray/logsheets/data/latex_templates/deployment_setup.tex.j2
+++ b/oceanarray/logsheets/data/latex_templates/deployment_setup.tex.j2
@@ -1,0 +1,97 @@
+\documentclass[a4paper]{article}
+\usepackage[a4paper,top=2.2cm,bottom=15mm,left=2.5cm,right=2.5cm,includehead]{geometry}
+\usepackage{array}
+\usepackage{colortbl}
+\newcolumntype{C}[1]{>{\centering\arraybackslash}p{#1}}
+\usepackage{longtable}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{helvet}
+\renewcommand{\familydefault}{\sfdefault}
+\usepackage{microtype}
+\usepackage{xcolor}
+\usepackage{amssymb}
+\usepackage{parskip}
+\usepackage{fancyhdr}
+
+\setlength{\parindent}{0pt}
+\setlength{\tabcolsep}{4pt}
+\setlength{\parskip}{0pt}
+\setlength{\headheight}{16pt}
+
+\definecolor{hdrgray}{gray}{0.82}
+\definecolor{prefill}{gray}{0.55}
+\definecolor{exrow}{RGB}{220,235,255}
+\definecolor{warnred}{RGB}{180,0,0}
+\definecolor{footgray}{gray}{0.55}
+
+\renewcommand{\arraystretch}{1.3}
+
+\newcommand{\pre}[1]{{\color{prefill}\small #1}}
+\newcommand{\datastrut}{\rule[-5pt]{0pt}{20pt}}
+
+\pagestyle{fancy}
+\fancyhf{}
+\renewcommand{\headrulewidth}{0.4pt}
+\renewcommand{\footrulewidth}{0pt}
+\lhead{\large\textbf{MIXSED MOORING LOGSHEET}}
+\rhead{\large\textbf{\textcolor{red}{DEPLOYMENT}}}
+\rfoot{{\color{footgray}\small (( timestamp ))}}
+
+\begin{document}
+
+(% if sheet_warnings %)
+\noindent\colorbox{red!10}{\parbox{\dimexpr\linewidth-2\fboxsep\relax}{%
+  {\color{warnred}\bfseries $\bigtriangleup$\ MISSING FROM instruments.yaml --- these serials were not found and are omitted from this sheet:}\\[4pt]
+  (% for w in sheet_warnings %)
+  {\color{warnred}\small \textbullet\ (( w ))}\\
+  (% endfor %)
+}}
+\bigskip
+(% endif %)
+
+\begin{tabular}{lllllll}
+  \textbf{Mooring:} & (( mooring_tex )) & &
+  \textbf{Date:} & \underline{\hspace{3cm}} & &
+  \textbf{User:} \underline{\hspace{3cm}} \\
+\end{tabular}
+
+%% UTC clock sync reminder
+{\color{warnred}\textbf{\small $\bigstar$~Confirm: laptop clock synced to UTC before setting instrument clocks.}}
+
+(% for section in sections %)
+
+\bigskip
+\begin{longtable}{(( section.colspec ))}
+%% ---- title + note rows (first page) ----------------------------------------
+\multicolumn{(( section.ncols ))}{l}{\textbf{\small (( section.title ))}}\\
+(% for line in section.note_lines %)
+\multicolumn{(( section.ncols ))}{l}{{\small (( line ))}}\\
+(% endfor %)
+\hline
+(( section.header_row ))\\
+\hline
+\endfirsthead
+%% ---- continuation header (subsequent pages) --------------------------------
+\multicolumn{(( section.ncols ))}{l}{%
+  \textbf{\small (( section.title ))} {\small (continued)}}\\
+\hline
+(( section.header_row ))\\
+\hline
+\endhead
+%% ---- footer ----------------------------------------------------------------
+\hline
+\endfoot
+%% ---- example row -----------------------------------------------------------
+\rowcolor{exrow}
+(( section.example_row ))\\
+\hline
+%% ---- data rows -------------------------------------------------------------
+(% for row in section.data_rows %)
+\datastrut (( row ))\\
+\hline
+(% endfor %)
+\end{longtable}
+
+(% endfor %)
+\end{document}

--- a/oceanarray/logsheets/data/latex_templates/mooring_download.tex.j2
+++ b/oceanarray/logsheets/data/latex_templates/mooring_download.tex.j2
@@ -1,0 +1,54 @@
+(% extends "_base_instrument.tex.j2" %)
+
+(% block lhead %)\large\textbf{Mooring Download}(% endblock %)
+(% block rhead %)\large\textbf{(( mooring_tex ))}(% endblock %)
+
+(% block body %)
+(% if sheet_warnings %)
+\noindent\colorbox{red!10}{\parbox{\dimexpr\linewidth-2\fboxsep\relax}{%
+  {\color{warnred}\bfseries $\bigtriangleup$\ MISSING FROM instruments.yaml --- these serials were not found and are omitted from this sheet:}\\[4pt]
+  (% for w in sheet_warnings %)
+  {\color{warnred}\small \textbullet\ (( w ))}\\
+  (% endfor %)
+}}
+\bigskip
+(% endif %)
+%% UTC clock sync reminder
+{\color{warnred}\textbf{\small $\bigstar$~Confirm: laptop clock synced to UTC before downloading.}}
+
+(% for section in sections %)
+\begin{longtable}{(( section.colspec ))}
+%% ---- title + note rows (first page) ----------------------------------------
+\multicolumn{(( section.ncols ))}{l}{\textbf{\small (( section.title ))}}\\
+(% for line in section.note_lines %)
+(% if loop.first %)
+\multicolumn{(( section.ncols ))}{l}{{\small (( line ))\hfill\textbf{User:}~\underline{\hspace{4cm}}}}\\
+(% else %)
+\multicolumn{(( section.ncols ))}{l}{{\small (( line ))}}\\
+(% endif %)
+(% endfor %)
+\hline
+(( section.header_row ))\\
+\hline
+\endfirsthead
+%% ---- continuation header (subsequent pages) --------------------------------
+\multicolumn{(( section.ncols ))}{l}{\textbf{\small (( section.title ))} {\small (continued)}}\\
+\hline
+(( section.header_row ))\\
+\hline
+\endhead
+%% ---- footer ----------------------------------------------------------------
+\hline
+\endfoot
+%% ---- example row (compact) -------------------------------------------------
+\rowcolor{exrow}
+(( section.example_row ))\\
+\hline
+%% ---- data rows (tall via \datastrut) ---------------------------------------
+(% for row in section.data_rows %)
+\datastrut (( row ))\\
+\hline
+(% endfor %)
+\end{longtable}
+(% endfor %)
+(% endblock %)

--- a/oceanarray/logsheets/data/latex_templates/recovery.tex.j2
+++ b/oceanarray/logsheets/data/latex_templates/recovery.tex.j2
@@ -1,0 +1,103 @@
+\documentclass[a4paper]{article}
+\usepackage[a4paper,top=2.2cm,bottom=15mm,left=2.5cm,right=2.5cm,includehead]{geometry}
+\usepackage{array}
+\usepackage{colortbl}
+\newcolumntype{C}[1]{>{\centering\arraybackslash}p{#1}}
+\usepackage{longtable}
+\usepackage{tabularx}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{helvet}
+\renewcommand{\familydefault}{\sfdefault}
+\usepackage{microtype}
+\usepackage{xcolor}
+\usepackage{parskip}
+\usepackage{fancyhdr}
+
+\setlength{\parindent}{0pt}
+\setlength{\tabcolsep}{4pt}
+\setlength{\parskip}{0pt}
+\setlength{\headheight}{16pt}
+
+\definecolor{hdrgray}{gray}{0.82}
+\definecolor{prefill}{gray}{0.55}
+\definecolor{footgray}{gray}{0.55}
+\definecolor{warnred}{RGB}{180,0,0}
+
+\renewcommand{\arraystretch}{2.0}
+
+\newcommand{\pre}[1]{{\color{prefill}\small #1}}
+\newcommand{\blank}[1]{\underline{\hspace{#1}}}
+
+\pagestyle{fancy}
+\fancyhf{}
+\renewcommand{\headrulewidth}{0.4pt}
+\renewcommand{\footrulewidth}{0pt}
+\lhead{\large\textbf{MIXSED MOORING LOGSHEET}}
+\rhead{\large\textbf{\textcolor{red}{RECOVERY}}}
+\rfoot{{\color{footgray}\small (( timestamp ))}}
+
+\begin{document}
+
+(% if sheet_warnings %)
+\noindent\colorbox{red!10}{\parbox{\dimexpr\linewidth-2\fboxsep\relax}{%
+  {\color{warnred}\bfseries $\bigtriangleup$\ MISSING FROM instruments.yaml --- these serials were not found and are omitted from this sheet:}\\[4pt]
+  (% for w in sheet_warnings %)
+  {\color{warnred}\small \textbullet\ (( w ))}\\
+  (% endfor %)
+}}
+\bigskip
+(% endif %)
+
+\begin{tabularx}{\linewidth}{@{}lX@{\hspace{1.5em}}lX@{}}
+  \textbf{Mooring:}               & (( mooring_tex ))          &
+  \textbf{Date:}                  & \blank{\hsize}             \\[6pt]
+  \textbf{Site arrival time:}     & \blank{\hsize}             &
+  \textbf{Ascent rate:}           & \blank{\hsize}             \\[6pt]
+  \textbf{Time of first ranging:} & \blank{\hsize}             &
+  \textbf{Water depth:}           & \blank{\hsize}             \\
+\end{tabularx}
+
+\bigskip
+
+%% --- Component table --------------------------------------------------------
+\begin{longtable}{(( comp_colspec ))}
+\rowcolor{hdrgray}
+(( comp_header_row ))\\
+\hline
+\endfirsthead
+\rowcolor{hdrgray}
+(( comp_header_row ))\\
+\hline
+\endhead
+\hline
+\endfoot
+(% for row in comp_rows %)
+(( row ))\\
+\hline
+(% endfor %)
+\end{longtable}
+
+\newpage
+
+%% --- Ranging table ----------------------------------------------------------
+\textbf{Ranging log}
+
+\begin{longtable}{(( rang_colspec ))}
+\rowcolor{hdrgray}
+(( rang_header_row ))\\
+\hline
+\endfirsthead
+\rowcolor{hdrgray}
+(( rang_header_row ))\\
+\hline
+\endhead
+\hline
+\endfoot
+(% for row in rang_rows %)
+(( row ))\\
+\hline
+(% endfor %)
+\end{longtable}
+
+\end{document}

--- a/oceanarray/mooring_level.py
+++ b/oceanarray/mooring_level.py
@@ -1087,7 +1087,11 @@ class MooringStacker:
         # OceanSITES convention: time is the unlimited (first) dimension.
         ds_out = ds_out.transpose("time", "N_LEVELS")
         ds_out = cast_output_dtypes(ds_out)
-        _enc = {v: {"zlib": True, "complevel": 5} for v in ds_out.data_vars}
+        _enc = {
+            v: {"zlib": True, "complevel": 5}
+            for v in ds_out.data_vars
+            if ds_out[v].dtype.kind not in ("O", "U", "S")
+        }
         ds_out.to_netcdf(output_path, encoding=_enc)
         _status("file", self._rel(output_path))
         return True
@@ -1354,7 +1358,11 @@ class MooringGridder:
         if output_path.exists():
             output_path.unlink()
         ds_out = cast_output_dtypes(ds_out)
-        _enc = {v: {"zlib": True, "complevel": 5} for v in ds_out.data_vars}
+        _enc = {
+            v: {"zlib": True, "complevel": 5}
+            for v in ds_out.data_vars
+            if ds_out[v].dtype.kind not in ("O", "U", "S")
+        }
         ds_out.to_netcdf(output_path, encoding=_enc)
         _status("file", self._rel(output_path))
         return True

--- a/oceanarray/parameters.py
+++ b/oceanarray/parameters.py
@@ -246,13 +246,13 @@ INSTRUMENT_ABBREV = {
 # ---------------------------------------------------------------------------
 INSTRUMENT_FILE_TYPES: dict = {
     "microcat": ["sbe-cnv", "sbe-ascii", "sbe-hex"],
-    "aquadopp": ["nortek-aqd", "nortek-ascii", "nortek-csv"],
+    "aquadopp": ["nortek-ascii", "nortek-csv"],
     "tr1050": ["rbr-hex"],  # RBR TR-1050 thermistor chain
-    "rbrsolo": ["rbr-rsk", "rbr-dat"],  # RBR Solo/Duet single-channel T or T+P
-    "seapoint": ["rbr-rsk", "rbr-dat"],  # Seapoint turbidity sensor via RBR logger
+    "rbrsolo": ["rbr-rsk"],  # RBR soloT — single-channel temperature
+    "rbrduet": ["rbr-rsk"],  # RBR duet — temperature + pressure or T+C
+    "seapoint": ["rbr-rsk"],  # Seapoint turbidity sensor via RBR logger
     "ADCP": [
         "rdi-raw",  # RDI Workhorse / Sentinel via dolfyn (mhkit[dolfyn] required)
-        "nortek-aqd",
         "nortek-ascii",
         "adcp-matlab-rdadcp",
         "adcp-matlab-uhhds",
@@ -262,11 +262,11 @@ INSTRUMENT_FILE_TYPES: dict = {
 # Derived: set of allowed ``instrument:`` values in mooring YAML files.
 KNOWN_INSTRUMENT_TYPES: frozenset = frozenset(INSTRUMENT_FILE_TYPES.keys())
 
-# File types accepted by the stage1 reader but not yet tied to a canonical
-# instrument name (deprecated, legacy, or not yet standardised).
+# File types that seasenselib accepts but are deprecated, experimental, or
+# not tied to a primary instrument: value above.
 EXTRA_FILE_TYPES: dict = {
+    "nortek-aqd": "aquadopp / ADCP (DEPRECATED alias; use nortek-ascii or nortek-csv)",
     "nortek-csv-oa": "aquadopp (DEPRECATED internal reader; use nortek-csv)",
-    "rbr-rsk": "RBR instruments (instrument name not yet standardised)",
-    "rbr-dat": "RBR instruments (instrument name not yet standardised)",
+    "rbr-dat": "RBR instruments (not in current seasenselib; use rbr-rsk)",
     "rbr-matlab-legacy": "RBR instruments (DEPRECATED legacy format)",
 }

--- a/oceanarray/stage3.py
+++ b/oceanarray/stage3.py
@@ -951,13 +951,23 @@ def _apply_qc_tests(
                 continue
             suspect_n = int(fl_cfg.get("suspect_n", 3))
             fail_n = int(fl_cfg.get("fail_n", 10))
-            _fl_result = qartod.flat_line_test(
-                inp=data,
-                tinp=time_s,
-                suspect_threshold=int(suspect_n * dt_s),
-                fail_threshold=int(fail_n * dt_s),
-                tolerance=float(fl_cfg.get("tolerance", 0.0)),
-            )
+            try:
+                _fl_result = qartod.flat_line_test(
+                    inp=data,
+                    tinp=time_s,
+                    suspect_threshold=int(suspect_n * dt_s),
+                    fail_threshold=int(fail_n * dt_s),
+                    tolerance=float(fl_cfg.get("tolerance", 0.0)),
+                )
+            except (ValueError, OverflowError) as _fl_err:
+                import warnings
+
+                warnings.warn(
+                    f"flat_line_test skipped for '{varname}': {_fl_err}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                continue
             # flat_line_test may return a masked array or plain ndarray depending
             # on the ioos_qc version; handle both.
             fl_flags = (

--- a/oceanarray/stage3.py
+++ b/oceanarray/stage3.py
@@ -937,6 +937,18 @@ def _apply_qc_tests(
             # Convert datetime64 → float seconds since epoch for ioos_qc
             time_s = time_vals.astype("datetime64[s]").astype(float)
             dt_s = float(np.nanmedian(np.diff(time_s))) if len(time_s) > 1 else 60.0
+            if dt_s <= 0:
+                # All timestamps are identical (or single record); ioos_qc would
+                # divide by zero inside flat_line_test — skip the test.
+                import warnings
+
+                warnings.warn(
+                    f"flat_line_test skipped for '{varname}': median time interval is "
+                    f"{dt_s:.1f} s (all timestamps identical?)",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                continue
             suspect_n = int(fl_cfg.get("suspect_n", 3))
             fail_n = int(fl_cfg.get("fail_n", 10))
             _fl_result = qartod.flat_line_test(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,13 @@ oceanarray = "oceanarray.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["oceanarray"]
+include = ["oceanarray", "oceanarray.*"]
+
+[tool.setuptools.package-data]
+oceanarray = [
+  "logsheets/data/column_defs.yaml",
+  "logsheets/data/latex_templates/*.tex.j2",
+]
 
 [tool.setuptools.dynamic]
 dependencies = { file = [
@@ -130,3 +136,12 @@ ignore = [
 # Nortek header parsers use except Exception: pass to handle malformed/missing files.
 # Stage1 also has TRY003 for a single ValueError with a descriptive message.
 "oceanarray/stage1.py" = ["BLE001", "TRY003"]
+# Logsheets modules: builders use sys.exit() for user-facing errors (CLI tool pattern),
+# BLE001/TRY for broad catches in _firmware.py, ANN/D deferred (internal impl files).
+"oceanarray/logsheets/_config.py" = ["BLE001", "TRY003", "ANN", "D"]
+"oceanarray/logsheets/_columns.py" = ["BLE001", "TRY003", "ANN", "D"]
+"oceanarray/logsheets/__init__.py" = ["D"]
+"oceanarray/logsheets/_firmware.py" = ["BLE001", "TRY003", "TRY300", "ANN", "D"]
+"oceanarray/logsheets/_latex.py" = ["BLE001", "TRY003", "ANN", "D"]
+"oceanarray/logsheets/_render.py" = ["BLE001", "TRY003", "ANN", "D"]
+"oceanarray/logsheets/builders/*.py" = ["BLE001", "TRY003", "TRY002", "ANN", "D", "ARG001"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,7 @@ ioos_qc
 dolfyn  # or: pip install "mhkit[dolfyn]"
 
 # seasenselib is installed separately: pip install -e seasenselib
+
+# Logsheets (oceanarray logsheet subcommand)
+jinja2>=3.0       # LaTeX template rendering
+packaging>=21.0   # MicroCAT firmware version comparison

--- a/tests/unit/test_logsheets.py
+++ b/tests/unit/test_logsheets.py
@@ -1,0 +1,575 @@
+"""Unit tests for oceanarray.logsheets (no pdflatex required).
+
+Builder smoke tests use fmt="tex" so they only write LaTeX source and
+never invoke pdflatex.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from oceanarray.logsheets import build_caldip_setup, build_recovery
+from oceanarray.logsheets._columns import (
+    apply_download_convention,
+    format_data_path_note,
+    resolve_columns,
+)
+from oceanarray.logsheets._config import (
+    DEFAULT_COLUMN_DEFS,
+    DEFAULT_TEMPLATES_DIR,
+    resolve_config,
+    sn_to_entry,
+)
+from oceanarray.logsheets._firmware import fw_group
+from oceanarray.logsheets._latex import (
+    colspec_from_cols,
+    data_row,
+    example_data_row,
+    header_row,
+    tex_safe,
+)
+
+
+class TestTexSafe:
+    def test_plain_string_unchanged(self):
+        assert tex_safe("hello world") == "hello world"
+
+    def test_special_chars_escaped(self):
+        assert tex_safe("&") == r"\&"
+        assert tex_safe("%") == r"\%"
+        assert tex_safe("$") == r"\$"
+        assert tex_safe("#") == r"\#"
+        assert tex_safe("_") == r"\_"
+        assert tex_safe("{") == r"\{"
+        assert tex_safe("}") == r"\}"
+        assert tex_safe("~") == r"\textasciitilde{}"
+        assert tex_safe("^") == r"\^{}"
+        assert tex_safe("\\") == r"\textbackslash{}"
+
+    def test_none_returns_empty_string(self):
+        assert tex_safe(None) == ""
+
+    def test_mixed_string(self):
+        result = tex_safe("T_C & 50%")
+        assert r"\_" in result
+        assert r"\&" in result
+        assert r"\%" in result
+
+    def test_integer_input(self):
+        assert tex_safe(42) == "42"
+
+
+class TestColspecFromCols:
+    def test_single_column(self):
+        cols = [{"width": 1.0, "align": "left"}]
+        spec = colspec_from_cols(cols)
+        assert spec.startswith("|p{")
+        assert spec.endswith("|")
+
+    def test_two_columns_produce_two_entries(self):
+        cols = [{"width": 1.0}, {"width": 2.0}]
+        spec = colspec_from_cols(cols)
+        assert spec.count("|") == 3  # leading + between + trailing
+
+    def test_non_left_uses_C_type(self):
+        cols = [{"width": 1.0}]
+        spec = colspec_from_cols(cols)
+        assert "C{" in spec
+
+    def test_fractions_sum_to_one(self):
+        cols = [{"width": 1.0}, {"width": 1.0}, {"width": 2.0}]
+        spec = colspec_from_cols(cols)
+        # 4 total weight → fracs 0.25, 0.25, 0.50
+        assert "0.25000" in spec
+        assert "0.50000" in spec
+
+
+class TestHeaderRow:
+    def test_contains_cellcolor_and_bfseries(self):
+        cols = [{"header": "SN", "width": 1.0}]
+        row = header_row(cols)
+        assert r"\cellcolor{hdrgray}" in row
+        assert r"\bfseries" in row
+        assert "SN" in row
+
+    def test_multiple_columns_joined_by_ampersand(self):
+        cols = [{"header": "A", "width": 1.0}, {"header": "B", "width": 1.0}]
+        row = header_row(cols)
+        assert " & " in row
+
+    def test_underscore_escaped_in_header(self):
+        cols = [{"header": "col_name", "width": 1.0}]
+        row = header_row(cols)
+        assert r"\_" in row
+
+
+class TestExampleDataRow:
+    def test_no_example_gives_empty_cell(self):
+        cols = [{"width": 1.0}]
+        row = example_data_row(cols)
+        assert row == ""
+
+    def test_example_wrapped_in_textit(self):
+        cols = [{"width": 1.0, "example": "26261"}]
+        row = example_data_row(cols)
+        assert r"\textit" in row
+        assert "26261" in row
+
+    def test_latex_example_not_double_escaped(self):
+        cols = [{"width": 1.0, "example": r"\textbf{X}"}]
+        row = example_data_row(cols)
+        # starts with \ so passed through as-is, not tex_safe'd
+        assert r"\textbf{X}" in row
+
+
+class TestDataRow:
+    def _cols(self, *specs):
+        return [{"header": h, "width": 1.0, "input": inp} for h, inp in specs]
+
+    def test_free_cell_is_empty(self):
+        cols = self._cols(("Notes", "free"))
+        assert data_row(cols) == ""
+
+    def test_tick_cell_is_empty(self):
+        cols = self._cols(("Done?", "tick"))
+        assert data_row(cols) == ""
+
+    def test_readonly_non_sn_is_empty(self):
+        cols = self._cols(("Model", "readonly"))
+        assert data_row(cols, sn=12345) == ""
+
+    def test_readonly_sn_column_shows_sn(self):
+        cols = self._cols(("SN", "readonly"))
+        assert "12345" in data_row(cols, sn=12345)
+
+    def test_readonly_sn_zero_gives_empty(self):
+        cols = self._cols(("SN", "readonly"))
+        assert data_row(cols, sn=0) == ""
+
+    def test_prefilled_extra_overrides_all(self):
+        cols = self._cols(("SN", "readonly"))
+        row = data_row(cols, sn=99, prefilled_extra={0: "OVERRIDE"})
+        assert "OVERRIDE" in row
+        assert "99" not in row
+
+    def test_extra_readonly_renders_as_small(self):
+        cols = self._cols(("Notes", "free"))
+        row = data_row(cols, extra_readonly={0: "fixed text"})
+        assert r"\small" in row
+        assert "fixed text" in row
+
+    def test_prefilled_with_default(self):
+        cols = [{"header": "Sint", "width": 1.0, "input": "prefilled", "default": "60"}]
+        row = data_row(cols)
+        assert r"\pre{60}" in row
+
+    def test_multiple_columns_separated_by_ampersand(self):
+        cols = self._cols(("SN", "readonly"), ("Notes", "free"))
+        row = data_row(cols, sn=100)
+        assert " & " in row
+
+
+# ---------------------------------------------------------------------------
+# _firmware.py
+# ---------------------------------------------------------------------------
+
+
+class TestFwGroup:
+    def test_odo_true_always_seaterm_v2_odo(self):
+        assert fw_group({"odo": True, "firmware": "2.9"}) == "seaterm_v2_odo"
+
+    def test_old_firmware_below_sentinel(self):
+        assert fw_group({"firmware": "2.9"}) == "old_seaterm"
+        assert fw_group({"firmware": "1.0"}) == "old_seaterm"
+
+    def test_firmware_at_sentinel_is_seaterm_v2(self):
+        assert fw_group({"firmware": "3.0d"}) == "seaterm_v2"
+
+    def test_firmware_above_sentinel(self):
+        assert fw_group({"firmware": "6.3.2"}) == "seaterm_v2"
+
+    def test_no_firmware_defaults_to_seaterm_v2(self):
+        assert fw_group({}) == "seaterm_v2"
+        assert fw_group({"firmware": None}) == "seaterm_v2"
+
+    def test_invalid_version_string_falls_back_to_string_compare(self):
+        # "3.0h" > "3.0d" lexicographically → seaterm_v2
+        assert fw_group({"firmware": "3.0h"}) == "seaterm_v2"
+        # "2.9z" < "3.0d" lexicographically → old_seaterm
+        assert fw_group({"firmware": "2.9z"}) == "old_seaterm"
+
+    def test_custom_sentinel(self):
+        assert fw_group({"firmware": "4.0"}, sentinel_str="5.0") == "old_seaterm"
+        assert fw_group({"firmware": "6.0"}, sentinel_str="5.0") == "seaterm_v2"
+
+
+# ---------------------------------------------------------------------------
+# _columns.py
+# ---------------------------------------------------------------------------
+
+_LIBRARY = {
+    "sn": {"header": "SN", "width": 0.6, "input": "readonly"},
+    "notes": {"header": "Notes", "width": 2.0, "input": "free"},
+}
+
+
+class TestResolveColumns:
+    def test_plain_string_key(self):
+        result = resolve_columns(["sn"], _LIBRARY)
+        assert len(result) == 1
+        assert result[0]["header"] == "SN"
+
+    def test_dict_with_overrides(self):
+        result = resolve_columns([{"sn": {"width": 1.5}}], _LIBRARY)
+        assert result[0]["width"] == 1.5
+        assert result[0]["header"] == "SN"
+
+    def test_inline_full_definition(self):
+        inline = {"header": "Custom", "width": 1.0, "input": "free"}
+        result = resolve_columns([inline], _LIBRARY)
+        assert result[0]["header"] == "Custom"
+
+    def test_missing_key_returns_empty_dict(self, capsys):
+        result = resolve_columns(["nonexistent"], _LIBRARY)
+        assert result == [{}]
+        captured = capsys.readouterr()
+        assert "nonexistent" in captured.out
+
+    def test_multiple_columns(self):
+        result = resolve_columns(["sn", "notes"], _LIBRARY)
+        assert len(result) == 2
+        assert result[1]["header"] == "Notes"
+
+
+class TestApplyDownloadConvention:
+    def test_placeholder_replaced(self):
+        cols = [{"header": "File ({download_convention})", "width": 1.0}]
+        result = apply_download_convention(cols, "26261_recovery.asc")
+        assert result[0]["header"] == "File (26261_recovery.asc)"
+
+    def test_no_placeholder_unchanged(self):
+        cols = [{"header": "Notes", "width": 1.0}]
+        result = apply_download_convention(cols, "anything")
+        assert result[0]["header"] == "Notes"
+
+    def test_original_list_not_mutated(self):
+        cols = [{"header": "File ({download_convention})", "width": 1.0}]
+        apply_download_convention(cols, "x")
+        assert "{download_convention}" in cols[0]["header"]
+
+
+class TestFormatDataPathNote:
+    def test_basic_substitution(self):
+        lines = format_data_path_note(
+            "Data at {raw_data}/files",
+            raw_data="/data/raw",
+        )
+        assert lines == [r"Data at /data/raw/files"]
+
+    def test_mooring_bolded(self):
+        lines = format_data_path_note("See {mooring}", mooring="dsG3_1_2026")
+        assert r"\textbf{" in lines[0]
+        assert "dsG3" in lines[0]
+
+    def test_instrument_bolded(self):
+        lines = format_data_path_note("on {instrument}", instrument="MicroCAT")
+        assert r"\textbf{" in lines[0]
+
+    def test_special_chars_in_path_escaped(self):
+        lines = format_data_path_note(
+            "path: {raw_data}",
+            raw_data="/data/raw_2026",  # underscore in path
+        )
+        assert r"\_" in lines[0]
+
+    def test_empty_note_returns_empty_list(self):
+        assert format_data_path_note("") == []
+        assert format_data_path_note(None) == []
+
+    def test_blank_lines_stripped(self):
+        lines = format_data_path_note("line1\n\nline2")
+        assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# _config.py
+# ---------------------------------------------------------------------------
+
+
+class TestResolveConfig:
+    def test_explicit_paths_take_precedence(self, tmp_path):
+        inv = tmp_path / "my_inventory.csv"
+        inv.touch()
+        lsc = tmp_path / "my_logsheet.yaml"
+        lsc.touch()
+        cfg = resolve_config(inventory_path=inv, logsheet_config_path=lsc)
+        assert cfg.instruments_path == inv
+        assert cfg.cruise_config_path == lsc
+
+    def test_config_dir_shorthand(self, tmp_path):
+        cfg = resolve_config(config_dir=tmp_path)
+        assert cfg.instruments_path == tmp_path / "instruments.yaml"
+        assert cfg.cruise_config_path == tmp_path / "cruise_config.yaml"
+
+    def test_defaults_to_bundled_column_defs(self, tmp_path):
+        cfg = resolve_config(config_dir=tmp_path)
+        assert cfg.column_defs_path == DEFAULT_COLUMN_DEFS
+
+    def test_user_column_defs_override_bundled(self, tmp_path):
+        user_col = tmp_path / "column_defs.yaml"
+        user_col.write_text("column_library: {}")
+        cfg = resolve_config(config_dir=tmp_path)
+        assert cfg.column_defs_path == user_col
+
+    def test_defaults_to_bundled_templates(self, tmp_path):
+        cfg = resolve_config(config_dir=tmp_path)
+        assert cfg.templates_dir == DEFAULT_TEMPLATES_DIR
+
+    def test_user_templates_dir_override(self, tmp_path):
+        user_tmpl = tmp_path / "latex_templates"
+        user_tmpl.mkdir()
+        cfg = resolve_config(config_dir=tmp_path)
+        assert cfg.templates_dir == user_tmpl
+
+    def test_default_output_dir(self, tmp_path):
+        cfg = resolve_config(config_dir=tmp_path)
+        assert cfg.output_dir == Path("logsheets")
+
+    def test_explicit_output_dir(self, tmp_path):
+        out = tmp_path / "out"
+        cfg = resolve_config(config_dir=tmp_path, output_dir=out)
+        assert cfg.output_dir == out
+
+    def test_env_var_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOGSHEETS_CONFIG_DIR", str(tmp_path))
+        cfg = resolve_config()
+        assert cfg.instruments_path == tmp_path / "instruments.yaml"
+
+    def test_env_var_ignored_when_explicit_path_given(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOGSHEETS_CONFIG_DIR", str(tmp_path))
+        inv = tmp_path / "explicit.csv"
+        inv.touch()
+        cfg = resolve_config(inventory_path=inv)
+        assert cfg.instruments_path == inv
+
+
+class TestLoadInstrumentsCSV:
+    def test_csv_parsed_correctly(self, tmp_path):
+        from oceanarray.logsheets._config import load_instruments, LogsheetsConfig
+        from oceanarray.logsheets._config import (
+            DEFAULT_COLUMN_DEFS,
+            DEFAULT_TEMPLATES_DIR,
+        )
+
+        csv_path = tmp_path / "inventory.csv"
+        csv_path.write_text(
+            "type,serial,model,owner,firmware,file_type\n"
+            "microcat,26261,SBE37SMP,UHH,6.3.2,sbe-hex\n"
+            "aquadopp,9920,Aquadopp,UHH,,nortek-ascii\n"
+        )
+        cfg = LogsheetsConfig(
+            cruise_config_path=tmp_path / "x.yaml",
+            instruments_path=csv_path,
+            column_defs_path=DEFAULT_COLUMN_DEFS,
+            templates_dir=DEFAULT_TEMPLATES_DIR,
+            output_dir=tmp_path,
+            proc_dir=None,
+        )
+        instruments = load_instruments(cfg)
+        assert ("microcat", 26261) in instruments
+        assert ("aquadopp", 9920) in instruments
+        assert instruments[("microcat", 26261)]["model"] == "SBE37SMP"
+        assert instruments[("microcat", 26261)]["serial"] == 26261
+
+    def test_csv_skips_rows_with_blank_type_or_serial(self, tmp_path):
+        from oceanarray.logsheets._config import load_instruments, LogsheetsConfig
+        from oceanarray.logsheets._config import (
+            DEFAULT_COLUMN_DEFS,
+            DEFAULT_TEMPLATES_DIR,
+        )
+
+        csv_path = tmp_path / "inventory.csv"
+        csv_path.write_text(
+            "type,serial,model\n"
+            ",26261,SBE37SMP\n"  # blank type
+            "microcat,,Aquadopp\n"  # blank serial
+            "microcat,26262,OK\n"
+        )
+        cfg = LogsheetsConfig(
+            cruise_config_path=tmp_path / "x.yaml",
+            instruments_path=csv_path,
+            column_defs_path=DEFAULT_COLUMN_DEFS,
+            templates_dir=DEFAULT_TEMPLATES_DIR,
+            output_dir=tmp_path,
+            proc_dir=None,
+        )
+        instruments = load_instruments(cfg)
+        assert len(instruments) == 1
+        assert ("microcat", 26262) in instruments
+
+
+class TestSnToEntry:
+    def _instruments(self):
+        return {
+            ("microcat", 26261): {"model": "SBE37SMP", "firmware": "6.3.2"},
+            ("aquadopp", 9920): {"model": "Aquadopp"},
+            ("rbrsolo", 240231): {"model": "RBRsolo"},
+        }
+
+    def test_found_microcat(self):
+        itype, entry = sn_to_entry(self._instruments(), 26261)
+        assert itype == "microcat"
+        assert entry["model"] == "SBE37SMP"
+
+    def test_found_aquadopp(self):
+        itype, entry = sn_to_entry(self._instruments(), 9920)
+        assert itype == "aquadopp"
+
+    def test_found_rbrsolo(self):
+        itype, entry = sn_to_entry(self._instruments(), 240231)
+        assert itype == "rbrsolo"
+
+    def test_not_found_raises_key_error(self):
+        with pytest.raises(KeyError, match="99999"):
+            sn_to_entry(self._instruments(), 99999)
+
+
+# ---------------------------------------------------------------------------
+# Builder smoke tests (fmt="tex", no pdflatex)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def logsheet_config_dir(tmp_path):
+    """Minimal user config dir: cruise_config.yaml + instruments.yaml."""
+    cruise_cfg = {
+        "cruise": "TestCruise",
+        "ship": "TestShip",
+        "cast_prefix": "N",
+        "microcat_firmware_sentinel": "3.0d",
+        "paths": {"caldip_data": "", "raw_data": ""},
+        "filename_conventions": {
+            "microcat": {
+                "caldip_old_seaterm": "{serial}_cal_dip_data.asc",
+                "caldip_seaterm_v2": "{serial}_cal_dip_data.xml",
+                "download_old_seaterm": "{serial}_recovery.asc",
+                "download_seaterm_v2": "{serial}_recovery.xml",
+            },
+            "aquadopp": {
+                "caldip": "{serial}_cal_dip_data.*",
+                "download": "{serial}_recovery.*",
+            },
+        },
+        "casts": {
+            "N1": {
+                "label": "Cast N1",
+                "post_deployment": False,
+                "microcat_serials": [26261],
+                "aquadopp_serials": [],
+                "rbrsolo_serials": [],
+                "tr1050_serials": [],
+            }
+        },
+        "moorings_to_recover": ["testMooring"],
+        "moorings_to_deploy": [],
+    }
+    instruments = {
+        "microcat": [
+            {
+                "serial": 26261,
+                "model": "SBE37SMP",
+                "owner": "UHH",
+                "firmware": "6.3.2",
+                "pumped": True,
+                "pressure": True,
+                "odo": False,
+                "depth_rating_m": 7000,
+            }
+        ],
+        "aquadopp": [],
+        "rbrsolo": [],
+        "tr1050": [],
+    }
+    (tmp_path / "cruise_config.yaml").write_text(yaml.dump(cruise_cfg))
+    (tmp_path / "instruments.yaml").write_text(yaml.dump(instruments))
+    return tmp_path
+
+
+@pytest.fixture()
+def mooring_yaml(tmp_path):
+    """Minimal mooring YAML at the oceanarray proc-dir convention."""
+    mooring_name = "testMooring"
+    moor_dir = tmp_path / "proc" / mooring_name
+    moor_dir.mkdir(parents=True)
+    moor_data = {
+        "name": mooring_name,
+        "waterdepth": 500,
+        "deployment_time": "2026-05-01T00:00:00",
+        "recovery_time": "2026-07-01T00:00:00",
+        "clamp": [
+            {
+                "instrument": "microcat",
+                "serial": 26261,
+                "hab": 100,
+                "file_type": "sbe-hex",
+                "filename": "26261_recovery.xml",
+            }
+        ],
+    }
+    yaml_path = moor_dir / f"{mooring_name}.mooring.yaml"
+    yaml_path.write_text(yaml.dump(moor_data))
+    return tmp_path / "proc"
+
+
+def _make_cfg(config_dir, proc_dir, tmp_path):
+    return resolve_config(
+        config_dir=config_dir,
+        output_dir=tmp_path / "output",
+        proc_dir=proc_dir,
+    )
+
+
+class TestBuildRecoverySmoke:
+    def test_tex_file_written(self, logsheet_config_dir, mooring_yaml, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, mooring_yaml, tmp_path)
+        out = build_recovery("testMooring", cfg, fmt="tex")
+        assert out.exists()
+        assert out.suffix == ".tex"
+
+    def test_tex_contains_mooring_name(
+        self, logsheet_config_dir, mooring_yaml, tmp_path
+    ):
+        cfg = _make_cfg(logsheet_config_dir, mooring_yaml, tmp_path)
+        out = build_recovery("testMooring", cfg, fmt="tex")
+        content = out.read_text()
+        assert "testMooring" in content
+
+    def test_tex_contains_waterdepth(self, logsheet_config_dir, mooring_yaml, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, mooring_yaml, tmp_path)
+        out = build_recovery("testMooring", cfg, fmt="tex")
+        content = out.read_text()
+        assert "500" in content  # waterdepth from mooring YAML
+
+    def test_missing_mooring_yaml_still_produces_output(
+        self, logsheet_config_dir, tmp_path
+    ):
+        proc_dir = tmp_path / "empty_proc"
+        proc_dir.mkdir()
+        cfg = _make_cfg(logsheet_config_dir, proc_dir, tmp_path)
+        out = build_recovery("testMooring", cfg, fmt="tex")
+        assert out.exists()
+
+
+class TestBuildCaldipSetupSmoke:
+    def test_tex_file_written(self, logsheet_config_dir, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, None, tmp_path)
+        out = build_caldip_setup("N1", cfg, fmt="tex")
+        assert out.exists()
+        assert out.suffix == ".tex"
+
+    def test_tex_contains_cast_label(self, logsheet_config_dir, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, None, tmp_path)
+        out = build_caldip_setup("N1", cfg, fmt="tex")
+        content = out.read_text()
+        assert "Cast N1" in content

--- a/tests/unit/test_logsheets.py
+++ b/tests/unit/test_logsheets.py
@@ -9,7 +9,13 @@ from pathlib import Path
 import pytest
 import yaml
 
-from oceanarray.logsheets import build_caldip_setup, build_recovery
+from oceanarray.logsheets import (
+    build_caldip_download,
+    build_caldip_setup,
+    build_deployment_setup,
+    build_mooring_download,
+    build_recovery,
+)
 from oceanarray.logsheets._columns import (
     apply_download_convention,
     format_data_path_note,
@@ -573,3 +579,100 @@ class TestBuildCaldipSetupSmoke:
         out = build_caldip_setup("N1", cfg, fmt="tex")
         content = out.read_text()
         assert "Cast N1" in content
+
+    def test_caldip_yaml_path_uses_name_as_label(self, logsheet_config_dir, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, None, tmp_path)
+        caldip = {
+            "name": "Cast X1",
+            "cruise": "TestCruise",
+            "instruments": [{"serial": 26261, "instrument": "microcat"}],
+        }
+        out = build_caldip_setup("x1.caldip.yaml", cfg, fmt="tex", caldip_yaml=caldip)
+        assert "Cast X1" in out.read_text()
+
+
+class TestBuildCaldipDownloadSmoke:
+    def test_tex_file_written(self, logsheet_config_dir, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, None, tmp_path)
+        out = build_caldip_download("N1", cfg, fmt="tex")
+        assert out.exists()
+        assert out.suffix == ".tex"
+
+    def test_tex_contains_cast_label(self, logsheet_config_dir, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, None, tmp_path)
+        out = build_caldip_download("N1", cfg, fmt="tex")
+        assert "Cast N1" in out.read_text()
+
+    def test_caldip_yaml_instruments_list(self, logsheet_config_dir, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, None, tmp_path)
+        caldip = {
+            "name": "Cast X1",
+            "cruise": "TestCruise",
+            "instruments": [{"serial": 26261, "instrument": "microcat"}],
+        }
+        out = build_caldip_download(
+            "x1.caldip.yaml", cfg, fmt="tex", caldip_yaml=caldip
+        )
+        assert "Cast X1" in out.read_text()
+
+    def test_missing_serial_produces_warning(self, logsheet_config_dir, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, None, tmp_path)
+        caldip = {
+            "name": "Cast W1",
+            "instruments": [{"serial": 99999, "instrument": "microcat"}],
+        }
+        out = build_caldip_download(
+            "w1.caldip.yaml", cfg, fmt="tex", caldip_yaml=caldip
+        )
+        # File still written; unknown serial produces a warning in the sheet.
+        assert out.exists()
+
+
+class TestBuildMooringDownloadSmoke:
+    def test_tex_file_written(self, logsheet_config_dir, mooring_yaml, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, mooring_yaml, tmp_path)
+        out = build_mooring_download("testMooring", cfg, fmt="tex")
+        assert out.exists()
+        assert out.suffix == ".tex"
+
+    def test_tex_contains_mooring_name(
+        self, logsheet_config_dir, mooring_yaml, tmp_path
+    ):
+        cfg = _make_cfg(logsheet_config_dir, mooring_yaml, tmp_path)
+        out = build_mooring_download("testMooring", cfg, fmt="tex")
+        assert "testMooring" in out.read_text()
+
+    def test_missing_mooring_yaml_still_produces_output(
+        self, logsheet_config_dir, tmp_path
+    ):
+        proc_dir = tmp_path / "empty_proc"
+        proc_dir.mkdir()
+        cfg = _make_cfg(logsheet_config_dir, proc_dir, tmp_path)
+        out = build_mooring_download("testMooring", cfg, fmt="tex")
+        assert out.exists()
+
+
+class TestBuildDeploymentSetupSmoke:
+    def test_tex_file_written(self, logsheet_config_dir, mooring_yaml, tmp_path):
+        cfg = _make_cfg(logsheet_config_dir, mooring_yaml, tmp_path)
+        out = build_deployment_setup("testMooring", cfg, fmt="tex")
+        assert out.exists()
+        assert out.suffix == ".tex"
+
+    def test_tex_contains_mooring_name(
+        self, logsheet_config_dir, mooring_yaml, tmp_path
+    ):
+        cfg = _make_cfg(logsheet_config_dir, mooring_yaml, tmp_path)
+        out = build_deployment_setup("testMooring", cfg, fmt="tex")
+        assert "testMooring" in out.read_text()
+
+    def test_missing_mooring_yaml_raises_system_exit(
+        self, logsheet_config_dir, tmp_path
+    ):
+        # deployment_setup requires the mooring YAML to exist — it cannot
+        # generate a sheet without the instrument list.
+        proc_dir = tmp_path / "empty_proc"
+        proc_dir.mkdir()
+        cfg = _make_cfg(logsheet_config_dir, proc_dir, tmp_path)
+        with pytest.raises(SystemExit):
+            build_deployment_setup("testMooring", cfg, fmt="tex")

--- a/tests/unit/test_stage1.py
+++ b/tests/unit/test_stage1.py
@@ -10,13 +10,14 @@ import xarray as xr
 import yaml
 
 pytest.importorskip("seasenselib", reason="seasenselib not installed")
-pytestmark = pytest.mark.needs_seasenselib
 
 from oceanarray.stage1 import (
     MooringProcessor,
     process_multiple_moorings,
     stage1_mooring,
 )
+
+pytestmark = pytest.mark.needs_seasenselib
 
 
 class TestMooringProcessor:

--- a/tests/unit/test_stage2.py
+++ b/tests/unit/test_stage2.py
@@ -13,7 +13,6 @@ import pytest
 import xarray as xr
 
 pytest.importorskip("seasenselib", reason="seasenselib not installed")
-pytestmark = pytest.mark.needs_seasenselib
 
 from oceanarray.stage2 import (
     Stage2Processor,
@@ -22,6 +21,8 @@ from oceanarray.stage2 import (
     process_multiple_moorings_stage2,
     stage2_mooring,
 )
+
+pytestmark = pytest.mark.needs_seasenselib
 
 
 class TestStage2Processor:

--- a/tests/unit/test_time_gridding.py
+++ b/tests/unit/test_time_gridding.py
@@ -13,13 +13,14 @@ import pytest
 import xarray as xr
 
 pytest.importorskip("seasenselib", reason="seasenselib not installed")
-pytestmark = pytest.mark.needs_seasenselib
 
 from oceanarray.time_gridding import (
     TimeGriddingProcessor,
     process_multiple_moorings_time_gridding,
     time_gridding_mooring,
 )
+
+pytestmark = pytest.mark.needs_seasenselib
 
 
 def create_mock_instrument_dataset(


### PR DESCRIPTION
## Summary

- Add `oceanarray/logsheets/` package — generates PDF fieldwork logsheets for mooring recovery/deployment and calibration-dip casts via a LaTeX/Jinja2 pipeline
- Add `oceanarray logsheet` subcommand to the main CLI
- Overhaul documentation: reorder CLI reference, add logsheets page, add file naming conventions page, update README with conda install instructions
- Fix two production bugs: `flat_line_test` divide-by-zero on degenerate timestamps (stage3), zlib compression crash on string variables (mooring_level)
  
## Changes

### New: `oceanarray/logsheets/` package

Logsheet builders covering instrument setup and download:

| Builder | Sheet type |
|---|---|
| `caldip_setup.py` | Per-instrument setup for a caldip cast |
| `caldip_download.py` | Download checklist after a caldip cast |
| `mooring_download.py` | Download checklist at mooring recovery |
| `deployment_setup.py` (`mooring-setup`) | Deployment setup log |
  
Config: `logsheet_config.yaml` (cruise-level settings) + `instrument_inventory.csv` (lab instrument registry with `type`, `serial`, `model`, `firmware`, `file_type`, capability flags).
  
### New: `oceanarray logsheet` CLI subcommand
  
```bash
oceanarray logsheet --type caldip-setup --cast B1 --config-dir config/ --proc-dir /data/proc
oceanarray logsheet --type mooring-recovery --mooring dsG3_1_2026 --config-dir config/
oceanarray logsheet --all --config-dir config/ --proc-dir /data/proc
```

`--type` choices renamed from old standalone tool: `setup-deployment` → `mooring-setup`.

### Bug fixes

- **`stage3.py`** — `flat_line_test` skipped with `RuntimeWarning` when median time interval is ≤ 0 (degenerate/single-record instrument); previously caused a divide-by-zero inside `ioos_qc`.
- **`mooring_level.py`** — zlib encoding now skips string/object-dtype variables (`dtype.kind in 'OUS'`); previously crashed when string variables (e.g. `coordinate_system`) were present in the stack or grid dataset.

### Docs

- `docs/source/logsheets.rst` — new: sheet types, config files, full CLI examples
- `docs/source/file_naming_conventions.rst` — new reference page: UHH raw file naming conventions (`####_recovery.<ext>` / `####_cal_dip_data.<ext>`) plus processed output file naming (moved from `directory_structure.rst`)
- `docs/source/cli_reference.rst` — reordered to workflow order; fixed `oceanarray list` description
- `README.md` — separate conda and pip+venv install sections; Python 3.10–3.12 recommendation
