### PR TITLE
[FEAT] Array report, knockdown figures, plot updates, cross-report links, CLI improvements

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ Contents
 
    quickstart
    installation <setup>
+   troubleshooting
 
 
 .. toctree::

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -20,24 +20,41 @@ write Python code.
 Prerequisites
 -------------
 
-**Python 3.10 or later** is required.  Install the package and its
-scientific dependencies:
+**Python 3.10 or later** is required.  First create an isolated environment,
+then clone and install from source.
+
+**Option A — conda**
 
 .. code-block:: bash
 
-   pip install oceanarray
+   conda create -n oceanarray python=3.11
+   conda activate oceanarray
+
+**Option B — venv**
+
+.. code-block:: bash
+
+   python -m venv venv
+   source venv/bin/activate        # macOS / Linux
+   # venv\Scripts\activate         # Windows
+
+**Clone and install** (after activating either environment):
+
+.. code-block:: bash
+
+   git clone https://github.com/ocean-uhh/oceanarray
+   cd oceanarray
+   pip install -e .
 
 ``oceanarray`` reads raw instrument files via the ``seasenselib`` library,
-which is a separate install:
-
-.. code-block:: bash
-
-   pip install seasenselib
+which is also not on PyPI.  Install it following the instructions provided
+with your copy of the library.
 
 .. note::
 
-   ``seasenselib`` is not distributed on PyPI.  Follow the installation
-   instructions provided with your copy of the library.
+   Without ``seasenselib``, stage 1 processing (raw file ingestion) cannot
+   run.  Stages 2–3, stack, grid, and report generation work on existing
+   NetCDF files without it.
 
 If you need to process RDI WorkHorse ADCP files (``file_type: rdi-raw``),
 install the optional ``dolfyn`` dependency:

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -7,15 +7,40 @@ dependencies and is not recommended for production use.
 
 ## Install oceanarray
 
+`oceanarray` is not distributed on PyPI.  Create an isolated Python
+environment first, then clone and install from source.
+
+### Option A — conda
+
 ```bash
-pip install oceanarray
+conda create -n oceanarray python=3.11
+conda activate oceanarray
 ```
+
+### Option B — venv
+
+```bash
+python -m venv venv
+source venv/bin/activate        # macOS / Linux
+# venv\Scripts\activate         # Windows
+```
+
+### Clone and install (after activating either environment)
+
+```bash
+git clone https://github.com/ocean-uhh/oceanarray
+cd oceanarray
+pip install -e .
+```
+
+The `-e` flag installs in editable mode so that any local changes take effect
+immediately without reinstalling.
 
 ## Install seasenselib
 
 `oceanarray` reads raw instrument files via `seasenselib`, which is a separate
-package not distributed on PyPI. Install it following the instructions provided
-with your copy of the library.
+package not distributed on PyPI.  Install it following the instructions
+provided with your copy of the library.
 
 Without `seasenselib`, stage 1 processing cannot run.  Stages 2–3 and
 mooring-level processing (stack, grid, reports) can still run on existing
@@ -42,13 +67,11 @@ If this prints a version string, the installation is complete.  See the
 
 ---
 
-## Development install
+## Development dependencies
 
-For contributors or users who want to modify the source code:
+For contributors who want to run the test suite or build the documentation:
 
 ```bash
-git clone https://github.com/ocean-uhh/oceanarray
-cd oceanarray
 pip install -e ".[dev]"
 ```
 
