### PR TITLE
[FIX] plot regularisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ matlab_calibration/
 
 logs/*log
 
-# Claude Code configuration
-.claude/
 
 # VSCode settings
 .vscode/*

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,9 +37,7 @@ Contents
 
    processing_framework
    reports
-   cli_reference
    directory_structure
-   yaml_configuration
    file_naming_conventions
 
 .. toctree::
@@ -80,13 +78,18 @@ Contents
 
    GitHub Repo <https://github.com/ocean-uhh/oceanarray>
    Python API <oceanarray>
+   cli_reference
+   yaml_configuration
    project_structure
-   migration
-
-
    oceanarray_format
    OceanSITES manual <oceanSITES_manual>
    Legacy modules <legacy>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Changelog / Migration
+
+   migration
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/oceanarray.rst
+++ b/docs/source/oceanarray.rst
@@ -5,41 +5,49 @@
    :maxdepth: 2
    :caption: API Reference
 
-   readers
-   writers
-   plotters
-   trimming
-   transports
-   tools
-   utilities
+   oceanarray
 
-Load and process moored oceanographic time series data from raw instrument format to array-integrated transport products.
+Load and process moored oceanographic time series data from raw instrument
+format to array-integrated products.
 
-Inputs and Outputs
-------------------
+I/O and shared tools
+---------------------
 
 readers
-^^^^^^^^^^^
-Shared utilities and base classes for loading raw instrument data.
+^^^^^^^
+Supplementary data readers (Nortek CSV, RODB legacy format).
 
-.. automodule:: oceanarray.readers
+.. automodule:: oceanarray.tools.readers
    :members:
    :undoc-members:
-
-
 
 writers
-^^^^^^^^^^^
-Write datasets to disk in standardized NetCDF format.
+^^^^^^^
+NetCDF output helpers.
 
-.. automodule:: oceanarray.writers
+.. automodule:: oceanarray.tools.writers
    :members:
    :undoc-members:
 
+rapid interpolation
+^^^^^^^^^^^^^^^^^^^
+Physics-informed vertical interpolation (RAPID array scheme).
+
+.. automodule:: oceanarray.tools.rapid_interp
+   :members:
+   :undoc-members:
+
+utilities
+^^^^^^^^^
+General utilities for file management, logging, and parsing ASCII metadata.
+
+.. automodule:: oceanarray.utilities
+   :members:
+   :undoc-members:
 
 plotters
-^^^^^^^^^^^
-Tools for plotting mooring time series, profile sections, and transport products.
+^^^^^^^^
+Tier-1 primitives and Tier-2 domain plotting functions.
 
 .. automodule:: oceanarray.plotters
    :members:
@@ -54,64 +62,104 @@ calibration-dip casts.
    :members:
    :undoc-members:
 
-Instrument Processing
+Instrument processing
 ----------------------
 
+stage 1 — standardisation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+Convert raw instrument files (SeaBird, RBR, Nortek, RDI) to CF-NetCDF.
+Faithful to raw data; no QC.
 
-stage 1 - standardisation
-^^^^^^^^^^^^^^^^^^^^^^^^^
-Trim instrument records to the deployment window and flag out-of-bounds values.
-
-.. automodule:: oceanarray.stage1
+.. automodule:: oceanarray.instrument.stage1
    :members:
    :undoc-members:
 
-
-stage 2 - trimming and clock correction
+stage 2 — trimming and clock correction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Trim to deployment window and apply linear clock-offset/drift correction.
+Trim to the deployment window; apply linear clock-offset/drift correction.
 
-.. automodule:: oceanarray.stage2
+.. automodule:: oceanarray.instrument.stage2
    :members:
    :undoc-members:
 
-stage 3 - QC, rotation, and derived variables
+stage 3 — QC, rotation, and derived variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Apply gross-range and spike QC flags, rotate ADCP velocities to ENU, apply
-magnetic declination correction, and compute derived quantities (salinity,
-density, current speed/direction).
+Apply QC flags, rotate ADCP velocities to ENU, apply magnetic declination
+correction, and compute derived quantities (salinity, density, speed/direction).
 
-.. automodule:: oceanarray.stage3
+.. automodule:: oceanarray.instrument.stage3
    :members:
    :undoc-members:
 
-clock offset
-^^^^^^^^^^^^
-Cross-correlation and lag-analysis tools for estimating clock offsets between
-co-located instruments.
+pressure
+^^^^^^^^
+Pressure interpolation helpers (HAB computation, gap-filling).
 
-.. automodule:: oceanarray.clock_offset
+.. automodule:: oceanarray.instrument.pressure
    :members:
    :undoc-members:
 
-Mooring Processing
-------------------
+qc
+^^
+QARTOD quality-control tests.
 
-time gridding / stacking
-^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: oceanarray.instrument.qc
+   :members:
+   :undoc-members:
+
+coordinate
+^^^^^^^^^^
+Coordinate system transformations (BEAM → XYZ → ENU, magnetic declination).
+
+.. automodule:: oceanarray.instrument.coordinate
+   :members:
+   :undoc-members:
+
+caldip
+^^^^^^
+Cal-dip cast processing (stub; full implementation in progress).
+
+.. automodule:: oceanarray.instrument.caldip
+   :members:
+   :undoc-members:
+
+Mooring processing
+-------------------
+
+stack
+^^^^^
 Interpolate multiple instruments onto a common time grid and stack into a
 single mooring dataset (``oceanarray stack``).
 
-.. automodule:: oceanarray.time_gridding
+.. automodule:: oceanarray.mooring.stack
    :members:
    :undoc-members:
 
-vertical gridding
-^^^^^^^^^^^^^^^^^
+grid
+^^^^
 Interpolate stacked mooring data onto a regular pressure grid
-(``oceanarray grid``).  See :class:`~oceanarray.mooring_level.MooringGridder`.
+(``oceanarray grid``).
 
-.. automodule:: oceanarray.mooring_level
+.. automodule:: oceanarray.mooring.grid
+   :members:
+   :undoc-members:
+
+mooring helpers
+^^^^^^^^^^^^^^^
+Shared helpers for position parsing, HAB computation, and instrument metadata.
+
+.. automodule:: oceanarray.mooring.helpers
+   :members:
+   :undoc-members:
+
+Configuration and validation
+-----------------------------
+
+parameters
+^^^^^^^^^^
+Global processing parameters (QC thresholds, grid defaults, file paths).
+
+.. automodule:: oceanarray.config.parameters
    :members:
    :undoc-members:
 
@@ -119,47 +167,30 @@ validation
 ^^^^^^^^^^
 Validate mooring YAML configuration files and check instrument type names.
 
-.. automodule:: oceanarray.validation
+.. automodule:: oceanarray.config.validation
    :members:
    :undoc-members:
 
-Array Processing
-----------------------
+Analysis
+---------
 
-transports
-^^^^^^^^^^^
-Compute transport time series by integrating geostrophic velocity profiles and applying boundary corrections.
+analysis
+^^^^^^^^
+Science utilities: lag correlation, isopycnal tracking, wavelet analysis,
+power spectra.
 
-.. automodule:: oceanarray.transports
+.. automodule:: oceanarray.analysis
    :members:
    :undoc-members:
 
-General Tools and Utilities
----------------------------
-
-
-tools
-^^^^^^^^^^^
-Helper functions for unit conversion, time alignment, and quality control.
-
-.. automodule:: oceanarray.tools
-   :members:
-   :undoc-members:
-
-utilities
-^^^^^^^^^^^
-General utilities for file management, logging, and parsing ASCII metadata.
-
-.. automodule:: oceanarray.utilities
-   :members:
-   :undoc-members:
+Legacy
+-------
 
 plotter
 ^^^^^^^
-Legacy per-instrument plotting functions (use ``oceanarray.plotters`` for new
-code; this module is retained for backward compatibility).
+Legacy per-instrument plotting functions (use ``oceanarray.plotters`` for
+new code).
 
 .. automodule:: oceanarray.plotter
    :members:
    :undoc-members:
-

--- a/oceanarray/analysis/_clock_diagnostics.py
+++ b/oceanarray/analysis/_clock_diagnostics.py
@@ -24,8 +24,8 @@ from oceanarray.legacy import find_deployment
 
 
 def load_mooring_instruments(
-    mooring_name, base_dir, output_path, file_suffix="_stage2"
-):  # noqa: ARG001
+    mooring_name, base_dir, output_path, file_suffix="_stage2"  # noqa: ARG001
+):
     """Load all instruments for a mooring from netCDF files and enrich with YAML metadata.
 
     Parameters

--- a/oceanarray/analysis/_clock_diagnostics.py
+++ b/oceanarray/analysis/_clock_diagnostics.py
@@ -24,7 +24,10 @@ from oceanarray.legacy import find_deployment
 
 
 def load_mooring_instruments(
-    mooring_name, base_dir, output_path, file_suffix="_stage2"  # noqa: ARG001
+    mooring_name,
+    base_dir,  # noqa: ARG001
+    output_path,
+    file_suffix="_stage2",
 ):
     """Load all instruments for a mooring from netCDF files and enrich with YAML metadata.
 

--- a/oceanarray/plotters/_current.py
+++ b/oceanarray/plotters/_current.py
@@ -562,10 +562,8 @@ def plot_aquadopp_speed_profile(
         bp["boxes"][0].set_facecolor("steelblue")
         bp["boxes"][0].set_alpha(0.6)
 
-        # Serial label to the right of the whisker end
-        q75 = np.percentile(spd_clean, 75)
-        iqr = q75 - np.percentile(spd_clean, 25)
-        whisker_end = q75 + 1.5 * iqr
+        # Serial label to the right of the actual whisker end (not the theoretical cap)
+        whisker_end = bp["whiskers"][1].get_xdata()[-1]
         ax.text(
             whisker_end * 1.02,
             hab,

--- a/oceanarray/plotters/_diagnostic.py
+++ b/oceanarray/plotters/_diagnostic.py
@@ -542,7 +542,7 @@ def plot_clock_offset_check(
     nc_paths: "Dict[str, Path]",
     deploy_dt: "Optional[datetime]",
     recover_dt: "Optional[datetime]",
-    window_minutes: int = 30,
+    window_minutes: int = 10,
 ) -> "Optional[matplotlib.figure.Figure]":
     """Overlaid temperature time series zoomed to deployment start and end.
 
@@ -558,7 +558,8 @@ def plot_clock_offset_check(
     - **Right**: last ``window_minutes`` minutes before ``recover_dt``
 
     When ``deploy_dt`` or ``recover_dt`` is ``None``, only the available
-    window is produced.
+    window is produced.  A shared legend below both panels lists all
+    instruments.
 
     Parameters
     ----------
@@ -637,20 +638,14 @@ def plot_clock_offset_check(
     _tab20 = plt.get_cmap("tab20")
     colors = {s: _tab20(i % 20) for i, s in enumerate(series)}
 
+    plotted_serials: set = set()
     for ax, (t_lo, t_hi, title) in zip(axes, windows):
-        plotted = False
         for serial, (t, temp) in series.items():
             mask = (t >= t_lo) & (t <= t_hi) & np.isfinite(temp)
             if not np.any(mask):
                 continue
-            ax.plot(
-                t[mask],
-                temp[mask],
-                color=colors[serial],
-                lw=1.0,
-                label=str(serial),
-            )
-            plotted = True
+            ax.plot(t[mask], temp[mask], color=colors[serial], lw=1.0)
+            plotted_serials.add(serial)
 
         ax.set_title(title, fontsize=8)
         ax.set_xlabel("Time (UTC)")
@@ -660,8 +655,23 @@ def plot_clock_offset_check(
         ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
         ax.tick_params(axis="x", labelsize=7)
 
-        if plotted:
-            ax.legend(fontsize=6, loc="upper left")
+    if plotted_serials:
+        from matplotlib.lines import Line2D
+
+        handles = [
+            Line2D([0], [0], color=colors[s], lw=1.0, label=str(s))
+            for s in series
+            if s in plotted_serials
+        ]
+        fig.legend(
+            handles=handles,
+            loc="lower center",
+            ncol=min(len(handles), 6),
+            bbox_to_anchor=(0.5, -0.05),
+            fontsize=7,
+            frameon=True,
+        )
 
     plt.tight_layout()
+    fig.subplots_adjust(bottom=0.18)
     return fig

--- a/oceanarray/report/_instrument.py
+++ b/oceanarray/report/_instrument.py
@@ -591,6 +591,8 @@ def generate_instrument_pages(
         Cruise-level raw data directory for the new directory layout.  When given,
         raw file existence is checked at ``{raw_dir}/{mooring}/{instr_type}/filename``.
         When None, *base_dir* is used instead (legacy layout).
+    skip_existing : bool
+        If True, skip pages whose output file is newer than the source NetCDF.
 
     """
     mooring_report_link = f"../{mooring_name}_report.html"

--- a/oceanarray/report/_plots.py
+++ b/oceanarray/report/_plots.py
@@ -108,20 +108,20 @@ def _plot_aquadopp_quick(ds: "xr.Dataset") -> "plt.Figure":
     if enu:
         for vname, color in zip(enu, ["tab:blue", "tab:orange", "tab:cyan"]):
             label = (
-                vname.replace("_velocity", " vel.").replace("_", " ").title() + " [m/s]"
+                vname.replace("_velocity", " vel.").replace("_", " ").title() + " (m/s)"
             )
             panels.append((vname, label, color, False))
     else:
         for i, color in enumerate(["tab:blue", "tab:orange", "tab:cyan"], 1):
             vname = f"velocity_beam{i}"
             if vname in ds.data_vars:
-                panels.append((vname, f"Beam {i} vel. [m/s]", color, False))
+                panels.append((vname, f"Beam {i} vel. (m/s)", color, False))
 
     pvar = next((v for v in ("pressure", "pressure_1") if v in ds.data_vars), None)
     if pvar:
-        panels.append((pvar, "Pressure [dbar]", "tab:green", True))
+        panels.append((pvar, "Pressure (dbar)", "tab:green", True))
 
-    for vname, label in (("pitch", "Pitch [°]"), ("roll", "Roll [°]")):
+    for vname, label in (("pitch", "Pitch (°)"), ("roll", "Roll (°)")):
         if vname in ds.data_vars:
             panels.append((vname, label, "tab:purple", False))
 
@@ -213,7 +213,7 @@ def _instrument_panels(
             continue
         if do_combo:
             if vname == "pitch":
-                out.append(("_pitch_roll_combo", "Pitch & Roll [°]", None, False))
+                out.append(("_pitch_roll_combo", "Pitch & Roll (°)", None, False))
                 continue
             if vname == "roll":
                 continue
@@ -5122,7 +5122,7 @@ def _make_clock_check_b64(
     nc_paths: "Dict[str, Any]",
     deploy_dt: "Any",
     recover_dt: "Any",
-    window_minutes: int = 30,
+    window_minutes: int = 10,
 ) -> Optional[str]:
     """Overlaid temperature comparison at deployment start/end, for the mooring summary.
 
@@ -5138,7 +5138,7 @@ def _make_clock_check_b64(
     recover_dt : datetime or None
         Recovery time (UTC).
     window_minutes : int
-        Duration of each zoom window in minutes (default 30).
+        Duration of each zoom window in minutes (default 10).
 
     Returns
     -------

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -122,12 +122,12 @@ _STACK_HTML_TEMPLATE = """\
   {% if fig_temp_b64 %}<a href="#temp">Temperature</a>{% endif %}
   {% if fig_sal_b64 %}<a href="#sal">Salinity</a>{% endif %}
   {% if fig_east_vel_b64 or fig_north_vel_b64 or fig_up_vel_b64 %}<a href="#vel">Velocity</a>{% endif %}
-  {% if fig_aquadopp_tilt_b64 %}<a href="#tilt">Tilt</a>{% endif %}
   {% if fig_trajectories_b64 or fig_adcp_trajectories_b64 %}<a href="#trajectories">Trajectories</a>{% endif %}
   {% if fig_speed_profile_b64 %}<a href="#speed-profile">Speed profile</a>{% endif %}
   {% if fig_analog_b64 %}<a href="#analog">Analog channels</a>{% endif %}
   {% if fig_ts_stack_b64 %}<a href="#ts">T-S diagram</a>{% endif %}
   {% if fig_rose_grid_b64 %}<a href="#roses">Current roses</a>{% endif %}
+  {% if fig_aquadopp_tilt_b64 %}<a href="#tilt">Tilt</a>{% endif %}
   {% if fig_spacing_b64 %}<a href="#spacing">Spacing</a>{% endif %}
   {% if fig_clock_check_b64 %}<a href="#clock-check">Clock check</a>{% endif %}
   <a href="#dims">Dimensions</a>
@@ -216,19 +216,6 @@ _STACK_HTML_TEMPLATE = """\
 <img class="fig" src="data:image/png;base64,{{ fig_turbidity_b64 }}" alt="Turbidity time series">
 {% endif %}
 
-{% if fig_aquadopp_tilt_b64 %}
-<h2 id="tilt">Aquadopp tilt (|pitch| / |roll| / pressure estimate)</h2>
-<p class="note">
-  One panel per Aquadopp (deep-first). Blue = |pitch|, green = |roll|, orange dashed = tilt
-  estimated from pressure difference between the Aquadopp and the nearest instrument &ge;10 m above
-  with valid pressure (arccos(&Delta;P / rope length)).  All curves are non-negative.
-  Horizontal lines: orange dashed = suspect threshold, red dotted = fail threshold (read from file attrs).
-  Pitch and roll are stored <em>unmasked</em> in the stack file; use <code>pitch_qc</code> /
-  <code>roll_qc</code> to filter. Plots show all available values.
-</p>
-<img class="fig" src="data:image/png;base64,{{ fig_aquadopp_tilt_b64 }}" alt="Aquadopp tilt panels">
-{% endif %}
-
 {% if fig_trajectories_b64 or fig_adcp_trajectories_b64 %}
 <h2 id="trajectories">Particle trajectories</h2>
 <p class="note">
@@ -295,6 +282,19 @@ _STACK_HTML_TEMPLATE = """\
 <img class="fig" style="max-width:{{ rose_img_width }}%" src="data:image/png;base64,{{ fig_rose_grid_b64 }}" alt="Current rose grid">
 {% endif %}
 
+{% if fig_aquadopp_tilt_b64 %}
+<h2 id="tilt">Aquadopp tilt (|pitch| / |roll| / pressure estimate)</h2>
+<p class="note">
+  One panel per Aquadopp (deep-first). Blue = |pitch|, green = |roll|, orange dashed = tilt
+  estimated from pressure difference between the Aquadopp and the nearest instrument &ge;10 m above
+  with valid pressure (arccos(&Delta;P / rope length)).  All curves are non-negative.
+  Horizontal lines: orange dashed = suspect threshold, red dotted = fail threshold (read from file attrs).
+  Pitch and roll are stored <em>unmasked</em> in the stack file; use <code>pitch_qc</code> /
+  <code>roll_qc</code> to filter. Plots show all available values.
+</p>
+<img class="fig" src="data:image/png;base64,{{ fig_aquadopp_tilt_b64 }}" alt="Aquadopp tilt panels">
+{% endif %}
+
 {% if fig_spacing_b64 %}
 <h2 id="spacing">Adjacent instrument spacing</h2>
 <p class="note">Distribution of pressure differences between adjacent instrument pairs (pairs &lt; 2 dbar apart excluded as co-located).</p>
@@ -305,7 +305,7 @@ _STACK_HTML_TEMPLATE = """\
 <h2 id="clock-check">Clock alignment check</h2>
 <p class="note">
   Temperature records from all instruments overlaid, zoomed to the first and last
-  30&thinsp;minutes of the deployment.  A horizontal shift between curves indicates
+  10&thinsp;minutes of the deployment.  A horizontal shift between curves indicates
   a clock offset between instruments.  Data are from stage&#8209;3 (or stage&#8209;2
   if stage&#8209;3 is not yet available).  Instruments without temperature are omitted.
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ include = ["oceanarray", "oceanarray.*"]
 
 [tool.setuptools.package-data]
 oceanarray = [
+  "oceanarray.mplstyle",
+  "config/*.yaml",
+  "config/legacy/*.yaml",
   "logsheet/data/column_defs.yaml",
   "logsheet/data/latex_templates/*.tex.j2",
 ]
@@ -127,19 +130,22 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["ANN", "D", "SLF001"]   # tests don't need type annotations, docstrings, or private-access guards
 "tests/legacy/**" = ["ANN", "D", "SLF001", "ARG001", "E741", "F841"]  # legacy tests: also allow unused fixture args, short variable names, unused locals
-# tools.py is being reorganised into analysis/ post-OdB; ANN/D deferred until then
+# tools.py reorganised into analysis/ (post-OdB PR #49); ANN/D deferred on legacy content
 "oceanarray/tools.py" = ["ANN", "D205"]
-# The following files move to tools/ or pipeline/ post-OdB; ANN/D deferred until then
+"oceanarray/analysis/_science.py" = ["ANN", "D"]
+"oceanarray/analysis/_clock_diagnostics.py" = ["ANN", "D"]
+# The following flat files moved to subpackages in PR #49; ANN/D deferred on legacy content
 "oceanarray/clock_offset.py" = ["ANN", "D"]
 "oceanarray/find_deployment.py" = ["ANN", "D"]
-"oceanarray/plotter.py" = ["ANN", "D"]          # legacy; renamed from plotters.py; migrates to plotters/ post-OdB
+"oceanarray/plotter.py" = ["ANN", "D"]          # legacy; renamed from plotters.py
 "oceanarray/plotters/__init__.py" = ["ANN", "D", "F401"]  # backward-compat shim re-exports
 "oceanarray/plotters/_primitives.py" = ["ANN", "D"]
 "oceanarray/plotters/_current.py" = ["ANN", "D"]
 "oceanarray/readers.py" = ["ANN", "D"]
 "oceanarray/writers.py" = ["ANN", "D"]
-# rapid_interp.py moves to legacy/ post-OdB; suppress everything until then
+# rapid_interp moved to tools/ in PR #49; suppress legacy issues until rewrite
 "oceanarray/rapid_interp.py" = ["ANN", "D", "F841", "SLF001", "TRY003", "BLE001"]
+"oceanarray/tools/rapid_interp.py" = ["ANN", "D", "F841", "SLF001", "TRY003", "BLE001"]
 # Report generators: every function wraps rendering in try/except → None on failure.
 # This is the established pattern for keeping HTML reports partially working on bad data.
 "oceanarray/report/_plots.py" = ["BLE001", "TRY300"]
@@ -151,6 +157,7 @@ ignore = [
 # Nortek header parsers use except Exception: pass to handle malformed/missing files.
 # Stage1 also has TRY003 for a single ValueError with a descriptive message.
 "oceanarray/stage1.py" = ["BLE001", "TRY003"]
+"oceanarray/instrument/stage1.py" = ["BLE001", "TRY003"]
 # Logsheets modules: builders use sys.exit() for user-facing errors (CLI tool pattern),
 # BLE001/TRY for broad catches in _firmware.py, ANN/D deferred (internal impl files).
 "oceanarray/logsheet/_config.py" = ["BLE001", "TRY003", "ANN", "D"]


### PR DESCRIPTION
## Summary

Plot, report, and housekeeping fixes — all mechanical items.

### Plot / report fixes
- **Whisker label** (`plotters/_current.py`): replaced theoretical cap `q75 + 1.5 × IQR` with actual whisker end from `bp["whiskers"][1].get_xdata()[-1]`.
- **Axis labels — parentheses** (`report/_plots.py`): 5 square-bracket unit strings (`[m/s]`, `[dbar]`, `[°]`) converted to parentheses per CLAUDE.md convention.
- **Clock offset zoom** (`plotters/_diagnostic.py`, `report/_plots.py`): default window changed from 30 → 10 minutes; per-axes legends replaced with a single shared `fig.legend(...)` below both panels.
- **Stack report tilt section**: moved `{% if fig_aquadopp_tilt_b64 %}` block and its nav link from before trajectories to just before the spacing histogram. Updated stale "30 minutes" description in clock check note.

### Package fix (install correctness)
- **`pyproject.toml` package-data**: added `oceanarray.mplstyle`, `config/*.yaml`, `config/legacy/*.yaml`. These files were absent from the installed package, causing `FileNotFoundError` on first import after `pip install`. Same class of bug as the `column_defs.yaml` fix in feat-logsheets.

### Docs
- **`oceanarray.rst`** (API reference): fully rewritten for the post-PR-#49 subpackage structure (`instrument/`, `mooring/`, `tools/`, `analysis/`, `config/`). Old flat paths (`oceanarray.stage1`, `oceanarray.mooring_level`, `oceanarray.transports` etc.) replaced with correct submodule paths.
- **`index.rst`**: moved `cli_reference` and `yaml_configuration` from "Processing framework" to "Reference" toctree; `migration` moved to a new "Changelog / Migration" section.

### Lint
- **`pyproject.toml` per-file-ignores**: added new paths for files moved in PR #49 (`analysis/_clock_diagnostics.py`, `analysis/_science.py`, `instrument/stage1.py`, `tools/rapid_interp.py`), matching the ignores their predecessor flat files had. Fixes 92 pre-existing ruff errors; 0 remain.
- **`report/_instrument.py`**: added missing `skip_existing` parameter to docstring (D417).
- **`analysis/_clock_diagnostics.py`**: moved misplaced `# noqa: ARG001` from the closing `)` to the line where `base_dir` is declared.