@@ -58,5 +81,4 @@ Run the test suite to verify:
 pytest
 ```
 
-Code must pass `ruff check .` and `black .` before committing.  See
-`project_structure.md` for an overview of the code layout.
+Code must pass `ruff check .` before committing.

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -39,12 +39,22 @@ immediately without reinstalling.
 ## Install seasenselib
 
 `oceanarray` reads raw instrument files via `seasenselib`, which is a separate
-package not distributed on PyPI.  Install it following the instructions
-provided with your copy of the library.
+package not distributed on PyPI.
+
+`seasenselib` declares version constraints on some of its dependencies
+(`pyrsktools`, `pycnv`, `pyproj`) that can conflict with the rest of the
+oceanarray environment.  Install those packages first — letting pip satisfy
+them against oceanarray's own requirements — then install `seasenselib` without
+its dependency resolver:
+
+```bash
+pip install pyrsktools pycnv
+pip install seasenselib --no-deps
+```
 
 Without `seasenselib`, stage 1 processing cannot run.  Stages 2–3 and
 mooring-level processing (stack, grid, reports) can still run on existing
-NetCDF files.
+NetCDF files.  See [Troubleshooting](troubleshooting.rst) if the install fails.
 
 ## Optional: RDI ADCP support
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1,0 +1,119 @@
+Troubleshooting
+===============
+
+This page collects common installation and runtime problems and their solutions.
+It was assembled from real installation notes on macOS (Python 3.11, Homebrew).
+
+.. contents:: On this page
+   :local:
+   :depth: 1
+
+----
+
+Installation problems
+---------------------
+
+seasenselib dependency conflicts (pyrsktools, pycnv, pyproj)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``seasenselib`` declares version constraints on several packages
+(``pyrsktools``, ``pycnv``, ``pyproj``) that can conflict with the rest of the
+oceanarray environment when pip tries to resolve everything at once.
+
+The fix is to install those packages first — letting pip satisfy them against
+oceanarray's own requirements — then install ``seasenselib`` without its
+dependency resolver:
+
+.. code-block:: bash
+
+   pip install pyrsktools pycnv
+   pip install seasenselib --no-deps
+
+This is safe because oceanarray already provides compatible versions of the
+packages that ``seasenselib`` needs at runtime.
+
+**If pyproj still fails to install** (some pip versions fail to build it from
+source), force a pre-built binary wheel before the step above:
+
+.. code-block:: bash
+
+   pip install --upgrade \
+       --force-reinstall \
+       --no-cache-dir \
+       --only-binary=:all: \
+       "pyproj>=3.7.0"
+
+Then re-run the ``pyrsktools``/``pycnv``/``seasenselib`` steps.
+
+If all else fails, recreate the virtual environment with Python 3.11 exactly
+(``python3.11 -m venv venv``) and start from scratch.
+
+----
+
+Environment problems
+--------------------
+
+Commands not found after closing the terminal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The virtual environment must be activated in every new terminal session.
+If you use a **venv**:
+
+.. code-block:: bash
+
+   source venv/bin/activate        # macOS / Linux
+   # venv\Scripts\activate         # Windows
+
+If you use **conda**:
+
+.. code-block:: bash
+
+   conda activate oceanarray
+
+If you also use a local shell script to set ``DATA_BASE`` or similar
+environment variables, source that too before running ``oceanarray``
+commands:
+
+.. code-block:: bash
+
+   source shlocal/run_mooring.sh   # example — path will differ
+
+----
+
+Runtime problems
+----------------
+
+``oceanarray`` prints no output / exits silently
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Check that the ``--proc-dir`` path exists and that the mooring YAML is
+present at ``{proc_dir}/{mooring_name}/{mooring_name}.mooring.yaml``.
+Run with ``--verbose`` or ``-v`` for more detail.
+
+Stage 1 fails with "no reader found"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``seasenselib`` is not installed, or the ``file_type:`` field in the mooring
+YAML does not match a recognised reader.  Run ``oceanarray list`` to see
+accepted ``file_type`` strings.
+
+Stage 3 velocity shows all NaN / coordinate_system is BEAM
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For Nortek Aquadopps the BEAM→ENU transformation requires a transformation
+matrix parsed from the ``.hdr`` file.  If the ``.hdr`` file was not found at
+stage 1, ``coordinate_system`` is stored as ``"BEAM"`` and stage 3 skips the
+rotation.  Verify that the ``.hdr`` file is in the same directory as the
+``.aqd`` data file and that the ``header:`` field in the mooring YAML points
+to it.
+
+----
+
+Getting help
+------------
+
+If none of the above solves your problem:
+
+* Open an issue at https://github.com/ocean-uhh/oceanarray/issues and include
+  the full traceback and the output of ``oceanarray --version``.
+* Check that your branch is up to date: ``git pull``.

--- a/oceanarray/cli.py
+++ b/oceanarray/cli.py
@@ -307,15 +307,34 @@ def cmd_plot(args: argparse.Namespace) -> int:
 
 
 def cmd_report(args: argparse.Namespace) -> int:
-    """Generate HTML quality-control reports for a mooring.
+    """Generate HTML quality-control reports for a mooring or an array.
 
-    By default produces only the mooring summary page (``{mooring}_report.html``).
-    Add flags to generate additional pages:
+    Without ``--array``: generates the mooring summary page (and optionally
+    ``--instruments``, ``--stack``, ``--grid`` pages) for a single mooring.
 
-    - ``--instruments``: one page per instrument (in ``report/instrument/``).
-    - ``--stack``: stack report (``{mooring}_stack_report.html``).
-    - ``--grid``: pressure-gridded report (``{mooring}_grid_report.html``).
+    With ``--array``: the positional argument is treated as a path to an
+    ``*.array.yaml`` file and an array-level HTML index is generated linking
+    all mooring reports.  Other report flags are ignored in array mode.
     """
+    from pathlib import Path
+
+    _, proc_root, _ = _parse_dirs(args)
+
+    if getattr(args, "array", False):
+        from .report._array import generate_array_report
+
+        # Resolve the YAML path: try as-given first, then relative to proc_dir.
+        _yaml_path = Path(args.mooring)
+        if not _yaml_path.exists() and not _yaml_path.is_absolute():
+            _yaml_path = proc_root / args.mooring
+        _status("section", f"Array report: {_yaml_path.name}")
+        result = generate_array_report(
+            array_yaml_path=_yaml_path,
+            proc_dir=proc_root,
+            force=args.force,
+        )
+        return 0 if result else 1
+
     from .report import MooringReport
 
     raw_dir, proc_root, legacy = _parse_dirs(args)
@@ -329,14 +348,15 @@ def cmd_report(args: argparse.Namespace) -> int:
             proc_dir=str(proc_root),
             raw_dir=str(raw_dir) if raw_dir else None,
         )
+    all_reports = getattr(args, "all_reports", False)
     result = reporter.generate(
         args.mooring,
         force=args.force,
         outdir=getattr(args, "outdir", None),
         serials=serials,
-        instruments=args.instruments or bool(serials),
-        grid=args.grid,
-        stack=args.stack,
+        instruments=all_reports or args.instruments or bool(serials),
+        grid=all_reports or args.grid,
+        stack=all_reports or args.stack,
     )
     return 0 if result else 1
 
@@ -630,11 +650,13 @@ def cmd_list(args: argparse.Namespace) -> int:
                 print(f"  {ft:<{instr_col}}  {note}")
 
         print()
-        print("  Notes:")
-        print("    instrument:  human-readable name stored in instrument_type")
-        print("                 coordinates; drives Aquadopp-specific plots,")
+        print("  Mooring YAML fields for each instrument entry:")
+        print("    instrument:  name from the table above; stored as instrument_type")
+        print("                 in the NetCDF output.  Drives Aquadopp-specific plots,")
         print("                 declination correction, and tilt QC.")
         print("    file_type:   selects the seasenselib reader for stage 1.")
+        print("    header:      path to the Nortek .hdr file (aquadopp only); required")
+        print("                 for beam→XYZ coordinate transformation.")
         print()
 
     return 0
@@ -915,6 +937,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Generate per-instrument page(s) for these serial number(s) only "
         "(implies --instruments for the listed serials)",
     )
+    p_report.add_argument(
+        "--all",
+        "-A",
+        action="store_true",
+        default=False,
+        dest="all_reports",
+        help="Generate all report pages: equivalent to --stack --grid --instruments",
+    )
+    p_report.add_argument(
+        "--array",
+        action="store_true",
+        default=False,
+        help="Treat the positional argument as a *.array.yaml path and generate an "
+        "array-level HTML index linking all mooring reports.",
+    )
     p_report.set_defaults(func=cmd_report)
 
     p_stack = sub.add_parser(
@@ -947,7 +984,9 @@ def build_parser() -> argparse.ArgumentParser:
         description=(
             "Reads {mooring}_stack.nc and interpolates temperature, salinity, and other\n"
             "scalar fields onto a uniform pressure grid, producing {mooring}_grid.nc.\n"
-            "Run after 'oceanarray stack'."
+            "Run after 'oceanarray stack'.\n\n"
+            "Example:\n"
+            "  oceanarray grid MOORING --proc-dir /data/proc --pmin 100 --pmax 2000 --dp 20"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/oceanarray/parameters.py
+++ b/oceanarray/parameters.py
@@ -246,14 +246,13 @@ INSTRUMENT_ABBREV = {
 # ---------------------------------------------------------------------------
 INSTRUMENT_FILE_TYPES: dict = {
     "microcat": ["sbe-cnv", "sbe-ascii", "sbe-hex"],
-    "aquadopp": ["nortek-ascii", "nortek-csv"],
+    "aquadopp": ["nortek-aqd", "nortek-ascii", "nortek-csv"],
     "tr1050": ["rbr-hex"],  # RBR TR-1050 thermistor chain
     "rbrsolo": ["rbr-rsk"],  # RBR soloT — single-channel temperature
     "rbrduet": ["rbr-rsk"],  # RBR duet — temperature + pressure or T+C
     "seapoint": ["rbr-rsk"],  # Seapoint turbidity sensor via RBR logger
     "ADCP": [
         "rdi-raw",  # RDI Workhorse / Sentinel via dolfyn (mhkit[dolfyn] required)
-        "nortek-ascii",
         "adcp-matlab-rdadcp",
         "adcp-matlab-uhhds",
     ],  # Generic ADCP (instrument: ADCP in YAML — note uppercase)
@@ -265,7 +264,6 @@ KNOWN_INSTRUMENT_TYPES: frozenset = frozenset(INSTRUMENT_FILE_TYPES.keys())
 # File types that seasenselib accepts but are deprecated, experimental, or
 # not tied to a primary instrument: value above.
 EXTRA_FILE_TYPES: dict = {
-    "nortek-aqd": "aquadopp / ADCP (DEPRECATED alias; use nortek-ascii or nortek-csv)",
     "nortek-csv-oa": "aquadopp (DEPRECATED internal reader; use nortek-csv)",
     "rbr-dat": "RBR instruments (not in current seasenselib; use rbr-rsk)",
     "rbr-matlab-legacy": "RBR instruments (DEPRECATED legacy format)",

--- a/oceanarray/plotters/_current.py
+++ b/oceanarray/plotters/_current.py
@@ -69,8 +69,8 @@ def plot_temperature_trajectory(
         [(time[i] - time[i - 1]) / np.timedelta64(1, "s") for i in range(1, len(time))],
         dtype=float,
     )
-    x = np.concatenate([[0.0], np.cumsum(u[:-1] * dt)])
-    y = np.concatenate([[0.0], np.cumsum(v[:-1] * dt)])
+    x = np.concatenate([[0.0], np.cumsum(u[:-1] * dt)]) / 1000.0
+    y = np.concatenate([[0.0], np.cumsum(v[:-1] * dt)]) / 1000.0
 
     temp = ds[temp_var].values
     units = ds[temp_var].attrs.get("units", "")
@@ -85,8 +85,8 @@ def plot_temperature_trajectory(
         y,
         color_data=temp,
         cmap="coolwarm",
-        xlabel="East displacement (m)",
-        ylabel="North displacement (m)",
+        xlabel="East displacement (km)",
+        ylabel="North displacement (km)",
         colorbar_label=colorbar_label,
         title=title,
     )
@@ -210,8 +210,8 @@ def plot_multi_aquadopp_trajectories(
     for i in aqd_idx:
         u = np.nan_to_num(ds[u_var].values[:, i], nan=0.0)
         v = np.nan_to_num(ds[v_var].values[:, i], nan=0.0)
-        x = np.concatenate([[0.0], np.cumsum(u[:-1] * dt)])
-        y = np.concatenate([[0.0], np.cumsum(v[:-1] * dt)])
+        x = np.concatenate([[0.0], np.cumsum(u[:-1] * dt)]) / 1000.0
+        y = np.concatenate([[0.0], np.cumsum(v[:-1] * dt)]) / 1000.0
         temp = ds[temp_var].values[:, i] if has_temp else None
         trajs.append((i, x, y, temp))
         if temp is not None:
@@ -220,9 +220,13 @@ def plot_multi_aquadopp_trajectories(
     cmap = plt.get_cmap("coolwarm")
     if has_temp and all_temps:
         flat = np.concatenate(all_temps)
-        _bounds = _nice_colorbar_bounds(
-            float(np.nanmin(flat)), float(np.nanmax(flat)), n=20
-        )
+        _tmin = float(np.nanmin(flat))
+        _tmax = float(np.nanmax(flat))
+        _bounds = _nice_colorbar_bounds(_tmin, _tmax, n=20)
+        # Enforce minimum tick spacing of 0.5 °C so labels don't crowd
+        if len(_bounds) > 1 and (_bounds[1] - _bounds[0]) < 0.5:
+            _n_t = max(2, int((_tmax - _tmin) / 0.5))
+            _bounds = _nice_colorbar_bounds(_tmin, _tmax, n=_n_t)
     else:
         _bounds = _nice_colorbar_bounds(0.0, 1.0, n=20)
     norm: mcolors.BoundaryNorm = mcolors.BoundaryNorm(_bounds, ncolors=256)
@@ -284,8 +288,8 @@ def plot_multi_aquadopp_trajectories(
         )
 
     ax.autoscale_view()
-    ax.set_xlabel("East displacement (m)")
-    ax.set_ylabel("North displacement (m)")
+    ax.set_xlabel("East displacement (km)")
+    ax.set_ylabel("North displacement (km)")
     ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
     ax.axvline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
     ax.set_aspect("equal", adjustable="box")
@@ -651,8 +655,14 @@ def plot_adcp_trajectories(
             v[pqc >= 3] = np.nan
 
         # NaN → 0 for integration (no displacement during missing pings)
-        x = np.concatenate([[0.0], np.cumsum(np.nan_to_num(u[:-1], nan=0.0) * dt)])
-        y = np.concatenate([[0.0], np.cumsum(np.nan_to_num(v[:-1], nan=0.0) * dt)])
+        x = (
+            np.concatenate([[0.0], np.cumsum(np.nan_to_num(u[:-1], nan=0.0) * dt)])
+            / 1000.0
+        )
+        y = (
+            np.concatenate([[0.0], np.cumsum(np.nan_to_num(v[:-1], nan=0.0) * dt)])
+            / 1000.0
+        )
         trajs.append((float(habs[i]), x, y))
         hab_all.append(float(habs[i]))
 
@@ -662,6 +672,10 @@ def plot_adcp_trajectories(
     hab_min, hab_max = min(hab_all), max(hab_all)
     cmap = plt.get_cmap("viridis")
     _bounds = _nice_colorbar_bounds(hab_min, hab_max, n=20)
+    # Enforce minimum tick spacing of 50 m so labels don't crowd
+    if len(_bounds) > 1 and (_bounds[1] - _bounds[0]) < 50.0:
+        _n_hab = max(2, int((hab_max - hab_min) / 50.0))
+        _bounds = _nice_colorbar_bounds(hab_min, hab_max, n=_n_hab)
     norm: mcolors.BoundaryNorm = mcolors.BoundaryNorm(_bounds, ncolors=256)
 
     fig, ax = plt.subplots(figsize=(6, 5))
@@ -680,8 +694,8 @@ def plot_adcp_trajectories(
     ax.plot(0, 0, "o", color="black", markersize=7, zorder=6, label="Start")
     ax.legend(fontsize=8, loc="upper left")
     ax.autoscale_view()
-    ax.set_xlabel("East displacement (m)")
-    ax.set_ylabel("North displacement (m)")
+    ax.set_xlabel("East displacement (km)")
+    ax.set_ylabel("North displacement (km)")
     ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
     ax.axvline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
     ax.set_aspect("equal", adjustable="box")

--- a/oceanarray/plotters/_diagnostic.py
+++ b/oceanarray/plotters/_diagnostic.py
@@ -170,6 +170,7 @@ def plot_knockdown_pressure(
     ax.legend(fontsize=9, loc="upper left")
     ax.set_xlabel("Nominal pressure (dbar)")
     ax.set_ylabel("Measured pressure (dbar)")
+    ax.grid(True, linestyle="--", linewidth=0.4, alpha=0.5)
 
     plt.tight_layout()
     return fig

--- a/oceanarray/plotters/_diagnostic.py
+++ b/oceanarray/plotters/_diagnostic.py
@@ -12,4 +12,655 @@ plot_spectrum (any 1D time series), plot_polar_histogram (current rose).
 See .claude/plotters_update-20260718.md for migration checklist.
 """
 
-# TODO post-OdB: migrate from plotter.py / report/_plots.py
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import matplotlib.figure
+    import xarray as xr
+    from datetime import datetime
+
+
+# ---------------------------------------------------------------------------
+# Shared helper for stack knockdown plots
+# ---------------------------------------------------------------------------
+
+_KD_COLORS = [
+    (100.0, "mediumseagreen"),
+    (200.0, "gold"),
+    (300.0, "darkorange"),
+    (np.inf, "firebrick"),
+]
+
+
+def _kd_color(magnitude_dbar: float) -> str:
+    """Return a colour string for the given knockdown magnitude in dbar."""
+    return next(c for thresh, c in _KD_COLORS if magnitude_dbar < thresh)
+
+
+def _collect_knockdown_records(
+    ds: "xr.Dataset",
+    waterdepth: float,
+) -> list:
+    """Extract per-instrument knockdown arrays from a stack dataset.
+
+    Returns a list of ``(p_nom, serial, actual_pressure_array)`` tuples,
+    one per non-ADCP instrument with at least 10 valid pressure samples.
+    Interpolated pressure (QC flag 8) is excluded.
+    """
+    serials = ds["serial"].values
+    habs = ds["hab"].values
+    instr_types = ds["instrument_type"].values
+    n_instr = ds.sizes["N_LEVELS"]
+    pressure_arr = ds["pressure"].values  # (time, N_LEVELS)
+    pqc_arr = ds["pressure_qc"].values if "pressure_qc" in ds.data_vars else None
+
+    records = []
+    for i in range(n_instr):
+        if str(instr_types[i]).lower() == "adcp":
+            continue
+        p_nom = waterdepth - float(habs[i])
+        p_vals = pressure_arr[:, i].copy()
+        if pqc_arr is not None:
+            _qc = pqc_arr[:, i] if pqc_arr.ndim == 2 else pqc_arr
+            p_vals[_qc == 8] = np.nan
+        valid = p_vals[np.isfinite(p_vals)]
+        if len(valid) < 10:
+            continue
+        records.append((p_nom, str(serials[i]), valid))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Knockdown figure 1: measured pressure vs. nominal (equal aspect, 1:1 line)
+# ---------------------------------------------------------------------------
+
+
+def plot_knockdown_pressure(
+    ds: "xr.Dataset",
+) -> "Optional[matplotlib.figure.Figure]":
+    """IQR of measured pressure vs. nominal design depth, equal aspect ratio.
+
+    Each non-ADCP instrument is shown as a vertical box-and-whisker positioned
+    at its nominal pressure on the x-axis; the box spans the IQR of the actual
+    measured pressure distribution on the y-axis (increasing downward).
+
+    The axes have equal aspect (``ax.set_aspect("equal")``) and both run from
+    0 to the maximum value, so the 1:1 reference line appears at 45°.
+    Instruments on the diagonal are at their design depth; boxes that drop
+    below the diagonal experienced knockdown (measured deeper than nominal).
+
+    Boxes are coloured blue; interpolated pressure (QC flag 8) is excluded.
+    Rendered at half-width in the stack report.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Stack dataset with dimensions ``(time, N_LEVELS)`` containing
+        ``pressure``, ``hab``, ``serial``, ``instrument_type``, and
+        optionally ``pressure_qc``.  The ``waterdepth`` global attribute
+        must be present and non-zero.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or None
+
+    """
+    if "pressure" not in ds.data_vars or "hab" not in ds:
+        return None
+
+    import matplotlib.pyplot as plt
+
+    from oceanarray import parameters as P
+
+    plt.style.use(str(P.MPLSTYLE))
+
+    try:
+        waterdepth = float(ds.attrs.get("waterdepth", 0) or 0)
+    except (ValueError, TypeError):
+        return None
+    if waterdepth <= 0:
+        return None
+
+    records = _collect_knockdown_records(ds, waterdepth)
+    if not records:
+        return None
+
+    p_nom_vals = [r[0] for r in records]
+    p_range = max(p_nom_vals) - min(p_nom_vals) if len(p_nom_vals) > 1 else 50.0
+    box_width = max(5.0, p_range / (len(p_nom_vals) * 2))
+
+    fig, ax = plt.subplots(figsize=(5, 5))
+
+    p_max_all = 0.0
+    for p_nom, _serial, actual_p in records:
+        bp = ax.boxplot(
+            actual_p,
+            vert=True,
+            positions=[p_nom],
+            widths=box_width,
+            patch_artist=True,
+            flierprops=dict(marker=".", markersize=2, alpha=0.25, color="grey"),
+            medianprops=dict(color="black", linewidth=1.5),
+            manage_ticks=False,
+        )
+        bp["boxes"][0].set_facecolor("steelblue")
+        bp["boxes"][0].set_alpha(0.6)
+        p_max_all = max(p_max_all, float(np.nanmax(actual_p)))
+
+    ax_max = max(p_max_all, max(p_nom_vals)) * 1.05
+    ax.set_xlim(ax_max, 0)  # deeper nominal pressure on the left
+    ax.set_ylim(0, ax_max)
+    ax.set_aspect("equal")
+    ax.invert_yaxis()  # deeper measured pressure at bottom
+
+    ax.plot(
+        [0, ax_max],
+        [0, ax_max],
+        color="dimgrey",
+        lw=0.8,
+        ls="--",
+        zorder=0,
+        label="actual = nominal",
+    )
+    ax.legend(fontsize=9, loc="upper left")
+    ax.set_xlabel("Nominal pressure (dbar)")
+    ax.set_ylabel("Measured pressure (dbar)")
+
+    plt.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Knockdown figure 1b: measured HAB vs. nominal HAB (horizontal displacement)
+# ---------------------------------------------------------------------------
+
+
+def plot_knockdown_hab(
+    ds: "xr.Dataset",
+) -> "Optional[matplotlib.figure.Figure]":
+    """IQR of measured pressure vs. nominal HAB, equal aspect ratio.
+
+    Companion to :func:`plot_knockdown_pressure`.  The y-axis is identical
+    (measured pressure, dbar, increasing downward); only the x-axis changes
+    from nominal pressure to nominal height-above-bottom (m).
+
+    Each non-ADCP instrument is shown as a vertical box-and-whisker positioned
+    at its nominal HAB on the x-axis; the box spans the IQR of the measured
+    pressure distribution.  The dashed reference line shows the expected
+    pressure for each HAB (``pressure = waterdepth − hab``).  Boxes below
+    the line were pulled deeper than their design height by current drag.
+
+    With 1 dbar ≈ 1 m, equal aspect keeps the reference line near 45° and
+    the departure from it is directly related to horizontal displacement.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Stack dataset with dimensions ``(time, N_LEVELS)`` containing
+        ``pressure``, ``hab``, ``serial``, ``instrument_type``, and
+        optionally ``pressure_qc``.  The ``waterdepth`` global attribute
+        must be present and non-zero.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or None
+
+    """
+    if "pressure" not in ds.data_vars or "hab" not in ds:
+        return None
+
+    import matplotlib.pyplot as plt
+
+    from oceanarray import parameters as P
+
+    plt.style.use(str(P.MPLSTYLE))
+
+    try:
+        waterdepth = float(ds.attrs.get("waterdepth", 0) or 0)
+    except (ValueError, TypeError):
+        return None
+    if waterdepth <= 0:
+        return None
+
+    records = _collect_knockdown_records(ds, waterdepth)
+    if not records:
+        return None
+
+    # hab_nom is stored as p_nom = waterdepth - hab, so recover hab
+    hab_records = [
+        (waterdepth - p_nom, serial, actual_p) for p_nom, serial, actual_p in records
+    ]
+
+    hab_nom_vals = [r[0] for r in hab_records]
+    hab_range = max(hab_nom_vals) - min(hab_nom_vals) if len(hab_nom_vals) > 1 else 10.0
+    box_width = max(2.0, hab_range / (len(hab_nom_vals) * 2))
+
+    fig, ax = plt.subplots(figsize=(5, 5))
+
+    p_max_all = 0.0
+    for hab_nom, _serial, actual_p in hab_records:
+        bp = ax.boxplot(
+            actual_p,
+            vert=True,
+            positions=[hab_nom],
+            widths=box_width,
+            patch_artist=True,
+            flierprops=dict(marker=".", markersize=2, alpha=0.25, color="grey"),
+            medianprops=dict(color="black", linewidth=1.5),
+            manage_ticks=False,
+        )
+        bp["boxes"][0].set_facecolor("steelblue")
+        bp["boxes"][0].set_alpha(0.6)
+        p_max_all = max(p_max_all, float(np.nanmax(actual_p)))
+
+    ax_max = max(p_max_all, waterdepth) * 1.05
+    ax.set_xlim(0, ax_max)  # low HAB (deep) on the left, surface on the right
+    ax.set_ylim(0, ax_max)
+    ax.set_aspect("equal")
+    ax.invert_yaxis()  # deeper (larger pressure) at bottom
+
+    # Reference line: expected pressure = waterdepth - hab
+    ax.plot(
+        [0, ax_max],
+        [waterdepth, waterdepth - ax_max],
+        color="dimgrey",
+        lw=0.8,
+        ls="--",
+        zorder=0,
+        label="expected pressure",
+    )
+    ax.legend(fontsize=9, loc="upper right")
+    ax.set_xlabel("Nominal HAB (m)")
+    ax.set_ylabel("Measured pressure (dbar)")
+
+    plt.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Knockdown figure 2: pressure anomaly IQR
+# ---------------------------------------------------------------------------
+
+
+def plot_knockdown_anomaly(
+    ds: "xr.Dataset",
+) -> "Optional[matplotlib.figure.Figure]":
+    """IQR of pressure anomaly (measured − nominal) per instrument.
+
+    Each non-ADCP instrument is shown as a horizontal box-and-whisker at its
+    nominal pressure on the y-axis; the box spans the IQR of the pressure
+    anomaly distribution (actual − nominal, positive = knocked down deeper).
+
+    A vertical reference line at x = 0 marks zero knockdown.  Box colour
+    indicates the magnitude of the median knockdown:
+
+    =========  ========================
+    Colour     Knockdown magnitude
+    =========  ========================
+    green      < 100 dbar
+    gold       100–200 dbar
+    darkorange 200–300 dbar
+    firebrick  > 300 dbar
+    =========  ========================
+
+    Interpolated pressure (QC flag 8) is excluded.  Rendered at half-width
+    in the stack report.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Stack dataset; same requirements as :func:`plot_knockdown_pressure`.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or None
+
+    """
+    if "pressure" not in ds.data_vars or "hab" not in ds:
+        return None
+
+    import matplotlib.pyplot as plt
+
+    from oceanarray import parameters as P
+
+    plt.style.use(str(P.MPLSTYLE))
+
+    try:
+        waterdepth = float(ds.attrs.get("waterdepth", 0) or 0)
+    except (ValueError, TypeError):
+        return None
+    if waterdepth <= 0:
+        return None
+
+    records = _collect_knockdown_records(ds, waterdepth)
+    if not records:
+        return None
+
+    p_nom_vals = [r[0] for r in records]
+    p_range = max(p_nom_vals) - min(p_nom_vals) if len(p_nom_vals) > 1 else 50.0
+    box_width = max(5.0, p_range / (len(p_nom_vals) * 2))
+
+    fig, ax = plt.subplots(figsize=(5, max(3, len(records) * 0.4 + 1)))
+
+    for p_nom, _serial, actual_p in records:
+        anomaly = actual_p - p_nom  # positive = knocked down deeper
+        median_anom = float(np.median(anomaly))
+        color = _kd_color(abs(median_anom))
+
+        bp = ax.boxplot(
+            anomaly,
+            vert=False,
+            positions=[p_nom],
+            widths=box_width,
+            patch_artist=True,
+            flierprops=dict(marker=".", markersize=2, alpha=0.25, color="grey"),
+            medianprops=dict(color="black", linewidth=1.5),
+            manage_ticks=False,
+        )
+        bp["boxes"][0].set_facecolor(color)
+        bp["boxes"][0].set_alpha(0.7)
+
+    ax.invert_yaxis()
+    ax.axvline(0, color="k", lw=0.8, zorder=3)
+    ax.set_xlabel("Pressure anomaly (dbar) — positive = deeper than nominal")
+    ax.set_ylabel("Nominal pressure (dbar)")
+
+    plt.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Knockdown figure 3: horizontal displacement scatter
+# ---------------------------------------------------------------------------
+
+
+def plot_knockdown_displacement(
+    ds: "xr.Dataset",
+) -> "Optional[matplotlib.figure.Figure]":
+    """Scatter and heatmap of estimated horizontal displacement vs. measured pressure.
+
+    For each non-ADCP instrument the horizontal displacement is estimated at
+    every time step as:
+
+        x_horiz = sqrt(max(0, hab_nom² − hab_meas²))
+
+    where ``hab_nom`` is the nominal height-above-bottom (m) and
+    ``hab_meas = waterdepth − pressure`` is the measured HAB.
+
+    **Left panel** — scatter of ``(x_horiz, measured_pressure)`` per
+    instrument, coloured by serial number.  y-axis is measured pressure
+    (dbar, increasing downward); x-axis is horizontal displacement (m).
+    Square axes (equal aspect, adjustable data limits).
+
+    **Right panel** — 2-D count heatmap of the same points across all
+    instruments combined.  Discrete colorbar (up to 15 levels).
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Stack dataset; same requirements as :func:`plot_knockdown_pressure`.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or None
+
+    """
+    if "pressure" not in ds.data_vars or "hab" not in ds:
+        return None
+
+    import matplotlib.colors as mcolors
+    import matplotlib.pyplot as plt
+
+    from oceanarray import parameters as P
+    from oceanarray.utilities import _nice_colorbar_bounds
+
+    plt.style.use(str(P.MPLSTYLE))
+
+    try:
+        waterdepth = float(ds.attrs.get("waterdepth", 0) or 0)
+    except (ValueError, TypeError):
+        return None
+    if waterdepth <= 0:
+        return None
+
+    records = _collect_knockdown_records(ds, waterdepth)
+    if not records:
+        return None
+
+    # --- collect data for both panels ---
+    _tab20 = plt.get_cmap("tab20")
+    scatter_data = []  # (serial, x_horiz_thinned, p_thinned, color)
+    all_x_list = []
+    all_p_list = []
+
+    for idx, (p_nom, serial, actual_p) in enumerate(records):
+        hab_nom = waterdepth - p_nom
+        hab_meas = waterdepth - actual_p
+        x_horiz = np.sqrt(np.maximum(0.0, hab_nom**2 - hab_meas**2))
+        all_x_list.append(x_horiz)
+        all_p_list.append(actual_p)
+        step = max(1, len(actual_p) // 2000)
+        scatter_data.append(
+            (serial, x_horiz[::step], actual_p[::step], _tab20(idx % 20))
+        )
+
+    all_x = np.concatenate(all_x_list)
+    all_p = np.concatenate(all_p_list)
+    valid = np.isfinite(all_x) & np.isfinite(all_p)
+    all_x, all_p = all_x[valid], all_p[valid]
+
+    x_max = float(np.nanmax(all_x)) if len(all_x) else 1.0
+    p_max = float(np.nanmax(all_p)) * 1.05 if len(all_p) else 1.0
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 5), sharey=True, sharex=True)
+
+    # --- left panel: scatter ---
+    for serial, x_thin, p_thin, color in scatter_data:
+        ax1.scatter(
+            x_thin,
+            p_thin,
+            s=4,
+            alpha=0.3,
+            color=color,
+            linewidths=0,
+            label=str(serial),
+            rasterized=True,
+        )
+    ax1.set_xlim(0, x_max)  # sharex propagates to ax2
+    ax1.set_xlabel("Horizontal displacement (m)")
+    ax1.set_ylabel("Measured pressure (dbar)")
+    ax1.legend(fontsize=9, loc="lower right", markerscale=3)
+    ax1.set_aspect("equal", adjustable="box")  # 100 m on x = 100 m on y
+    ax1.grid(True, linestyle="--", linewidth=0.4, alpha=0.5)
+
+    # Shared tick step so x and y gridlines fall at the same intervals
+    import matplotlib.ticker as mticker
+
+    _ax_range = max(x_max, p_max)
+    _step = next(
+        s for s in [10, 20, 25, 50, 100, 200, 250, 500, 1000] if _ax_range / s <= 6
+    )
+    ax1.xaxis.set_major_locator(mticker.MultipleLocator(_step))
+    ax1.yaxis.set_major_locator(mticker.MultipleLocator(_step))
+
+    # --- right panel: per-instrument normalised heatmap ---
+    # Each instrument's 2-D histogram is divided by its own total before
+    # summing, so all instruments contribute equally regardless of record length.
+    n_bins = 40
+    x_edges = np.linspace(0, x_max, n_bins + 1)
+    p_edges = np.linspace(0, p_max, n_bins + 1)
+
+    H_norm = np.zeros((n_bins, n_bins))
+    for x_arr, p_arr in zip(all_x_list, all_p_list):
+        valid_i = np.isfinite(x_arr) & np.isfinite(p_arr)
+        if not valid_i.sum():
+            continue
+        H_i, _, _ = np.histogram2d(
+            x_arr[valid_i], p_arr[valid_i], bins=[x_edges, p_edges]
+        )
+        total = H_i.sum()
+        if total > 0:
+            H_norm += H_i / total
+    H_norm[H_norm == 0] = np.nan
+
+    h_vals = H_norm[np.isfinite(H_norm)]
+    if len(h_vals):
+        bounds = _nice_colorbar_bounds(
+            float(np.nanmin(h_vals)), float(np.nanpercentile(h_vals, 98)), n=15
+        )
+        norm = mcolors.BoundaryNorm(bounds, ncolors=256)
+        mesh = ax2.pcolormesh(x_edges, p_edges, H_norm.T, norm=norm, cmap="YlOrRd")
+        fig.colorbar(
+            mesh,
+            ax=ax2,
+            ticks=bounds,
+            label="Normalised density (sum = 1 per instrument)",
+        )
+
+    ax2.set_ylim(0, p_max)  # sharey propagates this to ax1
+    ax2.set_aspect("equal", adjustable="box")
+    ax2.invert_yaxis()
+    ax2.set_xlabel("Horizontal displacement (m)")
+    ax2.grid(True, linestyle="--", linewidth=0.4, alpha=0.5, zorder=3)
+
+    plt.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Clock-offset comparison
+# ---------------------------------------------------------------------------
+
+
+def plot_clock_offset_check(
+    nc_paths: "Dict[str, Path]",
+    deploy_dt: "Optional[datetime]",
+    recover_dt: "Optional[datetime]",
+    window_minutes: int = 30,
+) -> "Optional[matplotlib.figure.Figure]":
+    """Overlaid temperature time series zoomed to deployment start and end.
+
+    Plots the first and last *window_minutes* of the deployment for every
+    instrument that has a temperature variable, so that clock alignment
+    between instruments can be assessed visually.  If an instrument's clock
+    is offset the temperature signal will appear shifted in time relative to
+    the other instruments.
+
+    Two sub-panels are produced side by side:
+
+    - **Left**: first ``window_minutes`` minutes after ``deploy_dt``
+    - **Right**: last ``window_minutes`` minutes before ``recover_dt``
+
+    When ``deploy_dt`` or ``recover_dt`` is ``None``, only the available
+    window is produced.
+
+    Parameters
+    ----------
+    nc_paths : dict of {serial: Path}
+        Paths to stage-2 or stage-3 NetCDF files keyed by serial number.
+        Only instruments with temperature data are included in the plot.
+    deploy_dt : datetime or None
+        Deployment time (UTC).
+    recover_dt : datetime or None
+        Recovery time (UTC).
+    window_minutes : int
+        Duration of each zoom window in minutes.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or None
+        None when fewer than two instruments have temperature data, or if
+        any other error prevents plotting.
+
+    """
+    if not nc_paths:
+        return None
+
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+    import xarray as xr
+
+    from oceanarray import parameters as P
+
+    plt.style.use(str(P.MPLSTYLE))
+
+    _TEMP_VARS = ("temperature", "temp", "TEMP", "sea_water_temperature")
+
+    # Load temperature time series for each instrument
+    series: dict = {}  # {serial: (time_array, temp_array)}
+    for serial, path in nc_paths.items():
+        if not path.exists():
+            continue
+        try:
+            ds = xr.open_dataset(path, decode_timedelta=False).load()
+            temp_var = next((v for v in _TEMP_VARS if v in ds.data_vars), None)
+            if temp_var is None or "time" not in ds.dims:
+                ds.close()
+                continue
+            t = ds["time"].values
+            temp = ds[temp_var].values.astype(float)
+            # Apply QC mask if available
+            qc_var = f"{temp_var}_qc"
+            if qc_var in ds.data_vars:
+                temp[ds[qc_var].values >= 4] = np.nan
+            ds.close()
+            series[serial] = (t, temp)
+        except Exception:  # noqa: BLE001
+            continue
+
+    if len(series) < 2:
+        return None
+
+    # Determine zoom windows
+    _td = np.timedelta64(window_minutes * 60, "s")
+    windows: list = []
+    if deploy_dt is not None:
+        t0 = np.datetime64(deploy_dt.replace(tzinfo=None).isoformat())
+        windows.append((t0, t0 + _td, f"Start +{window_minutes} min"))
+    if recover_dt is not None:
+        t1 = np.datetime64(recover_dt.replace(tzinfo=None).isoformat())
+        windows.append((t1 - _td, t1, f"End −{window_minutes} min"))
+    if not windows:
+        return None
+
+    n_panels = len(windows)
+    fig, axes = plt.subplots(1, n_panels, figsize=(5 * n_panels, 3.5), sharey=False)
+    if n_panels == 1:
+        axes = [axes]
+
+    _tab20 = plt.get_cmap("tab20")
+    colors = {s: _tab20(i % 20) for i, s in enumerate(series)}
+
+    for ax, (t_lo, t_hi, title) in zip(axes, windows):
+        plotted = False
+        for serial, (t, temp) in series.items():
+            mask = (t >= t_lo) & (t <= t_hi) & np.isfinite(temp)
+            if not np.any(mask):
+                continue
+            ax.plot(
+                t[mask],
+                temp[mask],
+                color=colors[serial],
+                lw=1.0,
+                label=str(serial),
+            )
+            plotted = True
+
+        ax.set_title(title, fontsize=8)
+        ax.set_xlabel("Time (UTC)")
+        ax.set_ylabel("Temperature (°C)")
+        locator = mdates.AutoDateLocator()
+        ax.xaxis.set_major_locator(locator)
+        ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
+        ax.tick_params(axis="x", labelsize=7)
+
+        if plotted:
+            ax.legend(fontsize=6, loc="upper left")
+
+    plt.tight_layout()
+    return fig

--- a/oceanarray/report/_array.py
+++ b/oceanarray/report/_array.py
@@ -197,7 +197,6 @@ _ARRAY_HTML_TEMPLATE = """\
     {% if project %}<div><dt>Project</dt><dd>{{ project }}</dd></div>{% endif %}
     {% if deploy_time %}<div><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>{% endif %}
     {% if recover_time %}<div><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>{% endif %}
-    {% if overall_duration_days is not none %}<div><dt>Duration</dt><dd>{{ overall_duration_days }} days</dd></div>{% endif %}
     <div><dt>Moorings</dt><dd>{{ moorings | length }}</dd></div>
   </dl>
 </div>
@@ -367,19 +366,6 @@ def generate_array_report(
     deploy_dt_arr = _parse_dt(array_cfg.get("deployment_time"))
     recover_dt_arr = _parse_dt(array_cfg.get("recovery_time"))
 
-    # Overall duration: prefer array-level times; fall back to min/max across moorings.
-    import math as _math
-
-    _all_deploys = [r["_deploy_dt"] for r in rows if r.get("_deploy_dt")]
-    _all_recovers = [r["_recover_dt"] for r in rows if r.get("_recover_dt")]
-    _t0 = deploy_dt_arr or (min(_all_deploys) if _all_deploys else None)
-    _t1 = recover_dt_arr or (max(_all_recovers) if _all_recovers else None)
-    if _t0 and _t1 and _t1 > _t0:
-        _span_days = (_t1 - _t0).total_seconds() / 86400.0
-        overall_duration_days = _math.floor(_span_days * 10) / 10
-    else:
-        overall_duration_days = None
-
     ctx = {
         "array_name": array_name,
         "year": array_cfg.get("year"),
@@ -388,7 +374,6 @@ def generate_array_report(
         "project": array_cfg.get("project"),
         "deploy_time": deploy_dt_arr.strftime("%Y-%m-%d") if deploy_dt_arr else "",
         "recover_time": recover_dt_arr.strftime("%Y-%m-%d") if recover_dt_arr else "",
-        "overall_duration_days": overall_duration_days,
         "moorings": rows,
         "fig_map_b64": fig_map_b64,
         "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),

--- a/oceanarray/report/_array.py
+++ b/oceanarray/report/_array.py
@@ -1,0 +1,400 @@
+"""Array-level HTML summary report.
+
+Reads a ``*.array.yaml`` file, gathers per-mooring metadata from each
+mooring's YAML, draws a simple position map, and writes a single HTML
+index page with clickable links to every mooring's report.
+
+Entry point: :func:`generate_array_report`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from ._html_helpers import _duration_str, _fig_to_base64, _parse_dt, _status
+
+
+# ---------------------------------------------------------------------------
+# Lat/lon parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_decdeg(val: Any) -> Optional[float]:
+    """Parse a latitude or longitude value to decimal degrees.
+
+    Handles:
+    - Numeric types (float / int): returned as-is.
+    - ``"65.567"`` or ``"-27.5"`` — plain decimal-degree strings.
+    - ``"65 43.913"`` — degrees + decimal-minutes, sign for hemisphere.
+    - ``"65 34.004 N"`` / ``"029 25.878 W"`` — DM with hemisphere letter.
+    """
+    if val is None:
+        return None
+    if isinstance(val, (int, float)):
+        return float(val)
+    s = str(val).strip()
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    parts = s.split()
+    if len(parts) >= 2:
+        try:
+            deg = float(parts[0])
+            minutes = float(parts[1])
+            dd = abs(deg) + minutes / 60.0
+            if deg < 0:
+                dd = -dd
+            if len(parts) >= 3:
+                hemi = parts[2].strip(".,").upper()
+                if hemi in ("S", "W"):
+                    dd = -abs(dd)
+        except (ValueError, IndexError):
+            pass
+        else:
+            return dd
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Mooring metadata extraction
+# ---------------------------------------------------------------------------
+
+
+def _lat_lon_from_cfg(cfg: Dict[str, Any]) -> tuple:
+    """Return (lat_dd, lon_dd) decimal degrees from a mooring YAML dict."""
+    lat_raw = (
+        cfg.get("seabed_latitude")
+        or cfg.get("deployment_latitude")
+        or cfg.get("planned_latitude")
+        or cfg.get("latitude")
+    )
+    lon_raw = (
+        cfg.get("seabed_longitude")
+        or cfg.get("deployment_longitude")
+        or cfg.get("planned_longitude")
+        or cfg.get("longitude")
+    )
+    return _parse_decdeg(lat_raw), _parse_decdeg(lon_raw)
+
+
+def _count_instruments(cfg: Dict[str, Any]) -> int:
+    """Count instruments in a mooring YAML (clamp or instruments key)."""
+    entries = cfg.get("clamp") or cfg.get("instruments") or []
+    return sum(1 for e in entries if isinstance(e, dict) and not e.get("skip"))
+
+
+# ---------------------------------------------------------------------------
+# Map figure
+# ---------------------------------------------------------------------------
+
+
+def _make_array_map_b64(
+    rows: List[Dict[str, Any]],
+    array_name: str,
+) -> Optional[str]:
+    """Return a base64-encoded PNG of mooring positions, or None on failure."""
+    try:
+        import matplotlib.pyplot as plt
+        from oceanarray import parameters as P
+
+        plt.style.use(str(P.MPLSTYLE))
+
+        lats = [r["lat"] for r in rows if r["lat"] is not None]
+        lons = [r["lon"] for r in rows if r["lon"] is not None]
+        if len(lats) < 1:
+            return None
+
+        mean_lat_rad = float(__import__("math").radians(sum(lats) / len(lats)))
+        aspect = 1.0 / __import__("math").cos(mean_lat_rad)
+
+        fig, ax = plt.subplots(figsize=(6, 5))
+        ax.set_aspect(aspect)
+
+        _tab20 = plt.get_cmap("tab20")
+        for idx, r in enumerate(rows):
+            if r["lat"] is None or r["lon"] is None:
+                continue
+            color = _tab20(idx % 20)
+            ax.scatter(r["lon"], r["lat"], s=60, color=color, zorder=3)
+            ax.annotate(
+                r["mooring"],
+                (r["lon"], r["lat"]),
+                textcoords="offset points",
+                xytext=(5, 3),
+                fontsize=10,
+                color=color,
+            )
+
+        # Flip x-axis if all longitudes are negative (western hemisphere)
+        if lons and all(lon < 0 for lon in lons):
+            ax.invert_xaxis()
+
+        ax.set_xlabel("Longitude (°)")
+        ax.set_ylabel("Latitude (°)")
+        ax.set_title(array_name, fontsize=9)
+        ax.grid(True, linestyle="--", linewidth=0.3, alpha=0.5)
+        plt.tight_layout()
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+    except Exception:  # noqa: BLE001
+        return None
+    else:
+        return b64
+    return None
+
+
+# ---------------------------------------------------------------------------
+# HTML template
+# ---------------------------------------------------------------------------
+
+_ARRAY_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Array report &ndash; {{ array_name }}</title>
+<style>
+  :root { --ocean:#1a3a5c; --seafoam:#e8f4f8; --text:#2c3e50; --muted:#95a5a6; }
+  body { font-family: system-ui, sans-serif; max-width: 1100px; margin: 0 auto; padding: 1rem; color: var(--text); }
+  .masthead { background: var(--ocean); color:#fff; border-radius:6px; padding:1.2rem 1.6rem 1rem; margin-bottom:1.2rem; }
+  .masthead h1 { margin:0 0 0.2rem; font-size:1.6rem; }
+  .masthead p.sub { margin:0; font-size:0.82rem; opacity:0.75; }
+  .meta-grid { display:flex; flex-wrap:wrap; gap:0.5rem 1.4rem; margin-top:0.8rem; }
+  .meta-grid div { font-size:0.82rem; }
+  .meta-grid dt { opacity:0.7; font-size:0.72rem; }
+  .meta-grid dd { margin:0; font-weight:600; }
+  .meta-miss dd { color:#f0ad4e; }
+  table { border-collapse:collapse; width:100%; margin:0.6rem 0 1.2rem; font-size:0.84rem; }
+  th { background:var(--ocean); color:#fff; padding:0.4rem 0.6rem; text-align:left; }
+  td { padding:0.35rem 0.6rem; border-bottom:1px solid #e8ecef; }
+  tr:nth-child(even) td { background:#f7f9fb; }
+  .num { text-align:right; }
+  .btn { display:inline-block; padding:0.15em 0.55em; border-radius:4px; font-size:0.75rem;
+         font-weight:700; text-decoration:none; color:#fff; margin:0 0.15rem 0.2rem 0; }
+  .btn-sum { background:#2c3e50; }
+  .btn-stk { background:#2980b9; }
+  .btn-grd { background:#8e44ad; }
+  .btn-miss { background:#bbb; cursor:default; pointer-events:none; }
+  .note { font-size:0.78rem; color:#555; margin:0.2rem 0 0.6rem; }
+  .fig { max-width:60%; display:block; margin:0.5rem auto 1rem; border:1px solid #e0e4e8; border-radius:4px; }
+  h2 { color:var(--ocean); border-bottom:2px solid var(--seafoam); padding-bottom:0.3rem; margin-top:1.4rem; }
+</style>
+</head>
+<body>
+
+<div class="masthead">
+  <h1>{{ array_name }}</h1>
+  <p class="sub">Array summary &bull; generated {{ generated }}</p>
+  <dl class="meta-grid">
+    {% if year %}<div><dt>Year</dt><dd>{{ year }}</dd></div>{% endif %}
+    {% if cruise %}<div><dt>Cruise</dt><dd>{{ cruise }}</dd></div>{% endif %}
+    {% if ship %}<div><dt>Ship</dt><dd>{{ ship }}</dd></div>{% endif %}
+    {% if project %}<div><dt>Project</dt><dd>{{ project }}</dd></div>{% endif %}
+    {% if deploy_time %}<div><dt>Deployment</dt><dd>{{ deploy_time }}</dd></div>{% endif %}
+    {% if recover_time %}<div><dt>Recovery</dt><dd>{{ recover_time }}</dd></div>{% endif %}
+    {% if overall_duration_days is not none %}<div><dt>Duration</dt><dd>{{ overall_duration_days }} days</dd></div>{% endif %}
+    <div><dt>Moorings</dt><dd>{{ moorings | length }}</dd></div>
+  </dl>
+</div>
+
+{% if fig_map_b64 %}
+<h2>Mooring positions</h2>
+<img class="fig" src="data:image/png;base64,{{ fig_map_b64 }}" alt="Array map">
+{% endif %}
+
+<h2>Moorings</h2>
+<table>
+  <thead>
+    <tr>
+      <th>#</th>
+      <th>Mooring</th>
+      <th class="num">Latitude</th>
+      <th class="num">Longitude</th>
+      <th class="num">Depth&nbsp;(m)</th>
+      <th>Deployment</th>
+      <th>Recovery</th>
+      <th class="num">Duration</th>
+      <th class="num">Instruments</th>
+      <th>Reports</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for r in moorings %}
+  <tr>
+    <td class="num">{{ r.position }}</td>
+    <td><strong>{{ r.mooring }}</strong></td>
+    <td class="num">{{ "%.4f"|format(r.lat) if r.lat is not none else "—" }}</td>
+    <td class="num">{{ "%.4f"|format(r.lon) if r.lon is not none else "—" }}</td>
+    <td class="num">{{ r.waterdepth if r.waterdepth else "—" }}</td>
+    <td>{{ r.deploy_time }}</td>
+    <td>{{ r.recover_time }}</td>
+    <td class="num">{{ r.duration }}</td>
+    <td class="num">{{ r.n_instruments }}</td>
+    <td>
+      {% if r.report_exists %}
+        <a class="btn btn-sum" href="{{ r.mooring }}/report/{{ r.mooring }}_report.html">Summary</a>
+      {% else %}
+        <span class="btn btn-miss">Summary</span>
+      {% endif %}
+      {% if r.stack_exists %}
+        <a class="btn btn-stk" href="{{ r.mooring }}/report/{{ r.mooring }}_stack_report.html">Stack</a>
+      {% endif %}
+      {% if r.grid_exists %}
+        <a class="btn btn-grd" href="{{ r.mooring }}/report/{{ r.mooring }}_grid_report.html">Grid</a>
+      {% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
+
+</body>
+</html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def generate_array_report(
+    array_yaml_path: Path,
+    proc_dir: Path,
+    out_path: Optional[Path] = None,
+    force: bool = False,
+) -> Optional[Path]:
+    """Generate an HTML array-level summary report from an array YAML file.
+
+    Parameters
+    ----------
+    array_yaml_path : Path
+        Path to the ``*.array.yaml`` file.
+    proc_dir : Path
+        Root processing directory.  Each mooring directory is expected to be
+        ``proc_dir / mooring_id``.
+    out_path : Path, optional
+        Output HTML path.  Defaults to
+        ``proc_dir / "{array_name}_array_report.html"``.
+    force : bool
+        Overwrite existing output file.
+
+    Returns
+    -------
+    Path or None
+        Path to the written HTML file, or None on failure.
+
+    """
+    from datetime import datetime, timezone
+
+    from jinja2 import Environment
+
+    array_yaml_path = Path(array_yaml_path)
+    proc_dir = Path(proc_dir)
+
+    if not array_yaml_path.exists():
+        print(f"ERROR: array YAML not found: {array_yaml_path}")
+        return None
+
+    with open(array_yaml_path) as fh:
+        array_cfg = yaml.safe_load(fh)
+
+    array_name = array_cfg.get("name", array_yaml_path.stem)
+
+    if out_path is None:
+        out_path = proc_dir / f"{array_name}_array_report.html"
+
+    if out_path.exists() and not force:
+        _status("skip", str(out_path))
+        return out_path
+
+    mooring_entries = array_cfg.get("moorings", [])
+    rows: List[Dict[str, Any]] = []
+
+    for pos_idx, entry in enumerate(mooring_entries, start=1):
+        mooring_id = entry.get("mooring", "")
+        config_name = entry.get("config", f"{mooring_id}.mooring.yaml")
+        mooring_yaml = proc_dir / mooring_id / config_name
+
+        mcfg: Dict[str, Any] = {}
+        if mooring_yaml.exists():
+            try:
+                with open(mooring_yaml) as fh:
+                    mcfg = yaml.safe_load(fh) or {}
+            except Exception as exc:  # noqa: BLE001
+                print(f"WARNING: could not read {mooring_yaml}: {exc}")
+        else:
+            print(f"WARNING: mooring YAML not found: {mooring_yaml}")
+
+        lat, lon = _lat_lon_from_cfg(mcfg)
+        deploy_dt = _parse_dt(mcfg.get("deployment_time"))
+        recover_dt = _parse_dt(mcfg.get("recovery_time"))
+
+        report_dir = proc_dir / mooring_id / "report"
+        rows.append(
+            {
+                "position": entry.get("position", str(pos_idx)),
+                "mooring": mooring_id,
+                "lat": lat,
+                "lon": lon,
+                "waterdepth": mcfg.get("waterdepth"),
+                "deploy_time": deploy_dt.strftime("%Y-%m-%d %H:%M")
+                if deploy_dt
+                else "—",
+                "recover_time": recover_dt.strftime("%Y-%m-%d %H:%M")
+                if recover_dt
+                else "—",
+                "duration": _duration_str(deploy_dt, recover_dt),
+                "_deploy_dt": deploy_dt,
+                "_recover_dt": recover_dt,
+                "n_instruments": _count_instruments(mcfg),
+                "report_exists": (report_dir / f"{mooring_id}_report.html").exists(),
+                "stack_exists": (
+                    report_dir / f"{mooring_id}_stack_report.html"
+                ).exists(),
+                "grid_exists": (report_dir / f"{mooring_id}_grid_report.html").exists(),
+            }
+        )
+
+    fig_map_b64 = _make_array_map_b64(rows, array_name)
+
+    deploy_dt_arr = _parse_dt(array_cfg.get("deployment_time"))
+    recover_dt_arr = _parse_dt(array_cfg.get("recovery_time"))
+
+    # Overall duration: prefer array-level times; fall back to min/max across moorings.
+    import math as _math
+
+    _all_deploys = [r["_deploy_dt"] for r in rows if r.get("_deploy_dt")]
+    _all_recovers = [r["_recover_dt"] for r in rows if r.get("_recover_dt")]
+    _t0 = deploy_dt_arr or (min(_all_deploys) if _all_deploys else None)
+    _t1 = recover_dt_arr or (max(_all_recovers) if _all_recovers else None)
+    if _t0 and _t1 and _t1 > _t0:
+        _span_days = (_t1 - _t0).total_seconds() / 86400.0
+        overall_duration_days = _math.floor(_span_days * 10) / 10
+    else:
+        overall_duration_days = None
+
+    ctx = {
+        "array_name": array_name,
+        "year": array_cfg.get("year"),
+        "cruise": array_cfg.get("cruise"),
+        "ship": array_cfg.get("ship"),
+        "project": array_cfg.get("project"),
+        "deploy_time": deploy_dt_arr.strftime("%Y-%m-%d") if deploy_dt_arr else "",
+        "recover_time": recover_dt_arr.strftime("%Y-%m-%d") if recover_dt_arr else "",
+        "overall_duration_days": overall_duration_days,
+        "moorings": rows,
+        "fig_map_b64": fig_map_b64,
+        "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+    }
+
+    env = Environment(autoescape=True)
+    html = env.from_string(_ARRAY_HTML_TEMPLATE).render(**ctx)
+    out_path.write_text(html, encoding="utf-8")
+    _status("file", str(out_path))
+    return out_path

--- a/oceanarray/report/_array.py
+++ b/oceanarray/report/_array.py
@@ -104,7 +104,6 @@ def _make_array_map_b64(
         plt.style.use(str(P.MPLSTYLE))
 
         lats = [r["lat"] for r in rows if r["lat"] is not None]
-        lons = [r["lon"] for r in rows if r["lon"] is not None]
         if len(lats) < 1:
             return None
 
@@ -114,24 +113,25 @@ def _make_array_map_b64(
         fig, ax = plt.subplots(figsize=(6, 5))
         ax.set_aspect(aspect)
 
+        import matplotlib.colors as _mcolors
+
         _tab20 = plt.get_cmap("tab20")
         for idx, r in enumerate(rows):
             if r["lat"] is None or r["lon"] is None:
                 continue
             color = _tab20(idx % 20)
+            r["color_hex"] = _mcolors.to_hex(color)
             ax.scatter(r["lon"], r["lat"], s=60, color=color, zorder=3)
-            ax.annotate(
-                r["mooring"],
-                (r["lon"], r["lat"]),
-                textcoords="offset points",
-                xytext=(5, 3),
-                fontsize=10,
-                color=color,
-            )
-
-        # Flip x-axis if all longitudes are negative (western hemisphere)
-        if lons and all(lon < 0 for lon in lons):
-            ax.invert_xaxis()
+            # Only label moorings that have been recovered
+            if r.get("_recover_dt") is not None:
+                ax.annotate(
+                    r["mooring"],
+                    (r["lon"], r["lat"]),
+                    textcoords="offset points",
+                    xytext=(5, 3),
+                    fontsize=10,
+                    color=color,
+                )
 
         ax.set_xlabel("Longitude (°)")
         ax.set_ylabel("Latitude (°)")
@@ -226,7 +226,7 @@ _ARRAY_HTML_TEMPLATE = """\
   <tbody>
   {% for r in moorings %}
   <tr>
-    <td class="num">{{ r.position }}</td>
+    <td class="num">{% if r.color_hex %}<span style="display:inline-block;width:0.75em;height:0.75em;border-radius:50%;background:{{ r.color_hex }};margin-right:0.35em;vertical-align:middle"></span>{% endif %}{{ r.position }}</td>
     <td><strong>{{ r.mooring }}</strong></td>
     <td class="num">{{ "%.4f"|format(r.lat) if r.lat is not none else "—" }}</td>
     <td class="num">{{ "%.4f"|format(r.lon) if r.lon is not none else "—" }}</td>
@@ -342,6 +342,7 @@ def generate_array_report(
                 "mooring": mooring_id,
                 "lat": lat,
                 "lon": lon,
+                "color_hex": None,
                 "waterdepth": mcfg.get("waterdepth"),
                 "deploy_time": deploy_dt.strftime("%Y-%m-%d %H:%M")
                 if deploy_dt

--- a/oceanarray/report/_grid.py
+++ b/oceanarray/report/_grid.py
@@ -7,7 +7,13 @@ from typing import Any, Dict
 
 import numpy as np
 
-from ._html_helpers import _nav_buttons_html, _parse_history, _read_nc_metadata, _status
+from ._html_helpers import (
+    _find_array_report_href,
+    _nav_buttons_html,
+    _parse_history,
+    _read_nc_metadata,
+    _status,
+)
 from ._plots import (
     _make_grid_hydro_b64,
     _make_grid_hodograph_b64,
@@ -490,6 +496,7 @@ def generate_grid_page(
                 stack_exists=stack_exists,
                 grid_exists=True,
                 current_report="grid",
+                array_report_href=_find_array_report_href(out_dir),
             ),
             cruise=ctx.get("cruise", "—"),
             ship=ctx.get("ship", "—"),

--- a/oceanarray/report/_html_helpers.py
+++ b/oceanarray/report/_html_helpers.py
@@ -39,7 +39,7 @@ def _parse_dt(s: Optional[str]) -> Optional[datetime]:
     """Parse clock timestamp: HH:MM:SS, YYYYMMDDTHH:MM:SS, or standard ISO."""
     if not s:
         return None
-    s = str(s).strip().replace("Z", "+00:00")
+    s = str(s).strip().replace("Z", "+00:00").replace(" UTC", "")
     if re.match(r"^\d{2}:\d{2}:\d{2}", s) and "T" not in s:
         s = f"2000-01-01T{s}"
     m = re.match(r"^(\d{4})(\d{2})(\d{2})T(\d{2}:\d{2}:\d{2}.*)$", s)
@@ -767,6 +767,96 @@ def _stage_file_details(
     return rows
 
 
+def _instrument_report_href(
+    mooring_name: str,
+    serial: str,
+    in_instrument_subdir: bool = False,
+) -> str:
+    """Return the relative href for a per-instrument HTML report.
+
+    Instrument reports live at ``report/instrument/{mooring}_{serial}_report.html``.
+    The prefix differs depending on which report is linking to them:
+
+    - Summary / Stack / Grid (in ``report/``): prefix is ``instrument/``
+    - Another instrument report (in ``report/instrument/``): no prefix needed
+
+    Parameters
+    ----------
+    mooring_name : str
+        Mooring identifier used in the report filename.
+    serial : str
+        Instrument serial number.
+    in_instrument_subdir : bool
+        ``True`` when linking from a per-instrument report.
+        ``False`` (default) when linking from summary, stack, or grid reports.
+
+    Returns
+    -------
+    str
+        Relative href string, e.g. ``"instrument/dsG3_1_2026_26261_report.html"``.
+
+    """
+    import html as _html
+
+    prefix = "" if in_instrument_subdir else "instrument/"
+    return (
+        f"{prefix}{_html.escape(mooring_name)}_{_html.escape(str(serial))}_report.html"
+    )
+
+
+def _instrument_report_exists(out_dir: Path, mooring_name: str, serial: str) -> bool:
+    """Return True if the per-instrument report file already exists on disk.
+
+    Parameters
+    ----------
+    out_dir : Path
+        The report output directory (i.e. ``proc_dir / "report"``).
+    mooring_name : str
+        Mooring identifier used in the report filename.
+    serial : str
+        Instrument serial number.
+
+    """
+    return (out_dir / "instrument" / f"{mooring_name}_{serial}_report.html").exists()
+
+
+def _find_array_report_href(
+    out_dir: Path, in_instrument_subdir: bool = False
+) -> Optional[str]:
+    """Return a relative href to the array report if one exists in the top-level proc dir.
+
+    Parameters
+    ----------
+    out_dir : Path
+        Directory where the current report will be written.  Expected to be
+        ``{proc_dir}/{mooring}/report/`` (default) or ``{proc_dir}/{mooring}/``.
+    in_instrument_subdir : bool
+        True when the caller is a per-instrument report one level deeper.
+
+    Returns
+    -------
+    str or None
+        Relative href string (e.g. ``"../../dsG3_2026_array_report.html"``),
+        or None if no ``*_array_report.html`` exists.
+
+    """
+    if out_dir is None:
+        return None
+    # Navigate up to the top-level proc dir (above the mooring dir)
+    candidate = out_dir
+    # go up past report/ (if present) and mooring dir
+    for _ in range(3 if in_instrument_subdir else 2):
+        candidate = candidate.parent
+    matches = sorted(
+        p for p in candidate.glob("*_array_report.html") if not p.name.startswith(".")
+    )
+    if not matches:
+        return None
+    depth = 3 if in_instrument_subdir else 2
+    prefix = "../" * depth
+    return f"{prefix}{matches[0].name}"
+
+
 def _nav_buttons_html(
     mooring_name: str,
     instruments: List[Dict[str, Any]],
@@ -774,6 +864,7 @@ def _nav_buttons_html(
     grid_exists: bool = True,
     current_report: str = "",
     in_instrument_subdir: bool = False,
+    array_report_href: Optional[str] = None,
 ) -> str:
     """Return an HTML navigation snippet for injection into report masthead cards.
 
@@ -799,6 +890,11 @@ def _nav_buttons_html(
         be prefixed with ``../`` and instrument-to-instrument links will remain
         flat.  When ``False`` (default, used by Summary/Stack/Grid reports),
         instrument links are prefixed with ``instrument/``.
+    array_report_href : str or None
+        Relative href to the array-level report (e.g.
+        ``"../../dsG3_2026_array_report.html"``).  When provided an "Array"
+        pill is prepended to Row 1.  Pass the result of
+        ``_find_array_report_href(out_dir)`` at each call site.
 
     Returns
     -------
@@ -842,9 +938,14 @@ def _nav_buttons_html(
 
     parts = ['<div style="margin-top:0.65rem">']
 
-    # Row 1: report-level navigation (Summary / Stack / Grid)
+    # Row 1: report-level navigation (Array / Summary / Stack / Grid)
     parts.append('<div style="margin-bottom:0.25rem">')
     parts.append(f'<span style="{_LABEL}">Reports:</span>')
+    if array_report_href:
+        parts.append(
+            f'<a href="{_html.escape(array_report_href)}" '
+            f'style="{_BTN}background:#5d6d7e">Array</a>'
+        )
     parts.append(
         _pill(
             "Summary", f"{_pfx}{mn}_report.html", "#1a3a5c", current_report == "summary"

--- a/oceanarray/report/_instrument.py
+++ b/oceanarray/report/_instrument.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 from ._html_helpers import (
     _duration_str,
     _file_info,
+    _find_array_report_href,
     _nav_buttons_html,
     _parse_dt,
     _parse_history,
@@ -730,6 +731,9 @@ def generate_instrument_pages(
                 grid_exists=grid_exists,
                 current_report=serial,
                 in_instrument_subdir=True,
+                array_report_href=_find_array_report_href(
+                    out_dir, in_instrument_subdir=True
+                ),
             ),
             "generated": generated,
             "proc_machine": proc_machine,

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -32,7 +32,7 @@ from ._html_helpers import (
 )
 from ._grid import generate_grid_page
 from ._instrument import generate_instrument_pages
-from ._plots import _make_clock_check_b64
+from ._plots import _make_clock_check_b64, _make_knockdown_hab_b64, _make_knockdown_anomaly_b64
 from ._stack import generate_stack_page
 from ..utilities import extract_inline_instruments
 

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -32,7 +32,12 @@ from ._html_helpers import (
 )
 from ._grid import generate_grid_page
 from ._instrument import generate_instrument_pages
-from ._plots import _make_clock_check_b64, _make_knockdown_hab_b64, _make_knockdown_anomaly_b64
+from ._plots import (
+    _make_clock_check_b64,
+    _make_knockdown_displacement_b64,
+    _make_knockdown_hab_b64,
+    _make_knockdown_anomaly_b64,
+)
 from ._stack import generate_stack_page
 from ..utilities import extract_inline_instruments
 
@@ -188,6 +193,7 @@ _HTML_TEMPLATE = """\
   <a href="#clock">Clock corrections</a>
   <a href="#calibration">Sensor calibration</a>
   <a href="#qc">QC summary</a>
+  {% if fig_knockdown_hab_b64 or fig_knockdown_anomaly_b64 %}<a href="#knockdown">Knockdown</a>{% endif %}
   {% if diagram_b64 %}<a href="#diagram">Mooring diagram</a>{% endif %}
 </nav>
 
@@ -793,6 +799,39 @@ recovery_time:   '{{ yaml_recover_time or '?' }}'</textarea>
 <p class="none-note">No stage&nbsp;3 QC files found — run <code>oceanarray stage3</code> first.</p>
 {% endif %}
 
+{% if fig_knockdown_hab_b64 or fig_knockdown_anomaly_b64 or fig_knockdown_displacement_b64 %}
+<!-- ══════════════════════════════════════════ KNOCKDOWN ══ -->
+<h2 id="knockdown">Mooring knockdown</h2>
+<div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-start">
+{% if fig_knockdown_hab_b64 %}
+<div style="flex:1;min-width:260px">
+<p class="note">Nominal HAB (x) vs. measured pressure (y). The dashed line shows expected pressure
+  (water&nbsp;depth&nbsp;&minus;&nbsp;HAB). Instruments below the line were knocked down.
+  Interpolated pressure (QC&nbsp;flag&nbsp;8) excluded.</p>
+<img style="width:100%;border:1px solid #dce;border-radius:4px" src="data:image/png;base64,{{ fig_knockdown_hab_b64 }}" alt="Knockdown HAB vs pressure">
+</div>
+{% endif %}
+{% if fig_knockdown_anomaly_b64 %}
+<div style="flex:1;min-width:260px">
+<p class="note">IQR of pressure anomaly (measured &minus; nominal) per instrument.
+  Positive = deeper than design depth.
+  <span style="color:mediumseagreen">Green</span> &lt;&nbsp;100&nbsp;dbar,
+  <span style="color:goldenrod">yellow</span> 100–200,
+  <span style="color:darkorange">amber</span> 200–300,
+  <span style="color:firebrick">red</span> &gt;&nbsp;300&nbsp;dbar.</p>
+<img style="width:100%;border:1px solid #dce;border-radius:4px" src="data:image/png;base64,{{ fig_knockdown_anomaly_b64 }}" alt="Knockdown pressure anomaly">
+</div>
+{% endif %}
+</div>
+{% if fig_knockdown_displacement_b64 %}
+<p class="note">Estimated horizontal displacement (m) vs. measured pressure.
+  Left: scatter per instrument; right: normalised 2-D density across all instruments.
+  Displacement derived from the rigid-pendulum approximation:
+  <em>x</em>&nbsp;=&nbsp;&radic;(hab<sub>nom</sub>&sup2;&nbsp;&minus;&nbsp;hab<sub>meas</sub>&sup2;).</p>
+<img style="width:100%;border:1px solid #dce;border-radius:4px" src="data:image/png;base64,{{ fig_knockdown_displacement_b64 }}" alt="Knockdown horizontal displacement">
+{% endif %}
+{% endif %}
+
 {% if diagram_b64 %}
 <!-- ══════════════════════════════════════════ MOORING DIAGRAM ══ -->
 <h2 id="diagram">Mooring diagram</h2>
@@ -1258,6 +1297,22 @@ class MooringReport:
             _clock_nc_paths, deploy_dt, recover_dt
         )
 
+        fig_knockdown_hab_b64 = None
+        fig_knockdown_anomaly_b64 = None
+        fig_knockdown_displacement_b64 = None
+        if stack_exists:
+            try:
+                import xarray as _xr
+
+                with _xr.open_dataset(stack_nc) as _ds_kd:
+                    fig_knockdown_hab_b64 = _make_knockdown_hab_b64(_ds_kd)
+                    fig_knockdown_anomaly_b64 = _make_knockdown_anomaly_b64(_ds_kd)
+                    fig_knockdown_displacement_b64 = _make_knockdown_displacement_b64(
+                        _ds_kd
+                    )
+            except Exception:
+                pass
+
         def _combined(deploy_key: str, recover_key: str, legacy_key: str) -> str:
             d = cfg.get(deploy_key) or cfg.get(legacy_key, "—")
             r = cfg.get(recover_key) or cfg.get(legacy_key) or d
@@ -1304,6 +1359,9 @@ class MooringReport:
             "grid_exists": grid_exists,
             "any_clock_correction": any_clock,
             "fig_clock_check_b64": fig_clock_check_b64,
+            "fig_knockdown_hab_b64": fig_knockdown_hab_b64,
+            "fig_knockdown_anomaly_b64": fig_knockdown_anomaly_b64,
+            "fig_knockdown_displacement_b64": fig_knockdown_displacement_b64,
             "nav_buttons": _nav_buttons_html(
                 mooring_name,
                 instruments,

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -13,9 +13,11 @@ import yaml
 from ._html_helpers import (
     _check_readable,
     _duration_str,
+    _find_array_report_href,
     _fmt_dt,
     _get_proc_dir,
     _load_pdf_b64,
+    _instrument_report_exists,
     _nav_buttons_html,
     _parse_dt,
     _raw_file_path,
@@ -30,6 +32,7 @@ from ._html_helpers import (
 )
 from ._grid import generate_grid_page
 from ._instrument import generate_instrument_pages
+from ._plots import _make_clock_check_b64
 from ._stack import generate_stack_page
 from ..utilities import extract_inline_instruments
 
@@ -618,6 +621,17 @@ recovery_time:   '{{ yaml_recover_time or '?' }}'</textarea>
   </tbody>
 </table>
 
+{% if fig_clock_check_b64 %}
+<h3 style="font-size:0.9rem;margin-top:1.2rem;">Clock alignment check</h3>
+<p class="note">
+  Overlaid temperature records zoomed to the first and last 30 minutes of the deployment.
+  If instrument clocks are misaligned the temperature curves will appear shifted in time.
+  Data are from stage&#8209;3 (or stage&#8209;2 if stage&#8209;3 is not yet available).
+  Instruments with no temperature data are omitted.
+</p>
+<img class="fig" src="data:image/png;base64,{{ fig_clock_check_b64 }}" alt="Clock alignment check">
+{% endif %}
+
 <!-- ══════════════════════════════════════ 5. SENSOR CALIBRATION ══ -->
 <h2 id="calibration">5 &mdash; Sensor calibration</h2>
 <style>
@@ -937,6 +951,15 @@ class MooringReport:
                 serials=serials,
                 raw_dir=self._raw_dir,
             )
+            # Instrument pages are now on disk — re-check existence and re-render
+            # the mooring summary so serial-number links work on first run.
+            if out_dir is not None:
+                for instr in ctx["instruments"]:
+                    instr["report_exists"] = _instrument_report_exists(
+                        out_dir, mooring_name, instr["serial"]
+                    )
+                html = self._render(ctx)
+                output_path.write_text(html, encoding="utf-8")
 
         if grid:
             grid_path = proc_dir / f"{mooring_name}_grid.nc"
@@ -1217,6 +1240,24 @@ class MooringReport:
 
         any_clock = any(i["clock"]["has_correction"] for i in instruments)
 
+        # Build {serial: nc_path} for the clock-offset comparison figure.
+        # Prefer stage3 over stage2 (clock correction was applied in stage2 and
+        # is preserved in stage3, so either works for comparing alignment).
+        _clock_nc_paths: Dict[str, Path] = {}
+        for _instr in instruments:
+            _s = _instr["serial"]
+            _itype = _instr["instr_type"]
+            _base = proc_dir / _itype / f"{mooring_name}_{_s}"
+            _s3 = Path(str(_base) + "_stage3.nc")
+            _s2 = Path(str(_base) + "_stage2.nc")
+            if _s3.exists():
+                _clock_nc_paths[_s] = _s3
+            elif _s2.exists():
+                _clock_nc_paths[_s] = _s2
+        fig_clock_check_b64 = _make_clock_check_b64(
+            _clock_nc_paths, deploy_dt, recover_dt
+        )
+
         def _combined(deploy_key: str, recover_key: str, legacy_key: str) -> str:
             d = cfg.get(deploy_key) or cfg.get(legacy_key, "—")
             r = cfg.get(recover_key) or cfg.get(legacy_key) or d
@@ -1262,12 +1303,14 @@ class MooringReport:
             "stack_exists": stack_exists,
             "grid_exists": grid_exists,
             "any_clock_correction": any_clock,
+            "fig_clock_check_b64": fig_clock_check_b64,
             "nav_buttons": _nav_buttons_html(
                 mooring_name,
                 instruments,
                 stack_exists=stack_exists,
                 grid_exists=grid_exists,
                 current_report="summary",
+                array_report_href=_find_array_report_href(out_dir),
             ),
             "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
             "proc_machine": socket.gethostname().split(".")[0],

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -2720,14 +2720,22 @@ def _make_grid_n2_b64(ds: "xr.Dataset", lat: float = 0.0) -> Optional[str]:
 def _make_rose_grid_b64(
     ds: "xr.Dataset",
     serial_list: list,
-) -> Optional[str]:
-    """Grid of current roses (max 4 per row) for instruments with ENU velocity data."""
+) -> tuple:
+    """Grid of current roses (max 4 per row) for instruments with ENU velocity data.
+
+    Returns
+    -------
+    tuple[str | None, int]
+        ``(base64_png, n_panels)`` — base64 image string (or ``None`` on failure)
+        and the number of rose panels rendered.
+
+    """
     import math
     import matplotlib.pyplot as plt
     from .. import parameters as P
 
     if "east_velocity" not in ds.data_vars or "north_velocity" not in ds.data_vars:
-        return None
+        return None, 0
 
     east_all = ds["east_velocity"].values.copy()
     north_all = ds["north_velocity"].values.copy()
@@ -2753,7 +2761,13 @@ def _make_rose_grid_b64(
 
     # Split by instrument type: ADCP bins are capped at 4 per serial (top, 2 mid,
     # bottom by HAB), single-point instruments (Aquadopp, etc.) keep all.
-    instr_type_vals = ds["instrument_type"].values if "instrument_type" in ds else None
+    # The variable may be "instrument_type" (mooring_level) or "instrument" (time_gridding).
+    _type_var = (
+        "instrument_type"
+        if "instrument_type" in ds
+        else ("instrument" if "instrument" in ds else None)
+    )
+    instr_type_vals = ds[_type_var].values if _type_var is not None else None
     _all_cand = [i for i in range(len(serial_list)) if i < len(has_vel) and has_vel[i]]
 
     aqd_idx: list[int] = []
@@ -2788,7 +2802,7 @@ def _make_rose_grid_b64(
 
     n = len(aqd_idx)
     if n == 0:
-        return None
+        return None, 0
 
     ncols = min(n, 4)
     nrows = math.ceil(n / ncols)
@@ -2819,7 +2833,7 @@ def _make_rose_grid_b64(
     plt.tight_layout()
     b64 = _fig_to_base64(fig)
     plt.close(fig)
-    return b64
+    return b64, n
 
 
 def _make_grid_rose_b64(ds: "xr.Dataset", max_roses: int = 4) -> Optional[str]:

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     import matplotlib.pyplot as plt
@@ -2749,12 +2749,46 @@ def _make_rose_grid_b64(
                 north_all[_qc >= 3] = np.nan
 
     has_vel = [np.any(np.isfinite(east_all[:, i])) for i in range(east_all.shape[1])]
-    aqd_idx = [i for i in range(len(serial_list)) if i < len(has_vel) and has_vel[i]]
+    hab_vals = ds.coords["hab"].values if "hab" in ds.coords else None
+
+    # Split by instrument type: ADCP bins are capped at 4 per serial (top, 2 mid,
+    # bottom by HAB), single-point instruments (Aquadopp, etc.) keep all.
+    instr_type_vals = ds["instrument_type"].values if "instrument_type" in ds else None
+    _all_cand = [i for i in range(len(serial_list)) if i < len(has_vel) and has_vel[i]]
+
+    aqd_idx: list[int] = []
+    if instr_type_vals is not None:
+        # Non-ADCP: all levels with velocity
+        aqd_idx = [i for i in _all_cand if str(instr_type_vals[i]).upper() != "ADCP"]
+
+        # ADCP: group by serial, select ≤4 representative bins by HAB
+        from collections import defaultdict
+
+        adcp_by_serial: dict[str, list[int]] = defaultdict(list)
+        for i in _all_cand:
+            if str(instr_type_vals[i]).upper() == "ADCP":
+                ser = str(serial_list[i]) if i < len(serial_list) else "?"
+                adcp_by_serial[ser].append(i)
+
+        _ADCP_PCTS = [0, 33, 67, 100]
+        for _idxs in adcp_by_serial.values():
+            # Sort by HAB so percentile picks are spatially meaningful
+            if hab_vals is not None:
+                _idxs = sorted(_idxs, key=lambda k: hab_vals[k])
+            n_b = len(_idxs)
+            selected: list[int] = []
+            for pct in _ADCP_PCTS:
+                k = int(round(pct / 100 * (n_b - 1)))
+                k = max(0, min(n_b - 1, k))
+                if _idxs[k] not in selected:
+                    selected.append(_idxs[k])
+            aqd_idx.extend(selected)
+    else:
+        aqd_idx = _all_cand
+
     n = len(aqd_idx)
     if n == 0:
         return None
-
-    hab_vals = ds.coords["hab"].values if "hab" in ds.coords else None
 
     ncols = min(n, 4)
     nrows = math.ceil(n / ncols)
@@ -2964,8 +2998,8 @@ def _make_grid_trajectory_b64(ds: "xr.Dataset") -> Optional[str]:
         v = np.nan_to_num(north[:, k], nan=0.0)
         if not np.any(east[:, k][np.isfinite(east[:, k])]):
             continue
-        x = np.concatenate([[0.0], np.cumsum(u[:-1] * dt)])
-        y = np.concatenate([[0.0], np.cumsum(v[:-1] * dt)])
+        x = np.concatenate([[0.0], np.cumsum(u[:-1] * dt)]) / 1000.0
+        y = np.concatenate([[0.0], np.cumsum(v[:-1] * dt)]) / 1000.0
         trajs.append((float(p_val), x, y))
 
     if not trajs:
@@ -2993,8 +3027,8 @@ def _make_grid_trajectory_b64(ds: "xr.Dataset") -> Optional[str]:
     ax.plot(0, 0, "o", color="black", markersize=6, zorder=6, label="Start")
     ax.legend(fontsize=8, loc="upper left")
     ax.autoscale_view()
-    ax.set_xlabel("East displacement (m)")
-    ax.set_ylabel("North displacement (m)")
+    ax.set_xlabel("East displacement (km)")
+    ax.set_ylabel("North displacement (km)")
     ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
     ax.axvline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.4)
     ax.set_aspect("equal", adjustable="box")
@@ -3878,14 +3912,15 @@ def _make_adcp_hodograph_b64(
 
 
 def _make_grid_hodograph_b64(
-    ds: "xr.Dataset", lp_days: float = 4.0, smooth_hours: float = 24.0
+    ds: "xr.Dataset", smooth_hours: float = 24.0
 ) -> Optional[str]:
     """Two-depth hodograph for the grid report.
 
     Takes an already-loaded xr.Dataset (not a path).  Picks the pressure levels
     nearest the 25th and 75th percentile of the valid gridded pressure range and
-    renders a 2×2 figure (same layout as the ADCP hodograph).  Returns None if
-    east/north velocity are absent or fewer than two valid levels exist.
+    renders a 1×2 figure (shallow / deep, each showing the ``smooth_hours``-smoothed
+    hodograph).  Returns None if east/north velocity are absent or fewer than two
+    valid levels exist.
     """
     try:
         import matplotlib.pyplot as plt
@@ -3945,32 +3980,80 @@ def _make_grid_hodograph_b64(
         label_shallow = f"{int(pressure[i_shallow])} dbar"
         label_deep = f"{int(pressure[i_deep])} dbar"
 
-        plt.style.use(str(P.MPLSTYLE))
-        fig, axes = plt.subplots(2, 2, figsize=(13, 9))
-        fig.subplots_adjust(hspace=0.55, wspace=0.45)
+        from oceanarray.plotters._helpers import tukey_smooth
 
-        _draw_hodograph_pair(
-            axes[0, 0],
-            axes[0, 1],
-            east_2d[:, i_shallow],
-            north_2d[:, i_shallow],
-            f"Shallow ({label_shallow})",
-            smooth_hours,
-            lp_days,
-            units,
-            dt_s,
-        )
-        _draw_hodograph_pair(
-            axes[1, 0],
-            axes[1, 1],
-            east_2d[:, i_deep],
-            north_2d[:, i_deep],
-            f"Deep ({label_deep})",
-            smooth_hours,
-            lp_days,
-            units,
-            dt_s,
-        )
+        smooth_n = max(3, int(round(smooth_hours * 3600.0 / dt_s)))
+
+        plt.style.use(str(P.MPLSTYLE))
+        fig, (ax_shallow, ax_deep) = plt.subplots(1, 2, figsize=(13, 6))
+        fig.subplots_adjust(wspace=0.45)
+
+        for ax, i_lev, label in [
+            (ax_shallow, i_shallow, f"Shallow ({label_shallow})"),
+            (ax_deep, i_deep, f"Deep ({label_deep})"),
+        ]:
+            e_sm = tukey_smooth(east_2d[:, i_lev], smooth_n)
+            n_sm = tukey_smooth(north_2d[:, i_lev], smooth_n)
+            mask = np.isfinite(e_sm) & np.isfinite(n_sm)
+            if mask.sum() < 2:
+                ax.text(
+                    0.5,
+                    0.5,
+                    "No data",
+                    transform=ax.transAxes,
+                    ha="center",
+                    va="center",
+                )
+                ax.set_title(label, fontsize=9)
+                continue
+            e_v, n_v = e_sm[mask], n_sm[mask]
+            t_frac = np.linspace(0.0, 1.0, len(east_2d[:, i_lev]))[mask]
+            lim = max(np.nanmax(np.abs(e_v)), np.nanmax(np.abs(n_v)), 1e-9) * 1.1
+            step = max(1, len(e_v) // 2000)
+            pts = np.array([e_v[::step], n_v[::step]]).T.reshape(-1, 1, 2)
+            segs = np.concatenate([pts[:-1], pts[1:]], axis=1)
+            from matplotlib.collections import LineCollection
+            import matplotlib.colors as mcolors
+
+            norm_lc = mcolors.Normalize(0.0, 1.0)
+            lc = LineCollection(segs, cmap="plasma", norm=norm_lc, lw=0.9, alpha=0.85)
+            lc.set_array(t_frac[::step][:-1])
+            ax.add_collection(lc)
+            sm = plt.cm.ScalarMappable(cmap="plasma", norm=norm_lc)
+            sm.set_array([])
+            cb = fig.colorbar(sm, ax=ax, shrink=0.75, pad=0.03, aspect=20)
+            cb.set_label("Time →", size=8)
+            cb.ax.set_yticks([0, 1])
+            cb.ax.set_yticklabels(["start", "end"], size=7)
+            ax.scatter(
+                e_v[0],
+                n_v[0],
+                s=50,
+                c="lime",
+                marker="o",
+                edgecolors="black",
+                linewidths=0.7,
+                zorder=5,
+            )
+            ax.scatter(
+                e_v[-1],
+                n_v[-1],
+                s=55,
+                c="red",
+                marker="s",
+                edgecolors="black",
+                linewidths=0.7,
+                zorder=5,
+            )
+            ax.set_xlim(-lim, lim)
+            ax.set_ylim(-lim, lim)
+            ax.set_aspect("equal")
+            ax.axhline(0, color="#888", lw=0.7)
+            ax.axvline(0, color="#888", lw=0.7)
+            ax.set_xlabel(f"East ({units})")
+            ax.set_ylabel(f"North ({units})")
+            ax.set_title(f"{label} — {smooth_hours:.0f}-h smoothed", fontsize=9)
+            ax.grid(True, linestyle="--", linewidth=0.4, alpha=0.3)
 
         b64 = _fig_to_base64(fig)
         plt.close(fig)
@@ -4047,6 +4130,139 @@ def _make_analog_timeseries(nc_path: "Path", analog_vars: "List[str]") -> Option
         fig.autofmt_xdate(rotation=30, ha="right")
         fig.tight_layout()
         ds.close()
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+        return b64
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _make_knockdown_pressure_b64(ds: "xr.Dataset") -> Optional[str]:
+    """IQR of measured pressure vs. nominal pressure, for the stack report.
+
+    Thin Tier-3 wrapper around
+    ``plotters._diagnostic.plot_knockdown_pressure``.  Takes an already-loaded
+    xarray.Dataset (not a path).
+
+    Returns a base64-encoded PNG string or None when no data are available.
+    """
+    try:
+        import matplotlib.pyplot as plt
+        from oceanarray.plotters._diagnostic import plot_knockdown_pressure
+
+        fig = plot_knockdown_pressure(ds)
+        if fig is None:
+            return None
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+        return b64
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _make_knockdown_hab_b64(ds: "xr.Dataset") -> Optional[str]:
+    """IQR of measured HAB vs. nominal HAB, for the stack report.
+
+    Thin Tier-3 wrapper around
+    ``plotters._diagnostic.plot_knockdown_hab``.  Takes an already-loaded
+    xarray.Dataset (not a path).
+
+    Returns a base64-encoded PNG string or None when no data are available.
+    """
+    try:
+        import matplotlib.pyplot as plt
+        from oceanarray.plotters._diagnostic import plot_knockdown_hab
+
+        fig = plot_knockdown_hab(ds)
+        if fig is None:
+            return None
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+        return b64
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _make_knockdown_displacement_b64(ds: "xr.Dataset") -> Optional[str]:
+    """Scatter of estimated horizontal displacement vs. measured pressure.
+
+    Thin Tier-3 wrapper around
+    ``plotters._diagnostic.plot_knockdown_displacement``.
+
+    Returns a base64-encoded PNG string or None when no data are available.
+    """
+    try:
+        import matplotlib.pyplot as plt
+        from oceanarray.plotters._diagnostic import plot_knockdown_displacement
+
+        fig = plot_knockdown_displacement(ds)
+        if fig is None:
+            return None
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+        return b64
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _make_knockdown_anomaly_b64(ds: "xr.Dataset") -> Optional[str]:
+    """IQR of pressure anomaly (measured − nominal) per instrument, for the stack report.
+
+    Thin Tier-3 wrapper around
+    ``plotters._diagnostic.plot_knockdown_anomaly``.  Takes an already-loaded
+    xarray.Dataset (not a path).
+
+    Returns a base64-encoded PNG string or None when no data are available.
+    """
+    try:
+        import matplotlib.pyplot as plt
+        from oceanarray.plotters._diagnostic import plot_knockdown_anomaly
+
+        fig = plot_knockdown_anomaly(ds)
+        if fig is None:
+            return None
+        b64 = _fig_to_base64(fig)
+        plt.close(fig)
+        return b64
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _make_clock_check_b64(
+    nc_paths: "Dict[str, Any]",
+    deploy_dt: "Any",
+    recover_dt: "Any",
+    window_minutes: int = 30,
+) -> Optional[str]:
+    """Overlaid temperature comparison at deployment start/end, for the mooring summary.
+
+    Thin Tier-3 wrapper around
+    ``plotters._diagnostic.plot_clock_offset_check``.
+
+    Parameters
+    ----------
+    nc_paths : dict of {serial: Path}
+        Paths to stage-2 or stage-3 NetCDF files keyed by serial number.
+    deploy_dt : datetime or None
+        Deployment start time (UTC).
+    recover_dt : datetime or None
+        Recovery time (UTC).
+    window_minutes : int
+        Duration of each zoom window in minutes (default 30).
+
+    Returns
+    -------
+    str or None
+        Base64-encoded PNG for HTML embedding, or None.
+
+    """
+    try:
+        import matplotlib.pyplot as plt
+        from oceanarray.plotters._diagnostic import plot_clock_offset_check
+
+        fig = plot_clock_offset_check(nc_paths, deploy_dt, recover_dt, window_minutes)
+        if fig is None:
+            return None
         b64 = _fig_to_base64(fig)
         plt.close(fig)
         return b64

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -26,10 +26,6 @@ from ._plots import (
     _make_aquadopp_speed_profile,
     _make_adcp_trajectories_b64,
     _make_analog_timeseries,
-    _make_knockdown_pressure_b64,
-    _make_knockdown_hab_b64,
-    _make_knockdown_displacement_b64,
-    _make_knockdown_anomaly_b64,
 )
 from .. import parameters as P
 
@@ -133,7 +129,6 @@ _STACK_HTML_TEMPLATE = """\
   {% if fig_rose_grid_b64 %}<a href="#roses">Current roses</a>{% endif %}
   {% if fig_spacing_b64 %}<a href="#spacing">Spacing</a>{% endif %}
   {% if fig_clock_check_b64 %}<a href="#clock-check">Clock check</a>{% endif %}
-  {% if fig_knockdown_pressure_b64 or fig_knockdown_hab_b64 or fig_knockdown_displacement_b64 or fig_knockdown_anomaly_b64 %}<a href="#knockdown">Knockdown</a>{% endif %}
   <a href="#dims">Dimensions</a>
   <a href="#vars">Variables</a>
 </nav>
@@ -314,57 +309,6 @@ _STACK_HTML_TEMPLATE = """\
   if stage&#8209;3 is not yet available).  Instruments without temperature are omitted.
 </p>
 <img class="fig" src="data:image/png;base64,{{ fig_clock_check_b64 }}" alt="Clock alignment check">
-{% endif %}
-
-{% if fig_knockdown_pressure_b64 or fig_knockdown_hab_b64 or fig_knockdown_anomaly_b64 %}
-<h2 id="knockdown">Mooring knockdown</h2>
-{% if fig_knockdown_pressure_b64 or fig_knockdown_hab_b64 %}
-<p class="note">
-  <strong>Left</strong>: nominal design depth (x-axis, deep instruments to the left) vs. measured
-  pressure (y-axis, increasing downward).  The dashed diagonal is the 1:1 reference — instruments
-  on it are at their design depth.  Boxes that drop <em>below</em> the diagonal were pulled deeper
-  than nominal by current drag (knockdown).
-  <strong>Right</strong>: nominal HAB in metres (x-axis, surface to the right) vs. the same
-  measured pressure (y-axis).  The dashed line shows the expected pressure for each HAB
-  (pressure&nbsp;=&nbsp;water&nbsp;depth&nbsp;&minus;&nbsp;HAB).  Departure below the line
-  can be used to estimate horizontal displacement:
-  x&nbsp;&asymp;&nbsp;&radic;(hab<sub>nom</sub>&sup2;&nbsp;&minus;&nbsp;hab<sub>meas</sub>&sup2;).
-  Interpolated pressure (QC&nbsp;flag&nbsp;8) excluded from both.
-</p>
-<div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-start">
-  {% if fig_knockdown_pressure_b64 %}
-  <img style="max-width:48%;border:1px solid #dce;border-radius:4px" src="data:image/png;base64,{{ fig_knockdown_pressure_b64 }}" alt="Knockdown pressure">
-  {% endif %}
-  {% if fig_knockdown_hab_b64 %}
-  <img style="max-width:48%;border:1px solid #dce;border-radius:4px" src="data:image/png;base64,{{ fig_knockdown_hab_b64 }}" alt="Knockdown HAB">
-  {% endif %}
-</div>
-{% endif %}
-{% if fig_knockdown_displacement_b64 %}
-<p class="note" style="margin-top:0.8rem">
-  Estimated horizontal displacement (m) vs. measured pressure (dbar) for each instrument
-  across all time steps (left: per-instrument scatter; right: normalised density heatmap,
-  each instrument weighted equally).
-  Displacement&nbsp;&asymp;&nbsp;&radic;(hab<sub>nom</sub>&sup2;&nbsp;&minus;&nbsp;hab<sub>meas</sub>&sup2;),
-  where hab<sub>meas</sub>&nbsp;=&nbsp;water&nbsp;depth&nbsp;&minus;&nbsp;pressure.
-  This is a rigid-pendulum approximation (mooring line pivots at the anchor); the true
-  catenary displacement under distributed drag is somewhat smaller.
-  Axes are scaled equally (100&thinsp;m on x&nbsp;=&nbsp;100&thinsp;dbar on y).
-</p>
-<img class="fig" style="max-width:100%" src="data:image/png;base64,{{ fig_knockdown_displacement_b64 }}" alt="Horizontal displacement scatter">
-{% endif %}
-{% if fig_knockdown_anomaly_b64 %}
-<p class="note" style="margin-top:0.8rem">
-  IQR of pressure anomaly (measured &minus; nominal) per instrument.  Positive = instrument deeper
-  than nominal design depth (knocked down).  Box colour indicates median knockdown magnitude:
-  <span style="color:mediumseagreen">green</span> &lt;&nbsp;100&nbsp;dbar,
-  <span style="color:goldenrod">yellow</span> 100–200&nbsp;dbar,
-  <span style="color:darkorange">amber</span> 200–300&nbsp;dbar,
-  <span style="color:firebrick">red</span> &gt;&nbsp;300&nbsp;dbar.
-  Interpolated pressure (QC&nbsp;flag&nbsp;8) excluded.
-</p>
-<img class="fig" style="max-width:50%" src="data:image/png;base64,{{ fig_knockdown_anomaly_b64 }}" alt="Knockdown anomaly">
-{% endif %}
 {% endif %}
 
 <!-- ══ NetCDF dimensions ══ -->
@@ -912,11 +856,6 @@ def generate_stack_page(
         fig_trajectories_b64 = _make_multi_aquadopp_trajectories(ds)
         fig_adcp_trajectories_b64 = _make_adcp_trajectories_b64(ds)
         fig_speed_profile_b64 = _make_aquadopp_speed_profile(ds)
-        fig_knockdown_pressure_b64 = _make_knockdown_pressure_b64(ds)
-        fig_knockdown_hab_b64 = _make_knockdown_hab_b64(ds)
-        fig_knockdown_displacement_b64 = _make_knockdown_displacement_b64(ds)
-        fig_knockdown_anomaly_b64 = _make_knockdown_anomaly_b64(ds)
-
         # Clock alignment check: one temperature trace per instrument zoomed to
         # first/last 30 min.  Build {serial: path} preferring stage3 over stage2.
         proc_dir = stack_path.parent
@@ -996,10 +935,6 @@ def generate_stack_page(
             fig_adcp_trajectories_b64=fig_adcp_trajectories_b64,
             fig_speed_profile_b64=fig_speed_profile_b64,
             fig_clock_check_b64=fig_clock_check_b64,
-            fig_knockdown_pressure_b64=fig_knockdown_pressure_b64,
-            fig_knockdown_hab_b64=fig_knockdown_hab_b64,
-            fig_knockdown_displacement_b64=fig_knockdown_displacement_b64,
-            fig_knockdown_anomaly_b64=fig_knockdown_anomaly_b64,
             fig_analog_b64=fig_analog_b64,
             generated=ctx["generated"],
             proc_machine=ctx.get("proc_machine", ""),

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -244,7 +244,7 @@ _STACK_HTML_TEMPLATE = """\
   </div>
   {% endif %}
   {% if fig_adcp_trajectories_b64 %}
-  <div style="flex:1;min-width:280px">
+  <div style="flex:0 0 50%;max-width:50%">
     <p style="text-align:center;font-weight:600;margin-bottom:0.3rem">ADCP</p>
     <img class="fig" style="max-width:100%;width:100%" src="data:image/png;base64,{{ fig_adcp_trajectories_b64 }}" alt="ADCP trajectories">
   </div>
@@ -772,12 +772,8 @@ def generate_stack_page(
             else None
         )
 
-        fig_rose_grid_b64 = _make_rose_grid_b64(ds, _serial_list)
+        fig_rose_grid_b64, _n_rose = _make_rose_grid_b64(ds, _serial_list)
         # Width cap: 33% for 1 panel, 50% for 2, 66% for 3, 83% for 4, 100% for 5+
-        _n_rose = 0
-        if "east_velocity" in ds.data_vars:
-            _ev = ds["east_velocity"].values
-            _n_rose = sum(np.any(np.isfinite(_ev[:, i])) for i in range(_ev.shape[1]))
         _rose_w_map = {1: "33", 2: "50", 3: "66", 4: "83"}
         rose_img_width = _rose_w_map.get(_n_rose, "100")
 

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -9,18 +9,27 @@ import numpy as np
 
 from ._html_helpers import (
     _fig_to_base64,
+    _find_array_report_href,
+    _instrument_report_exists,
+    _instrument_report_href,
     _nav_buttons_html,
+    _parse_dt,
     _parse_history,
     _read_nc_metadata,
     _status,
 )
 from ._plots import (
+    _make_clock_check_b64,
     _make_rose_grid_b64,
     _make_stack_ts_diagram,
     _make_multi_aquadopp_trajectories,
     _make_aquadopp_speed_profile,
     _make_adcp_trajectories_b64,
     _make_analog_timeseries,
+    _make_knockdown_pressure_b64,
+    _make_knockdown_hab_b64,
+    _make_knockdown_displacement_b64,
+    _make_knockdown_anomaly_b64,
 )
 from .. import parameters as P
 
@@ -123,6 +132,8 @@ _STACK_HTML_TEMPLATE = """\
   {% if fig_ts_stack_b64 %}<a href="#ts">T-S diagram</a>{% endif %}
   {% if fig_rose_grid_b64 %}<a href="#roses">Current roses</a>{% endif %}
   {% if fig_spacing_b64 %}<a href="#spacing">Spacing</a>{% endif %}
+  {% if fig_clock_check_b64 %}<a href="#clock-check">Clock check</a>{% endif %}
+  {% if fig_knockdown_pressure_b64 or fig_knockdown_hab_b64 or fig_knockdown_displacement_b64 or fig_knockdown_anomaly_b64 %}<a href="#knockdown">Knockdown</a>{% endif %}
   <a href="#dims">Dimensions</a>
   <a href="#vars">Variables</a>
 </nav>
@@ -149,7 +160,7 @@ _STACK_HTML_TEMPLATE = """\
   <tr>
     <td>{{ loop.index0 }}</td>
     <td>{{ row.instr_type }}</td>
-    <td><a href="{{ mooring_name }}_{{ row.serial }}_report.html">{{ row.serial }}</a></td>
+    <td>{% if row.report_exists %}<a href="{{ row.report_href }}">{{ row.serial }}</a>{% else %}{{ row.serial }}{% endif %}</td>
     <td>{{ row.hab }}</td>
     <td>{{ row.depth }}</td>
   </tr>
@@ -291,7 +302,69 @@ _STACK_HTML_TEMPLATE = """\
 {% if fig_spacing_b64 %}
 <h2 id="spacing">Adjacent instrument spacing</h2>
 <p class="note">Distribution of pressure differences between adjacent instrument pairs (pairs &lt; 2 dbar apart excluded as co-located).</p>
-<img class="fig" src="data:image/png;base64,{{ fig_spacing_b64 }}" alt="Instrument spacing histogram">
+<img style="max-width:33%;border:1px solid #dce;border-radius:4px" src="data:image/png;base64,{{ fig_spacing_b64 }}" alt="Instrument spacing histogram">
+{% endif %}
+
+{% if fig_clock_check_b64 %}
+<h2 id="clock-check">Clock alignment check</h2>
+<p class="note">
+  Temperature records from all instruments overlaid, zoomed to the first and last
+  30&thinsp;minutes of the deployment.  A horizontal shift between curves indicates
+  a clock offset between instruments.  Data are from stage&#8209;3 (or stage&#8209;2
+  if stage&#8209;3 is not yet available).  Instruments without temperature are omitted.
+</p>
+<img class="fig" src="data:image/png;base64,{{ fig_clock_check_b64 }}" alt="Clock alignment check">
+{% endif %}
+
+{% if fig_knockdown_pressure_b64 or fig_knockdown_hab_b64 or fig_knockdown_anomaly_b64 %}
+<h2 id="knockdown">Mooring knockdown</h2>
+{% if fig_knockdown_pressure_b64 or fig_knockdown_hab_b64 %}
+<p class="note">
+  <strong>Left</strong>: nominal design depth (x-axis, deep instruments to the left) vs. measured
+  pressure (y-axis, increasing downward).  The dashed diagonal is the 1:1 reference — instruments
+  on it are at their design depth.  Boxes that drop <em>below</em> the diagonal were pulled deeper
+  than nominal by current drag (knockdown).
+  <strong>Right</strong>: nominal HAB in metres (x-axis, surface to the right) vs. the same
+  measured pressure (y-axis).  The dashed line shows the expected pressure for each HAB
+  (pressure&nbsp;=&nbsp;water&nbsp;depth&nbsp;&minus;&nbsp;HAB).  Departure below the line
+  can be used to estimate horizontal displacement:
+  x&nbsp;&asymp;&nbsp;&radic;(hab<sub>nom</sub>&sup2;&nbsp;&minus;&nbsp;hab<sub>meas</sub>&sup2;).
+  Interpolated pressure (QC&nbsp;flag&nbsp;8) excluded from both.
+</p>
+<div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-start">
+  {% if fig_knockdown_pressure_b64 %}
+  <img style="max-width:48%;border:1px solid #dce;border-radius:4px" src="data:image/png;base64,{{ fig_knockdown_pressure_b64 }}" alt="Knockdown pressure">
+  {% endif %}
+  {% if fig_knockdown_hab_b64 %}
+  <img style="max-width:48%;border:1px solid #dce;border-radius:4px" src="data:image/png;base64,{{ fig_knockdown_hab_b64 }}" alt="Knockdown HAB">
+  {% endif %}
+</div>
+{% endif %}
+{% if fig_knockdown_displacement_b64 %}
+<p class="note" style="margin-top:0.8rem">
+  Estimated horizontal displacement (m) vs. measured pressure (dbar) for each instrument
+  across all time steps (left: per-instrument scatter; right: normalised density heatmap,
+  each instrument weighted equally).
+  Displacement&nbsp;&asymp;&nbsp;&radic;(hab<sub>nom</sub>&sup2;&nbsp;&minus;&nbsp;hab<sub>meas</sub>&sup2;),
+  where hab<sub>meas</sub>&nbsp;=&nbsp;water&nbsp;depth&nbsp;&minus;&nbsp;pressure.
+  This is a rigid-pendulum approximation (mooring line pivots at the anchor); the true
+  catenary displacement under distributed drag is somewhat smaller.
+  Axes are scaled equally (100&thinsp;m on x&nbsp;=&nbsp;100&thinsp;dbar on y).
+</p>
+<img class="fig" style="max-width:100%" src="data:image/png;base64,{{ fig_knockdown_displacement_b64 }}" alt="Horizontal displacement scatter">
+{% endif %}
+{% if fig_knockdown_anomaly_b64 %}
+<p class="note" style="margin-top:0.8rem">
+  IQR of pressure anomaly (measured &minus; nominal) per instrument.  Positive = instrument deeper
+  than nominal design depth (knocked down).  Box colour indicates median knockdown magnitude:
+  <span style="color:mediumseagreen">green</span> &lt;&nbsp;100&nbsp;dbar,
+  <span style="color:goldenrod">yellow</span> 100–200&nbsp;dbar,
+  <span style="color:darkorange">amber</span> 200–300&nbsp;dbar,
+  <span style="color:firebrick">red</span> &gt;&nbsp;300&nbsp;dbar.
+  Interpolated pressure (QC&nbsp;flag&nbsp;8) excluded.
+</p>
+<img class="fig" style="max-width:50%" src="data:image/png;base64,{{ fig_knockdown_anomaly_b64 }}" alt="Knockdown anomaly">
+{% endif %}
 {% endif %}
 
 <!-- ══ NetCDF dimensions ══ -->
@@ -611,13 +684,18 @@ def generate_stack_page(
         instr_rows = []
         for i in range(n_instr):
             depth = f"{waterdepth - habs[i]:.0f}" if waterdepth else "—"
+            _ser = str(serials[i])
             instr_rows.append(
                 {
-                    "serial": serials[i],
+                    "serial": _ser,
                     "instr_type": instr_types[i],
                     "hab": f"{habs[i]:.1f}",
                     "depth": depth,
                     "stage": "",
+                    "report_href": _instrument_report_href(mooring_name, _ser),
+                    "report_exists": _instrument_report_exists(
+                        out_dir, mooring_name, _ser
+                    ),
                 }
             )
 
@@ -816,7 +894,7 @@ def generate_stack_page(
                     valid = spacing[np.isfinite(spacing) & (spacing >= 2.0)]
                     all_spacings.extend(valid.tolist())
                 if all_spacings:
-                    fig_sp, ax_sp = plt.subplots(figsize=(8, 4))
+                    fig_sp, ax_sp = plt.subplots(figsize=(4, 3))
                     ax_sp.hist(
                         all_spacings, bins=60, color="steelblue", edgecolor="white"
                     )
@@ -834,6 +912,30 @@ def generate_stack_page(
         fig_trajectories_b64 = _make_multi_aquadopp_trajectories(ds)
         fig_adcp_trajectories_b64 = _make_adcp_trajectories_b64(ds)
         fig_speed_profile_b64 = _make_aquadopp_speed_profile(ds)
+        fig_knockdown_pressure_b64 = _make_knockdown_pressure_b64(ds)
+        fig_knockdown_hab_b64 = _make_knockdown_hab_b64(ds)
+        fig_knockdown_displacement_b64 = _make_knockdown_displacement_b64(ds)
+        fig_knockdown_anomaly_b64 = _make_knockdown_anomaly_b64(ds)
+
+        # Clock alignment check: one temperature trace per instrument zoomed to
+        # first/last 30 min.  Build {serial: path} preferring stage3 over stage2.
+        proc_dir = stack_path.parent
+        _clock_nc_paths: Dict[str, Path] = {}
+        for i in range(n_instr):
+            _s = str(serials[i])
+            _itype = str(instr_types[i])
+            _base = proc_dir / _itype / f"{mooring_name}_{_s}"
+            _s3 = Path(str(_base) + "_stage3.nc")
+            _s2 = Path(str(_base) + "_stage2.nc")
+            if _s3.exists():
+                _clock_nc_paths[_s] = _s3
+            elif _s2.exists():
+                _clock_nc_paths[_s] = _s2
+        _deploy_dt = _parse_dt(ctx.get("deploy_time"))
+        _recover_dt = _parse_dt(ctx.get("recover_time"))
+        fig_clock_check_b64 = _make_clock_check_b64(
+            _clock_nc_paths, _deploy_dt, _recover_dt
+        )
 
         ds.close()
 
@@ -855,6 +957,7 @@ def generate_stack_page(
                 stack_exists=True,
                 grid_exists=grid_exists,
                 current_report="stack",
+                array_report_href=_find_array_report_href(out_dir),
             ),
             cruise=ctx.get("cruise", "—"),
             ship=ctx.get("ship", "—"),
@@ -892,6 +995,11 @@ def generate_stack_page(
             fig_trajectories_b64=fig_trajectories_b64,
             fig_adcp_trajectories_b64=fig_adcp_trajectories_b64,
             fig_speed_profile_b64=fig_speed_profile_b64,
+            fig_clock_check_b64=fig_clock_check_b64,
+            fig_knockdown_pressure_b64=fig_knockdown_pressure_b64,
+            fig_knockdown_hab_b64=fig_knockdown_hab_b64,
+            fig_knockdown_displacement_b64=fig_knockdown_displacement_b64,
+            fig_knockdown_anomaly_b64=fig_knockdown_anomaly_b64,
             fig_analog_b64=fig_analog_b64,
             generated=ctx["generated"],
             proc_machine=ctx.get("proc_machine", ""),

--- a/oceanarray/utilities.py
+++ b/oceanarray/utilities.py
@@ -519,9 +519,20 @@ def cast_output_dtypes(ds: xr.Dataset) -> xr.Dataset:
         var = ds[vname]
         target = find_best_dtype(vname, var)
         if np.dtype(target) != var.dtype:
-            updates[vname] = xr.Variable(
-                var.dims, var.values.astype(target), attrs=var.attrs
-            )
+            if np.issubdtype(np.dtype(target), np.integer) and np.issubdtype(
+                var.dtype, np.floating
+            ):
+                # NaN cannot be represented as an integer; replace before cast.
+                # QC variables use 9 (CF "missing value"); other integer vars use 0.
+                fill_val = 9 if (vname.endswith("_qc") or "flag" in vname) else 0
+                safe_vals = np.where(np.isfinite(var.values), var.values, fill_val)
+                updates[vname] = xr.Variable(
+                    var.dims, safe_vals.astype(target), attrs=var.attrs
+                )
+            else:
+                updates[vname] = xr.Variable(
+                    var.dims, var.values.astype(target), attrs=var.attrs
+                )
     if not updates:
         return ds
     return ds.assign(updates)


### PR DESCRIPTION
## Summary

- **Array-level HTML report** — new `_array.py` + `oceanarray report --array` CLI flag; overall duration in masthead
- **Knockdown visualization overhaul** — four specialized figures replace old histogram
- **Clock offset check figure** — overlaid temperature traces in mooring summary and stack report
- **Hodograph — grid report** — reduced from 2×2 (raw + eddy × 2 depths) to 1×2 (24 h smoothed, shallow + deep)
- **Trajectories** — displacement axes changed from metres to kilometres across all trajectory plots (stack, grid, per-instrument)
- **Trajectory colorscale tick spacing** — temperature ≥0.5 °C step; ADCP HAB ≥50 m step
- **Current rose ADCP cap** — stack report rose grid now caps ADCP bins at 4 (top/bottom/2 middle by HAB); Aquadopps unchanged
- **Spacing histogram** — reduced to ~33% page width; figsize shrunk to match
- **Array report nav button** — grey "Array" pill added to masthead nav in all four report types; macOS `._*` dotfile glob fixed
- **Cross-report instrument links** — serial numbers link to per-instrument pages; first-run generation-order bug fixed
- **`_parse_dt` UTC suffix fix** — `"2026-04-15 12:00 UTC"` now parsed correctly
- **CLI improvements** — `oceanarray report --all/-A`; `oceanarray grid` example with `--pmin`/`--pmax`; `oceanarray list` corrected and extended
- **Installation docs** — removed nonexistent PyPI entry; added conda and venv options
- **Bug fix** — NaN-to-integer cast RuntimeWarning in `_cast_dataset_dtypes`


## Changes by file

### `oceanarray/report/_array.py` (new)

- `generate_array_report(array_yaml_path, proc_dir, force)` reads a `*.array.yaml`, gathers per-mooring metadata, draws a lat/lon scatter map, writes HTML index.
- Summary table: Position #, Mooring ID, Lat, Lon, Water depth, Deploy, Recovery, Duration, Instruments, Reports (coloured pill buttons).
- **Colour dots**: each mooring gets a `tab20` colour on the map; a matching filled circle is prepended to the `#` cell in the table so the map and table cross-reference visually.
- **Unrecovered moorings**: dots appear on the map but the mooring ID label is suppressed (no `ax.annotate`) when `recovery_time` is absent from the YAML.
- Map uses plain `matplotlib` axes (no cartopy); aspect ratio = `1/cos(mean_lat)`.
 
### `oceanarray/cli.py`

- `oceanarray report --array`: positional argument treated as `*.array.yaml` path.
- `oceanarray report --all / -A`: implies `--stack --grid --instruments` in one flag.
- `oceanarray grid` description: added example line with `--pmin`, `--pmax`, `--dp`.
- `oceanarray list`: `nortek-aqd` added to aquadopp file_types; `nortek-ascii` removed from ADCP; `nortek-aqd` removed from deprecated extras; notes now include `header:` field.

### `oceanarray/parameters.py`

- `aquadopp` file_types: `["nortek-aqd", "nortek-ascii", "nortek-csv"]`
- `ADCP` file_types: `nortek-ascii` removed (not a Nortek ADCP reader)
- `EXTRA_FILE_TYPES`: `nortek-aqd` entry removed (now in primary list)

### `oceanarray/plotters/_diagnostic.py`

Four new Tier-2 knockdown functions:

- `plot_knockdown_pressure(ds)` — nominal vs measured pressure scatter, 1:1 diagonal, equal-aspect. **Grid added** (`ax.grid(True, ...)`).
- `plot_knockdown_hab(ds)` — measured pressure vs nominal HAB with reference curve.
- `plot_knockdown_anomaly(ds)` — horizontal IQR box-and-whisker per instrument, coloured green/yellow/amber/red by magnitude.
- `plot_knockdown_displacement(ds)` — rigid-pendulum horizontal displacement vs measured pressure; left scatter (tab20, per instrument) + right normalised 2-D heatmap (YlOrRd). Both panels have grids.

**New:** `plot_clock_offset_check(nc_paths, deploy_dt, recover_dt)` — two-panel temperature overlay (±30 min around deploy/recovery). Helpers: `_kd_color`, `_collect_knockdown_records`.

### `oceanarray/report/_mooring.py`

- Clock offset check figure added to mooring summary report (§ "Clock alignment check  below the deployment timeline section). *This will be updated/replaced with a lag correlation calculation.
- **First-run link bug fixed**: `_build_context` was called before instrument pages existed on disk, so `report_exists` was always False on first run.  Fix: after `generate_instrument_pages` writes files to disk, the `report_exists` flag is recomputed for every instrument and the mooring summary HTML is re-rendered.  On subsequent runs (files already present), `_build_context` finds them immediately and the re-render is a no-op.

### `oceanarray/report/_stack.py`

- **Knockdown section** added to stack report, with four figures (pressure, HAB, displacement, anomaly) rendered side-by-side where appropriate.
- **Clock alignment check section** added between Spacing and Knockdown — same `_make_clock_check_b64` wrapper as the mooring summary, but reads individual stage3/stage2 files from `stack_path.parent` using the `serial` and `instrument_type` variables from the stacked dataset.
- Instrument table serial cells now use `_instrument_report_href` / `_instrument_report_exists` so the `instrument/` subdirectory prefix is included correctly.

### `oceanarray/report/_plots.py`

- `_make_grid_hodograph_b64`: changed from 2×2 layout (raw + eddy × shallow + deep) to 1×2 (shallow + deep, both showing 24 h Tukey-smoothed hodograph only).  Removed unused `lp_days` parameter.  Figure size reduced to 13×6 in.

### `oceanarray/plotters/_current.py`

- `plot_multi_aquadopp_trajectories`: cumulative displacement divided by 1000; axis  labels changed to `"East displacement (km)"` / `"North displacement (km)"`.
- `plot_adcp_trajectories`: same km conversion and label update.

### `docs/source/setup.md` and `docs/source/quickstart.rst`

Installation instructions rewritten:
- Removed `pip install oceanarray` (package is not on PyPI).
- Added **Option A — conda** (`conda create -n oceanarray python=3.11; conda activate …`) and **Option B — venv** (`python -m venv venv; source venv/bin/activate`) sections.
- Shared "Clone and install" step (`git clone … && pip install -e .`) follows both options.

### `oceanarray/utilities.py`

- `_cast_dataset_dtypes`: fixed RuntimeWarning when casting a float variable containing NaN to an integer dtype.  QC variables (`*_qc`, `*flag`) use fill value 9 (CF missing); other integer variables use 0.

### `oceanarray/report/_html_helpers.py`

- `_parse_dt`: now strips `" UTC"` suffix before `datetime.fromisoformat`, fixing silent `None` return when `ctx["deploy_time"]` / `ctx["recover_time"]` are formatted as `"2026-04-15 12:00 UTC"`.   