### PR TITLE
[REFACTOR] single-source registries, serial handling, validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ First public release.
 
 ### Processing pipeline
 
-- **Stage 1** — raw instrument files → CF-NetCDF: Sea-Bird SBE37 MicroCAT (`sbe-cnv`, `sbe-ascii`), Nortek Aquadopp (`nortek-aqd`, `nortek-ascii`, `nortek-csv`), RBR Solo/Duet (`rbr-rsk`, `rbr-dat`), RDI WorkHorse ADCP (`rdi-raw`). Nortek BEAM→XYZ transformation matrix parsed from `.hdr` file and applied at stage 1; matrix stored in output for reproducibility.
+- **Stage 1** — raw instrument files → CF-NetCDF: Sea-Bird SBE37 MicroCAT (`sbe-cnv`, `sbe-ascii`), Nortek Aquadopp (`nortek-raw`, `nortek-ascii`, `nortek-csv`), RBR Solo/Duet (`rbr-rsk`, `rbr-dat`), RDI WorkHorse ADCP (`rdi-raw`). Nortek BEAM→XYZ transformation matrix parsed from `.hdr` file and applied at stage 1; matrix stored in output for reproducibility.
 - **Stage 2** — deployment trimming (YAML `deployment_time`/`recovery_time`) and linear clock-drift correction from recovery timestamps.
 - **Stage 3** — QARTOD gross-range and spike QC on T/C/S/P; pressure interpolation (QC flag 8) for instruments without a pressure sensor; Aquadopp XYZ→ENU rotation using heading/pitch/roll + IGRF magnetic declination (`ppigrf`); tilt QC on velocity; potential density via `gsw`.
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ By default only the main mooring summary is generated (fast).  Use flags to opt 
 | Instrument | File types | Variables |
 |------------|------------|-----------|
 | Sea-Bird SBE37 MicroCAT | `sbe-cnv`, `sbe-asc`, `sbe-ascii` | T, C, P |
-| Nortek Aquadopp | `nortek-aqd`, `nortek-ascii`, `nortek-csv` | U, V, W, P, T |
+| Nortek Aquadopp | `nortek-raw`, `nortek-ascii`, `nortek-csv` | U, V, W, P, T |
 | RBR Solo / Duet | `rbr-rsk`, `rbr-dat` | T (Solo), T+C (Duet) |
 | RDI WorkHorse ADCP | `rdi-raw` | U, V, W (all bins) |
 

--- a/docs/source/methods/standardisation.rst
+++ b/docs/source/methods/standardisation.rst
@@ -37,7 +37,7 @@ The :class:`oceanarray.stage1.MooringProcessor` class supports multiple instrume
 
 - **Sea-Bird CNV files** (`sbe-cnv`): Standard SBE 37 MicroCAT output
 - **Sea-Bird ASCII files** (`sbe-asc`): Alternative SBE ASCII format
-- **Nortek AquaDopp** (`nortek-aqd`): Current meter data with header files
+- **Nortek AquaDopp** (`nortek-raw`): Current meter data with header files
 - **RBR RSK files** (`rbr-rsk`): RBR logger binary format
 - **RBR ASCII files** (`rbr-dat`): RBR text output
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -124,7 +124,7 @@ instruments is shown below.
      - serial: "400115"
        instrument: aquadopp
        filename: A400115_dsG3.aqd
-       file_type: nortek-aqd
+       file_type: nortek-raw
        header_file: A400115_dsG3.hdr
        hab: 460
 

--- a/docs/source/yaml_configuration.rst
+++ b/docs/source/yaml_configuration.rst
@@ -43,7 +43,7 @@ for your deployment before running any ``oceanarray`` command.
      - serial: "400115"
        instrument: aquadopp
        filename: A400115_dsG3.aqd
-       file_type: nortek-aqd
+       file_type: nortek-raw
        header_file: A400115_dsG3.hdr
        hab: 460
 
@@ -364,7 +364,7 @@ Valid values and their descriptions:
      - ``rbr-rsk``, ``rbr-dat``
    * - ``aquadopp``
      - Nortek Aquadopp current meter
-     - ``nortek-aqd``, ``nortek-ascii``, ``nortek-csv``
+     - ``nortek-raw``, ``nortek-ascii``, ``nortek-csv``
    * - ``ADCP``
      - RDI WorkHorse broadband ADCP
      - ``rdi-raw``
@@ -405,7 +405,7 @@ Valid ``file_type`` values
      - SeaBird HEX
      - SBE16
      -
-   * - ``nortek-aqd``
+   * - ``nortek-raw``
      - Nortek binary AQD
      - Aquadopp
      - Requires a matching ``.hdr`` file; supply path with ``header_file``

--- a/oceanarray/cli.py
+++ b/oceanarray/cli.py
@@ -1016,13 +1016,19 @@ def cmd_stub(args: argparse.Namespace) -> int:
                 "hab": None,
                 "sample_interval_seconds": None,
                 "filename": None,
-                "file_type": "nortek-aqd",
+                "file_type": "nortek-raw",
                 "header": None,
                 "clock_offset": 0,
                 "computer_clock_at_recovery": None,
                 "instrument_clock_at_recovery": None,
             }
         )
+    )
+    clamp[-1].yaml_add_eol_comment(
+        "if comma-separated (e.g. '16430, R01-024') the first token is the "
+        "primary serial used in filenames/output; the rest is beacon_id. "
+        "Characters illegal in filenames are stripped.",
+        "serial",
     )
     clamp[-1].yaml_add_eol_comment("height above bottom (m) of transducer", "hab")
     clamp[-1].yaml_add_eol_comment(

--- a/oceanarray/config/parameters.py
+++ b/oceanarray/config/parameters.py
@@ -254,15 +254,16 @@ INSTRUMENT_ABBREV = {
 # ---------------------------------------------------------------------------
 INSTRUMENT_FILE_TYPES: dict = {
     "microcat": ["sbe-cnv", "sbe-ascii", "sbe-hex"],
-    "aquadopp": ["nortek-aqd", "nortek-ascii", "nortek-csv"],
+    "sbe56": ["sbe-cnv", "sbe-ascii"],  # SeaBird SBE56 temperature logger
+    "sbe16": ["sbe-cnv", "sbe-hex"],  # SeaBird SBE16 CTD
+    "aquadopp": ["nortek-raw", "nortek-ascii", "nortek-csv"],
     "tr1050": ["rbr-hex"],  # RBR TR-1050 thermistor chain
     "rbrsolo": ["rbr-rsk"],  # RBR soloT — single-channel temperature
     "rbrduet": ["rbr-rsk"],  # RBR duet — temperature + pressure or T+C
     "seapoint": ["rbr-rsk"],  # Seapoint turbidity sensor via RBR logger
     "ADCP": [
         "rdi-raw",  # RDI Workhorse / Sentinel via dolfyn (mhkit[dolfyn] required)
-        "adcp-matlab-rdadcp",
-        "adcp-matlab-uhhds",
+        "adcp-matlab",  # seasenselib auto-detects RD-ADCP vs UHHDS Matlab exports
     ],  # Generic ADCP (instrument: ADCP in YAML — note uppercase)
 }
 
@@ -270,9 +271,22 @@ INSTRUMENT_FILE_TYPES: dict = {
 KNOWN_INSTRUMENT_TYPES: frozenset = frozenset(INSTRUMENT_FILE_TYPES.keys())
 
 # File types that seasenselib accepts but are deprecated, experimental, or
-# not tied to a primary instrument: value above.
+# not tied to a primary ``instrument:`` value above.  These remain valid in a
+# mooring YAML but are not the recommended key for any current instrument class.
 EXTRA_FILE_TYPES: dict = {
+    "sbe-asc": "SeaBird (legacy oceanarray alias for sbe-ascii)",
     "nortek-csv-oa": "aquadopp (DEPRECATED internal reader; use nortek-csv)",
     "rbr-dat": "RBR instruments (not in current seasenselib; use rbr-rsk)",
+    "rbr-matlab": "RBR instruments (seasenselib Matlab reader)",
     "rbr-matlab-legacy": "RBR instruments (DEPRECATED legacy format)",
+    "rbr-hex-oa": "RBR TR-1050 (internal oceanarray hex reader; use rbr-hex)",
 }
+
+# Single source of truth for valid ``file_type:`` values in a mooring YAML.
+# Union of every per-instrument reader key with the extra/deprecated keys above.
+# ``validation.VALID_FILE_TYPES`` and ``stage1.SUPPORTED_FILE_TYPES`` both derive
+# from this — add a new file type to ``INSTRUMENT_FILE_TYPES`` or
+# ``EXTRA_FILE_TYPES``, never to those consumers.
+ALL_FILE_TYPES: frozenset = frozenset(
+    ft for fts in INSTRUMENT_FILE_TYPES.values() for ft in fts
+) | frozenset(EXTRA_FILE_TYPES)

--- a/oceanarray/config/parameters.py
+++ b/oceanarray/config/parameters.py
@@ -274,7 +274,6 @@ KNOWN_INSTRUMENT_TYPES: frozenset = frozenset(INSTRUMENT_FILE_TYPES.keys())
 # not tied to a primary ``instrument:`` value above.  These remain valid in a
 # mooring YAML but are not the recommended key for any current instrument class.
 EXTRA_FILE_TYPES: dict = {
-    "sbe-asc": "SeaBird (legacy oceanarray alias for sbe-ascii)",
     "nortek-csv-oa": "aquadopp (DEPRECATED internal reader; use nortek-csv)",
     "rbr-dat": "RBR instruments (not in current seasenselib; use rbr-rsk)",
     "rbr-matlab": "RBR instruments (seasenselib Matlab reader)",

--- a/oceanarray/config/validation.py
+++ b/oceanarray/config/validation.py
@@ -86,7 +86,6 @@ from oceanarray import parameters as P
 KNOWN_ALIASES: Dict[str, str] = {
     "sbe37": "microcat",
     "nortek": "aquadopp",
-    "adcp": "ADCP",  # instrument type is upper-case in YAML (see CLAUDE.md)
 }
 
 # Valid ``file_type:`` values are single-sourced from ``parameters.ALL_FILE_TYPES``
@@ -210,7 +209,10 @@ def validate_mooring_yaml(yaml_path: str) -> List[ValidationIssue]:
                     f"{prefix} instrument='{instrument}' is deprecated — use '{correct}' instead",
                 )
             )
-        elif instrument not in P.KNOWN_INSTRUMENT_TYPES:
+        elif (
+            instrument not in P.KNOWN_INSTRUMENT_TYPES
+            and instrument.upper() != "ADCP"  # accept both 'adcp' and 'ADCP'
+        ):
             issues.append(
                 ValidationIssue(
                     "WARNING",

--- a/oceanarray/config/validation.py
+++ b/oceanarray/config/validation.py
@@ -17,7 +17,7 @@ Valid instrument names and their typical file types
 | sbe16      | SeaBird SBE16 CTD            | sbe-cnv, sbe-hex       |
 | rbrsolo    | RBR Solo temperature         | rbr-rsk, rbr-dat       |
 | rbrduet    | RBR Duet CT                  | rbr-rsk, rbr-dat       |
-| aquadopp   | Nortek Aquadopp current meter| nortek-aqd, nortek-ascii, nortek-csv |
+| aquadopp   | Nortek Aquadopp current meter| nortek-raw, nortek-ascii, nortek-csv |
 | adcp       | Acoustic Doppler Current Prof| adcp-matlab            |
 | tr1050     | Turner TR-1050 (via RBR)     | rbr-matlab             |
 +------------+------------------------------+------------------------+
@@ -72,75 +72,27 @@ records what was applied and when.
 
 import re
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple
+from typing import Dict, List, NamedTuple
 
 import yaml
 
+from oceanarray import parameters as P
 
-VALID_INSTRUMENTS: Dict[str, Dict[str, Any]] = {
-    "microcat": {
-        "description": "SeaBird SBE37 CTD",
-        "typical_file_types": ["sbe-cnv", "sbe-ascii"],
-    },
-    "sbe56": {
-        "description": "SeaBird SBE56 temperature logger",
-        "typical_file_types": ["sbe-cnv"],
-    },
-    "sbe16": {
-        "description": "SeaBird SBE16 CTD",
-        "typical_file_types": ["sbe-cnv", "sbe-hex"],
-    },
-    "rbrsolo": {
-        "description": "RBR Solo temperature logger",
-        "typical_file_types": ["rbr-rsk", "rbr-dat"],
-    },
-    "rbrduet": {
-        "description": "RBR Duet CT logger",
-        "typical_file_types": ["rbr-rsk", "rbr-dat"],
-    },
-    "aquadopp": {
-        "description": "Nortek Aquadopp current meter",
-        "typical_file_types": ["nortek-aqd", "nortek-ascii"],
-    },
-    "adcp": {
-        "description": "Acoustic Doppler Current Profiler (lowercase; use 'ADCP' in YAML)",
-        "typical_file_types": ["rdi-raw", "adcp-matlab"],
-    },
-    "ADCP": {
-        "description": "Acoustic Doppler Current Profiler (RDI or similar)",
-        "typical_file_types": ["rdi-raw", "adcp-matlab"],
-    },
-    "tr1050": {
-        "description": "Turner TR-1050 fluorometer (via RBR logger)",
-        "typical_file_types": ["rbr-matlab", "rbr-hex-oa"],
-    },
-    "seapoint": {
-        "description": "Seapoint turbidity sensor (via RBR logger)",
-        "typical_file_types": ["rbr-rsk", "rbr-dat"],
-    },
-}
+
+# Instrument-type validity is single-sourced from ``parameters.KNOWN_INSTRUMENT_TYPES``
+# (derived from ``INSTRUMENT_FILE_TYPES``).  This keeps ``oceanarray list`` and
+# ``oceanarray validate`` in agreement; add new instrument types there, not here.
 
 KNOWN_ALIASES: Dict[str, str] = {
     "sbe37": "microcat",
     "nortek": "aquadopp",
+    "adcp": "ADCP",  # instrument type is upper-case in YAML (see CLAUDE.md)
 }
 
-VALID_FILE_TYPES = {
-    "sbe-cnv",
-    "sbe-asc",
-    "sbe-ascii",
-    "sbe-hex",
-    "nortek-aqd",
-    "nortek-ascii",
-    "nortek-csv",  # seasenselib reader (future)
-    "nortek-csv-oa",  # DEPRECATED: internal oceanarray CSV reader
-    "rbr-rsk",
-    "rbr-dat",
-    "rbr-matlab",
-    "adcp-matlab",
-    "rdi-raw",  # RDI ADCP raw binary; requires mhkit[dolfyn]
-    "rbr-hex-oa",  # internal oceanarray hex reader for TR-1050; use rbr-hex once seasenselib supports it
-}
+# Valid ``file_type:`` values are single-sourced from ``parameters.ALL_FILE_TYPES``
+# (union of ``INSTRUMENT_FILE_TYPES`` readers and ``EXTRA_FILE_TYPES``).  Add new
+# file types there, not here — this keeps ``validate`` and stage1 in agreement.
+VALID_FILE_TYPES = P.ALL_FILE_TYPES
 
 UNSUPPORTED_FILE_TYPES: Dict[str, str] = {}
 
@@ -258,12 +210,12 @@ def validate_mooring_yaml(yaml_path: str) -> List[ValidationIssue]:
                     f"{prefix} instrument='{instrument}' is deprecated — use '{correct}' instead",
                 )
             )
-        elif instrument not in VALID_INSTRUMENTS:
+        elif instrument not in P.KNOWN_INSTRUMENT_TYPES:
             issues.append(
                 ValidationIssue(
                     "WARNING",
                     f"{prefix} instrument='{instrument}' is not in the known list: "
-                    f"{', '.join(sorted(VALID_INSTRUMENTS))}",
+                    f"{', '.join(sorted(P.KNOWN_INSTRUMENT_TYPES))}",
                 )
             )
 

--- a/oceanarray/instrument/stage1.py
+++ b/oceanarray/instrument/stage1.py
@@ -19,6 +19,7 @@ from oceanarray.utilities import (
     should_skip_regeneration,
 )
 from oceanarray import parameters as P
+from oceanarray.paths import safe_serial
 
 # Suppress noisy INFO/WARNING messages from seasenselib/pycnv.
 logging.getLogger("seasenselib").setLevel(logging.WARNING)
@@ -202,14 +203,12 @@ class MooringProcessor:
     # Variables to remove for specific file types
     VARS_TO_REMOVE = {
         "sbe-cnv": ["potential_temperature", "julian_days_offset", "density"],
-        "sbe-asc": ["potential_temperature", "julian_days_offset", "density"],
         "sbe-ascii": ["potential_temperature", "julian_days_offset", "density"],
     }
 
     # Coordinates to remove for specific file types
     COORDS_TO_REMOVE = {
         "sbe-cnv": ["depth", "latitude", "longitude"],
-        "sbe-asc": ["depth", "latitude", "longitude"],
         "sbe-ascii": ["depth", "latitude", "longitude"],
     }
 
@@ -637,7 +636,7 @@ class MooringProcessor:
         except Exception:
             return dataset
 
-        instr_serial = re.sub(r"[^\w]", "", str(instrument_config.get("serial", "")))
+        instr_serial = safe_serial(instrument_config.get("serial", ""))
 
         # Matches the start of a new calibration section or end-of-header markers
         _section_start = re.compile(
@@ -779,7 +778,7 @@ class MooringProcessor:
         if not cal_coeffs:
             return dataset
 
-        instr_serial = re.sub(r"[^\w]", "", str(instrument_config.get("serial", "")))
+        instr_serial = safe_serial(instrument_config.get("serial", ""))
 
         def _coeff_str(coeffs: Dict[str, Any]) -> str:
             return ", ".join(
@@ -919,7 +918,7 @@ class MooringProcessor:
         instrument serial (e.g. 7507).  Rename so all three SENSOR_* variables
         for one instrument share the same serial suffix.
         """
-        instr_serial = re.sub(r"[^\w]", "", str(instrument_config.get("serial", "")))
+        instr_serial = safe_serial(instrument_config.get("serial", ""))
         if not instr_serial:
             return dataset
         expected = f"SENSOR_PRES_{instr_serial}"
@@ -1289,9 +1288,8 @@ class MooringProcessor:
         if not raw_serial or raw_serial == "unknown":
             return None
         # Strip illegal filename chars (e.g. '*' used as a YAML annotation marker)
-        import re as _re
 
-        raw_serial = _re.sub(r"[^\w\-]", "", raw_serial)
+        raw_serial = safe_serial(raw_serial)
 
         candidates: list = []  # list of (filename, file_type, header_or_None)
 
@@ -1528,13 +1526,10 @@ class MooringProcessor:
             mooring_name, instrument_config, output_inst_dir
         )
 
-        # Skip only if the output is present and newer than both its raw input
-        # and the mooring YAML — editing either forces a rebuild.  --force always
-        # regenerates.  (Shared rule with the report layer; see B3.)
-        mooring_yaml = output_path / f"{mooring_name}.mooring.yaml"
-        if should_skip_regeneration(
-            output_file, force, False, input_file, mooring_yaml
-        ):
+        # Skip only if the output is present and newer than its raw input.
+        # The mooring YAML is deliberately NOT a staleness source: comment or
+        # spacing edits should not trigger reprocessing.  --force always regenerates.
+        if should_skip_regeneration(output_file, force, False, input_file):
             _status("skip", self._rel(output_file))
             return True
 
@@ -1859,11 +1854,11 @@ class MooringProcessor:
 
         # Filter by serial if requested
         if serials:
-            safe_serials = {re.sub(r"[^\w\-]", "", str(s)) for s in serials}
+            safe_serials = {safe_serial(s) for s in serials}
             instrument_list = [
                 ic
                 for ic in instrument_list
-                if re.sub(r"[^\w\-]", "", str(ic.get("serial", ""))) in safe_serials
+                if safe_serial(ic.get("serial", "")) in safe_serials
             ]
             self._log_print(
                 f"Filtered to {len(instrument_list)} instrument(s) matching serial(s): {', '.join(serials)}"
@@ -1891,7 +1886,9 @@ class MooringProcessor:
         if total_count == 0:
             self._log_print("No instruments matched — nothing processed.")
             return False
-        return success_count == total_count
+        # Partial success is still success: instruments that processed are written
+        # and the record summary reports which succeeded and which failed.
+        return success_count > 0
 
 
 def stage1_mooring(

--- a/oceanarray/instrument/stage1.py
+++ b/oceanarray/instrument/stage1.py
@@ -12,7 +12,12 @@ import xarray as xr
 import yaml
 import seasenselib
 from seasenselib.writers import NetCdfWriter
-from oceanarray.utilities import _status, cast_output_dtypes, extract_inline_instruments
+from oceanarray.utilities import (
+    _status,
+    cast_output_dtypes,
+    extract_inline_instruments,
+    should_skip_regeneration,
+)
 from oceanarray import parameters as P
 
 # Suppress noisy INFO/WARNING messages from seasenselib/pycnv.
@@ -187,22 +192,12 @@ def _parse_nortek_pressure_cal(hdr_path: Path) -> dict:
 class MooringProcessor:
     """Handles stage1 processing of mooring data."""
 
-    # Supported format keys for seasenselib.read() or internal readers
-    SUPPORTED_FILE_TYPES = {
-        "sbe-cnv",
-        "sbe-ascii",  # newer seasenselib ASCII reader (with date normalisation)
-        "nortek-aqd",
-        "nortek-ascii",
-        "nortek-csv",  # seasenselib reader (future; not yet implemented)
-        "nortek-csv-oa",  # DEPRECATED: internal oceanarray CSV reader; use nortek-csv once seasenselib supports it
-        "rbr-rsk",
-        "rbr-matlab-legacy",
-        "rbr-dat",
-        "rbr-hex",
-        "rbr-hex-oa",  # legacy internal reader — use rbr-hex instead
-        "sbe-hex",
-        "rdi-raw",  # RDI ADCP raw binary (requires mhkit[dolfyn])
-    }
+    # Supported format keys for seasenselib.read() or internal readers.
+    # Single-sourced from ``parameters.ALL_FILE_TYPES`` so the stage1 gate and the
+    # YAML validator cannot drift.  Add new file types to ``INSTRUMENT_FILE_TYPES``
+    # or ``EXTRA_FILE_TYPES`` in parameters, not here.  Note: some keys (e.g.
+    # ``nortek-csv``) are accepted vocabulary but not yet implemented by a reader.
+    SUPPORTED_FILE_TYPES = P.ALL_FILE_TYPES
 
     # Variables to remove for specific file types
     VARS_TO_REMOVE = {
@@ -335,7 +330,7 @@ class MooringProcessor:
         Parameters
         ----------
         file_type:
-            One of ``SUPPORTED_FILE_TYPES`` (e.g. ``"nortek-aqd"``, ``"sbe-cnv"``).
+            One of ``SUPPORTED_FILE_TYPES`` (e.g. ``"nortek-raw"``, ``"sbe-cnv"``).
         file_path:
             Path to the raw instrument file.
         header_path:
@@ -389,7 +384,7 @@ class MooringProcessor:
             return ds
 
         kwargs = {}
-        if file_type in ("nortek-aqd", "nortek-ascii") and header_path:
+        if file_type in ("nortek-raw", "nortek-ascii") and header_path:
             kwargs["header_file"] = header_path
 
         ds = seasenselib.read(
@@ -398,7 +393,7 @@ class MooringProcessor:
             pipeline_skip_stages=["derivation"],
             **kwargs,
         )
-        if file_type in ("nortek-ascii", "nortek-aqd"):
+        if file_type in ("nortek-ascii", "nortek-raw"):
             if header_path:
                 coord_system = _parse_nortek_coord_system(Path(header_path))
             else:
@@ -1201,10 +1196,10 @@ class MooringProcessor:
 
     @staticmethod
     def _safe_serial(serial: str) -> str:
-        """Strip characters that are illegal in filenames (e.g. '*' used as a YAML marker)."""
-        import re
+        """Return a filename-safe serial token (see :func:`oceanarray.paths.safe_serial`)."""
+        from oceanarray.paths import safe_serial
 
-        return re.sub(r"[^\w\-]", "", str(serial))
+        return safe_serial(serial)
 
     def _generate_output_filename(
         self, mooring_name: str, instrument_config: Dict[str, Any], output_dir: Path
@@ -1353,7 +1348,7 @@ class MooringProcessor:
                                     "nortek-csv",
                                     _hdr_rel,
                                 )
-                # Also try the .aqd binary directly (nortek-aqd format).
+                # Also try the .aqd binary directly (nortek-raw format).
                 # These may live in aquadopp/ OR legacy nortek/ subdirs.
                 _aqd_roots = [
                     *[r / "aquadopp" for r in [raw_mooring_dir] if r is not None],
@@ -1367,7 +1362,7 @@ class MooringProcessor:
                         _hdr = _aqd.with_suffix(".hdr")
                         return (
                             _aqd.name,
-                            "nortek-aqd",
+                            "nortek-raw",
                             _hdr.name if _hdr.exists() else None,
                         )
                     _tried_400.append(str(_root / f"A{raw_serial}*.aqd"))
@@ -1533,8 +1528,13 @@ class MooringProcessor:
             mooring_name, instrument_config, output_inst_dir
         )
 
-        # Skip if output file already exists (unless forced)
-        if output_file.exists() and not force:
+        # Skip only if the output is present and newer than both its raw input
+        # and the mooring YAML — editing either forces a rebuild.  --force always
+        # regenerates.  (Shared rule with the report layer; see B3.)
+        mooring_yaml = output_path / f"{mooring_name}.mooring.yaml"
+        if should_skip_regeneration(
+            output_file, force, False, input_file, mooring_yaml
+        ):
             _status("skip", self._rel(output_file))
             return True
 
@@ -1590,7 +1590,7 @@ class MooringProcessor:
         header_key = instrument_config.get("header_file") or instrument_config.get(
             "header"
         )
-        if file_type in ("nortek-aqd", "nortek-ascii", "nortek-csv") and header_key:
+        if file_type in ("nortek-raw", "nortek-ascii", "nortek-csv") and header_key:
             instrument_name = instrument_config.get("instrument", "unknown")
             # 'nortek' is a deprecated instrument name; files live in 'aquadopp/' dir.
             instr_dir = "aquadopp" if instrument_name == "nortek" else instrument_name
@@ -1625,7 +1625,7 @@ class MooringProcessor:
             dataset = self._normalize_rdi_raw(dataset, instrument_config)
 
         # Store Nortek pressure sensor calibration coefficients from oceanarray.hdr as attrs
-        if file_type in ("nortek-aqd", "nortek-ascii") and header_file:
+        if file_type in ("nortek-raw", "nortek-ascii") and header_file:
             pcal = _parse_nortek_pressure_cal(Path(header_file))
             for k, v in pcal.items():
                 dataset.attrs[f"nortek_pressure_cal_{k}"] = v
@@ -1634,7 +1634,7 @@ class MooringProcessor:
         # then apply it to produce velocity_x/y/z (keeping beam vars for verification).
         # Old-format .hdr files use a "Transformation matrix" text block;
         # new-format .hdr and String Data.csv use GETXFAVG/GETXFBURST fields.
-        if file_type in ("nortek-aqd", "nortek-ascii", "nortek-csv") and header_file:
+        if file_type in ("nortek-raw", "nortek-ascii", "nortek-csv") and header_file:
             T_mat = _parse_nortek_T_matrix_hdr(Path(header_file))
             if T_mat is None:
                 T_mat = _parse_nortek_T_matrix_csv(Path(header_file))
@@ -1888,7 +1888,10 @@ class MooringProcessor:
         self._log_print(
             f"Completed processing: {success_count}/{total_count} instruments successful"
         )
-        return success_count > 0
+        if total_count == 0:
+            self._log_print("No instruments matched — nothing processed.")
+            return False
+        return success_count == total_count
 
 
 def stage1_mooring(

--- a/oceanarray/instrument/stage2.py
+++ b/oceanarray/instrument/stage2.py
@@ -1094,7 +1094,10 @@ class Stage2Processor:
         self._log_print(
             f"Stage 2 completed: {success_count}/{total_count} instruments successful"
         )
-        return success_count > 0
+        if total_count == 0:
+            self._log_print("No instruments matched — nothing processed.")
+            return False
+        return success_count == total_count
 
 
 def stage2_mooring(

--- a/oceanarray/instrument/stage2.py
+++ b/oceanarray/instrument/stage2.py
@@ -1097,7 +1097,9 @@ class Stage2Processor:
         if total_count == 0:
             self._log_print("No instruments matched — nothing processed.")
             return False
-        return success_count == total_count
+        # Partial success is still success: instruments that processed are written
+        # and the record summary reports which succeeded and which failed.
+        return success_count > 0
 
 
 def stage2_mooring(

--- a/oceanarray/instrument/stage3.py
+++ b/oceanarray/instrument/stage3.py
@@ -373,7 +373,9 @@ class Stage3Processor:
         if not instruments:
             self._log("No instruments matched — nothing processed.")
             return False
-        return success_count == len(instruments)
+        # Partial success is still success: instruments that processed are written
+        # and the record summary reports which succeeded and which failed.
+        return success_count > 0
 
     # ------------------------------------------------------------------
     def _process_instrument(

--- a/oceanarray/instrument/stage3.py
+++ b/oceanarray/instrument/stage3.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 
 import datetime
 import hashlib
-import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -51,6 +50,7 @@ import numpy as np
 import xarray as xr
 import yaml
 
+from oceanarray.paths import safe_serial
 from oceanarray.utilities import (
     cast_output_dtypes,
     drop_all_zero_vars,
@@ -83,7 +83,8 @@ from oceanarray.instrument.coordinate import (
 
 
 def _safe_serial(serial: Any) -> str:
-    return re.sub(r"[^\w\-]", "", str(serial))
+    """Return a filename-safe serial token (see :func:`oceanarray.paths.safe_serial`)."""
+    return safe_serial(serial)
 
 
 class Stage3Processor:
@@ -369,6 +370,9 @@ class Stage3Processor:
         self._log(
             f"Stage 3 complete: {success_count}/{len(instruments)} instruments written"
         )
+        if not instruments:
+            self._log("No instruments matched — nothing processed.")
+            return False
         return success_count == len(instruments)
 
     # ------------------------------------------------------------------

--- a/oceanarray/mooring/grid.py
+++ b/oceanarray/mooring/grid.py
@@ -154,6 +154,22 @@ class MooringGridder:
             and v not in _GRID_EXCLUDE
         ]
 
+        # Tell the operator which present physics variables were excluded from the
+        # grid rather than dropping them silently (D2).
+        _excluded = sorted(
+            v
+            for v in ds.data_vars
+            if ds[v].dims == ("time", "N_LEVELS")
+            and not v.endswith("_qc")
+            and v != "pressure"
+            and v in _GRID_EXCLUDE
+        )
+        if _excluded:
+            print(
+                f"  NOTE: {len(_excluded)} variable(s) excluded from gridding "
+                f"(listed in _GRID_EXCLUDE): {', '.join(_excluded)}"
+            )
+
         stacked: Dict[str, np.ndarray] = {
             v: np.full((n_p, n_time), np.nan) for v in grid_vars
         }

--- a/oceanarray/mooring/grid.py
+++ b/oceanarray/mooring/grid.py
@@ -145,25 +145,21 @@ class MooringGridder:
                 "roll",
             }
         )
-        grid_vars = [
+        # Variables eligible for gridding: physics vars on the (time, N_LEVELS)
+        # grid, excluding pressure and QC flags.  Compute once, then split into
+        # kept vs excluded so the two lists cannot drift (D2).
+        _grid_candidates = [
             v
             for v in ds.data_vars
             if v != "pressure"
             and ds[v].dims == ("time", "N_LEVELS")
             and not v.endswith("_qc")
-            and v not in _GRID_EXCLUDE
         ]
+        grid_vars = [v for v in _grid_candidates if v not in _GRID_EXCLUDE]
 
         # Tell the operator which present physics variables were excluded from the
         # grid rather than dropping them silently (D2).
-        _excluded = sorted(
-            v
-            for v in ds.data_vars
-            if ds[v].dims == ("time", "N_LEVELS")
-            and not v.endswith("_qc")
-            and v != "pressure"
-            and v in _GRID_EXCLUDE
-        )
+        _excluded = sorted(v for v in _grid_candidates if v in _GRID_EXCLUDE)
         if _excluded:
             print(
                 f"  NOTE: {len(_excluded)} variable(s) excluded from gridding "

--- a/oceanarray/mooring/helpers.py
+++ b/oceanarray/mooring/helpers.py
@@ -2,10 +2,10 @@
 
 from pathlib import Path
 from typing import Any, Dict, Optional
-import re
 import numpy as np
 import xarray as xr
 from oceanarray import parameters as P
+from oceanarray.paths import safe_serial
 
 STACK_VARS = [
     "temperature",
@@ -74,14 +74,8 @@ _STACK_RAW: frozenset = frozenset(
 
 
 def _safe_serial(serial: Any) -> str:
-    """Sanitise a serial number string for use in filenames.
-
-    If the raw YAML value contains a comma (e.g. ``16430, R01-024``), only
-    the first comma-separated token is used — the remainder is a beacon ID
-    or annotation and is not part of the filename.
-    """
-    s = str(serial).split(",")[0]
-    return re.sub(r"[^\w\-]", "", s)
+    """Return a filename-safe serial token (see :func:`oceanarray.paths.safe_serial`)."""
+    return safe_serial(serial)
 
 
 def _apply_qc_mask(src_v: np.ndarray, ds: "xr.Dataset", vname: str) -> np.ndarray:

--- a/oceanarray/mooring/stack.py
+++ b/oceanarray/mooring/stack.py
@@ -321,6 +321,9 @@ class MooringStacker:
         # Per-instrument scalar metadata: {varname: [value_for_instr0, value_for_instr1, ...]}
         scalar_meta: Dict[str, list] = {}  # populated during loop
         scalar_attrs: Dict[str, dict] = {}
+        # Stage-3 time-series variables not in STACK_VARS are dropped here; collect
+        # them so the operator is told rather than losing data silently (D2).
+        dropped_ts_vars: set = set()
 
         for i, info in enumerate(instruments):
             serials.append(info["serial"])
@@ -369,6 +372,13 @@ class MooringStacker:
                 if not var_attrs[vname] and vname in ds.data_vars:
                     var_attrs[vname] = dict(ds[vname].attrs)
 
+            # Track any time-series stage-3 variables that STACK_VARS omits.
+            dropped_ts_vars.update(
+                v
+                for v, da in ds.data_vars.items()
+                if "time" in da.dims and v not in STACK_VARS
+            )
+
             # Collect scalar (0-D) metadata variables — keep all instruments consistent
             for vname, da in ds.data_vars.items():
                 if da.dims:  # skip time-series variables
@@ -397,6 +407,14 @@ class MooringStacker:
             for vname in scalar_meta:
                 if len(scalar_meta[vname]) < i + 1:
                     scalar_meta[vname].append(None)
+
+        if dropped_ts_vars:
+            print(
+                f"  NOTE: {len(dropped_ts_vars)} stage-3 time-series variable(s) not in "
+                f"STACK_VARS were dropped from the stack: "
+                f"{', '.join(sorted(dropped_ts_vars))}. "
+                f"Add them to STACK_VARS in mooring/helpers.py to retain them."
+            )
 
         # Release cached ADCP parent datasets
         for _ds_adcp in _adcp_parent_datasets.values():

--- a/oceanarray/paths.py
+++ b/oceanarray/paths.py
@@ -1,0 +1,34 @@
+"""Filesystem path and filename conventions for the oceanarray pipeline.
+
+Single source of truth for turning instrument serial numbers into
+filename-safe tokens.  As the pipeline's path handling is consolidated
+(removing ``basedir``), folder resolution and the output filename pattern
+are intended to move here too.
+"""
+
+import re
+from typing import Any
+
+
+def safe_serial(serial: Any) -> str:
+    """Return a filename-safe token for an instrument serial number.
+
+    If the raw value contains a comma (e.g. ``"16430, R01-024"``), only the
+    first comma-separated token is the primary serial used in filenames and
+    output; the remainder is a beacon id or annotation and is dropped.  Any
+    remaining characters that are illegal in filenames (e.g. ``*`` used as a
+    YAML marker) are stripped.
+
+    Parameters
+    ----------
+    serial : Any
+        Raw serial value from the mooring YAML (``str``, ``int``, or other).
+
+    Returns
+    -------
+    str
+        Sanitised serial token containing only word characters and hyphens.
+
+    """
+    primary = str(serial).split(",")[0]
+    return re.sub(r"[^\w\-]", "", primary)

--- a/oceanarray/report/_html_helpers.py
+++ b/oceanarray/report/_html_helpers.py
@@ -15,7 +15,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
-from ..utilities import _nice_colorbar_bounds, _status  # noqa: F401  (re-exported)
+from ..paths import safe_serial
+from ..utilities import (  # noqa: F401  (re-exported)
+    _nice_colorbar_bounds,
+    _status,
+    should_skip_regeneration,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -24,7 +29,8 @@ from ..utilities import _nice_colorbar_bounds, _status  # noqa: F401  (re-export
 
 
 def _safe_serial(serial: Any) -> str:
-    return re.sub(r"[^\w\-]", "", str(serial))
+    """Return a filename-safe serial token (see :func:`oceanarray.paths.safe_serial`)."""
+    return safe_serial(serial)
 
 
 def _get_proc_dir(base_dir: Path, mooring_name: str) -> Path:
@@ -137,7 +143,7 @@ def _check_readable(file_path: Path, file_type: str) -> Tuple[bool, str]:
                 return True, "ok"
             return False, "no SeaBird header markers"
 
-        elif file_type in ("nortek-ascii", "nortek-aqd"):
+        elif file_type in ("nortek-ascii", "nortek-raw"):
             hdr = file_path.with_suffix(".hdr")
             if not hdr.exists():
                 candidates = list(file_path.parent.glob(file_path.stem + "*.hdr"))
@@ -209,21 +215,8 @@ def _should_skip(
     skip_existing: bool,
     *sources: Path,
 ) -> bool:
-    """Decide whether to skip regenerating *output*.
-
-    Three-mode logic (matching ctd_report CLI design):
-    - force=True          → never skip
-    - skip_existing=True  → skip if output exists (old behaviour)
-    - default             → skip only if output is newer than all *sources*
-    """
-    if force:
-        return False
-    if not output.exists():
-        return False
-    if skip_existing:
-        return True
-    out_mtime = output.stat().st_mtime
-    return not any(s.exists() and s.stat().st_mtime > out_mtime for s in sources)
+    """Decide whether to skip regenerating *output* (see :func:`should_skip_regeneration`)."""
+    return should_skip_regeneration(output, force, skip_existing, *sources)
 
 
 def _fig_to_base64(fig: Any) -> str:

--- a/oceanarray/utilities.py
+++ b/oceanarray/utilities.py
@@ -3,12 +3,58 @@
 import math
 from datetime import datetime
 from functools import wraps
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 import xarray as xr
 
 from oceanarray import logger
+
+
+def should_skip_regeneration(
+    output: Path,
+    force: bool,
+    skip_existing: bool,
+    *sources: Path,
+) -> bool:
+    """Decide whether regenerating *output* can be skipped.
+
+    Three-mode logic (matching the report layer / ctd_report CLI design):
+
+    - ``force=True``         → never skip (always regenerate).
+    - ``skip_existing=True`` → skip whenever *output* exists, regardless of
+      source modification times (the fast, mtime-agnostic behaviour).
+    - default                → skip only if *output* exists and is newer than
+      every path in *sources* (mtime-based staleness).  A source newer than
+      *output* — for example an edited mooring YAML — forces regeneration.
+
+    Parameters
+    ----------
+    output : Path
+        The file that would be (re)generated.
+    force : bool
+        If True, never skip.
+    skip_existing : bool
+        If True, skip whenever *output* exists regardless of source mtimes.
+    *sources : Path
+        Input files *output* is derived from (raw data, previous-stage NetCDF,
+        the mooring YAML).  Non-existent sources are ignored.
+
+    Returns
+    -------
+    bool
+        True if regeneration can be skipped; False if *output* must be rebuilt.
+
+    """
+    if force:
+        return False
+    if not output.exists():
+        return False
+    if skip_existing:
+        return True
+    out_mtime = output.stat().st_mtime
+    return not any(s.exists() and s.stat().st_mtime > out_mtime for s in sources)
 
 
 def extract_inline_instruments(

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,50 @@
+"""Tests for oceanarray.paths — filename/path conventions.
+
+Regression coverage for the serial-cleaning divergence: before consolidation,
+``_safe_serial`` existed in four modules and two of them did not split on the
+comma, so a serial like ``"16430, R01-024"`` produced ``"16430R01-024"`` in
+stage1/stage3/report filenames but ``"16430"`` via the stack path — the same
+instrument landing under two different filenames.
+"""
+
+import pytest
+
+from oceanarray.paths import safe_serial
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("16430, R01-024", "16430"),  # comma → primary token only
+        ("16430", "16430"),  # already clean, unchanged
+        (12345, "12345"),  # int accepted
+        ("ABC*123", "ABC123"),  # illegal filename char stripped
+        ("4021, beacon", "4021"),  # comma + annotation dropped
+        ("SN-77", "SN-77"),  # hyphen preserved
+    ],
+)
+def test_safe_serial(raw, expected):
+    """safe_serial takes the primary comma-token and strips illegal characters."""
+    assert safe_serial(raw) == expected
+
+
+def test_all_call_sites_agree():
+    """Every ``_safe_serial`` copy in the pipeline must delegate to the same rule.
+
+    Locks in the consolidation: a comma-bearing serial must resolve identically
+    across stage1, stage3, the report layer, and the mooring helpers.
+    """
+    from oceanarray.instrument.stage1 import MooringProcessor
+    from oceanarray.instrument.stage3 import _safe_serial as s3
+    from oceanarray.mooring.helpers import _safe_serial as h
+    from oceanarray.report._html_helpers import _safe_serial as r
+
+    raw = "16430, R01-024"
+    results = {
+        safe_serial(raw),
+        MooringProcessor._safe_serial(raw),
+        s3(raw),
+        h(raw),
+        r(raw),
+    }
+    assert results == {"16430"}

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -32,19 +32,28 @@ def test_all_call_sites_agree():
     """Every ``_safe_serial`` copy in the pipeline must delegate to the same rule.
 
     Locks in the consolidation: a comma-bearing serial must resolve identically
-    across stage1, stage3, the report layer, and the mooring helpers.
+    across stage3, the report layer, and the mooring helpers.  (stage1 is covered
+    separately because importing it requires the optional ``seasenselib`` package.)
     """
-    from oceanarray.instrument.stage1 import MooringProcessor
     from oceanarray.instrument.stage3 import _safe_serial as s3
     from oceanarray.mooring.helpers import _safe_serial as h
     from oceanarray.report._html_helpers import _safe_serial as r
 
     raw = "16430, R01-024"
-    results = {
-        safe_serial(raw),
-        MooringProcessor._safe_serial(raw),
-        s3(raw),
-        h(raw),
-        r(raw),
-    }
+    results = {safe_serial(raw), s3(raw), h(raw), r(raw)}
     assert results == {"16430"}
+
+
+@pytest.mark.needs_seasenselib
+def test_stage1_call_site_agrees():
+    """stage1's ``_safe_serial`` static method delegates to the same rule.
+
+    Separated from :func:`test_all_call_sites_agree` because importing stage1
+    pulls in the optional ``seasenselib`` dependency.
+    """
+    pytest.importorskip("seasenselib")
+    from oceanarray.instrument.stage1 import MooringProcessor
+
+    assert MooringProcessor._safe_serial("16430, R01-024") == safe_serial(
+        "16430, R01-024"
+    )

--- a/tests/unit/test_stage1.py
+++ b/tests/unit/test_stage1.py
@@ -86,7 +86,7 @@ class TestMooringProcessor:
         expected_types = [
             "sbe-cnv",
             "sbe-ascii",
-            "nortek-aqd",
+            "nortek-raw",
             "rbr-rsk",
             "rbr-dat",
         ]

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -283,3 +283,57 @@ def test_nice_colorbar_bounds_salinity_range():
     assert len(bounds) == 21
     assert bounds[0] < 34.78 or np.isclose(bounds[0], 34.78, atol=0.1)
     assert bounds[-1] > 35.14 or np.isclose(bounds[-1], 35.14, atol=0.1)
+
+
+def _touch(path, mtime):
+    """Create *path* and set its modification time to *mtime* (epoch seconds)."""
+    path.write_text("x")
+    import os
+
+    os.utime(path, (mtime, mtime))
+
+
+def test_should_skip_regeneration_force(tmp_path):
+    """force=True never skips, even when the output is up to date."""
+    out = tmp_path / "out.nc"
+    src = tmp_path / "src.raw"
+    _touch(src, 100)
+    _touch(out, 200)
+    assert utilities.should_skip_regeneration(out, True, False, src) is False
+
+
+def test_should_skip_regeneration_missing_output(tmp_path):
+    """A non-existent output is never skipped."""
+    out = tmp_path / "out.nc"
+    src = tmp_path / "src.raw"
+    _touch(src, 100)
+    assert utilities.should_skip_regeneration(out, False, False, src) is False
+
+
+def test_should_skip_regeneration_skip_existing(tmp_path):
+    """skip_existing=True skips a present output regardless of source mtimes."""
+    out = tmp_path / "out.nc"
+    src = tmp_path / "src.raw"
+    _touch(out, 100)
+    _touch(src, 999)  # newer source, but skip_existing ignores mtimes
+    assert utilities.should_skip_regeneration(out, False, True, src) is True
+
+
+def test_should_skip_regeneration_stale_source(tmp_path):
+    """A source newer than the output forces regeneration (no skip)."""
+    out = tmp_path / "out.nc"
+    yaml = tmp_path / "m.mooring.yaml"
+    _touch(out, 100)
+    _touch(yaml, 200)  # e.g. edited YAML after the output was built
+    assert utilities.should_skip_regeneration(out, False, False, yaml) is False
+
+
+def test_should_skip_regeneration_up_to_date(tmp_path):
+    """An output newer than all sources is skipped."""
+    out = tmp_path / "out.nc"
+    src = tmp_path / "src.raw"
+    yaml = tmp_path / "m.mooring.yaml"
+    _touch(src, 100)
+    _touch(yaml, 100)
+    _touch(out, 200)
+    assert utilities.should_skip_regeneration(out, False, False, src, yaml) is True

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -119,7 +119,7 @@ def test_validate_nortek_alias_is_error(tmp_path):
             "instrument": "nortek",
             "serial": 1234,
             "filename": "f.dat",
-            "file_type": "nortek-aqd",
+            "file_type": "nortek-raw",
         }
     ]
     path = _write_yaml(tmp_path, data)


### PR DESCRIPTION

## Summary

Tightens the internal "contracts" between config, validation, and the processing stages: single-sources the instrument-type and file-type vocabularies, consolidates duplicated serial-parsing into one rule, and adds a shared re-run staleness helper. Also corrects the `nortek-aqd` file-type key (never a valid seasenselib reader) and collapses the split `adcp-matlab` readers back to the single auto-detecting key.

## Changes

### File-type vocabulary — single source of truth  *(config/parameters.py, validation.py, instrument/stage1.py)*

- **New `parameters.ALL_FILE_TYPES`** — the single source of valid `file_type:` values, derived as `union(INSTRUMENT_FILE_TYPES readers) | EXTRA_FILE_TYPES`. `validation.VALID_FILE_TYPES` and `stage1.SUPPORTED_FILE_TYPES` now both derive from it instead of three hand-edited lists that had drifted.
  - Fixes: `rbr-hex` (tr1050's reader) was missing from `VALID_FILE_TYPES`, so valid tr1050 YAMLs failed validation.
  - Fixes: `adcp-matlab` was missing from stage1's `SUPPORTED_FILE_TYPES`, so it raised "unsupported" before reaching its own dispatch.
- **`nortek-aqd` → `nortek-raw`** everywhere (code, tests, docs). `nortek-aqd` was never a seasenselib reader key; the binary `.aqd` workflow is `nortek-raw`.
- **`adcp-matlab-rdadcp` / `adcp-matlab-uhhds` → `adcp-matlab`**. seasenselib auto-detects the RD-ADCP vs UHHDS variant; all non-bypass types route to `seasenselib.read(file_format=...)`, so no per-variant dispatch is needed.
- **Removed `sbe-asc`** from the vocabulary — its oceanarray bypass reader no longer exists, so it had no dispatch branch and would have failed at `seasenselib.read`.

### Instrument-type vocabulary — single source  *(parameters.py, validation.py)*

- Added `sbe56` / `sbe16` to `INSTRUMENT_FILE_TYPES` (they were accepted by `validate` but not shown by `list`).
- Deleted `validation.VALID_INSTRUMENTS`; the validator now reads `parameters.KNOWN_INSTRUMENT_TYPES`. `list` and `validate` now agree.
- **`adcp` and `ADCP` both accepted.** The validator no longer errors on lowercase `adcp` (the pipeline lowercases and dispatches on it internally); either casing validates.

### Serial parsing — consolidated  *(new oceanarray/paths.py + call sites)*

- New public `paths.safe_serial` — comma-split (primary token only) + strip illegal filename chars.
- Replaced four duplicated `_safe_serial` copies (stage1, stage3, `_html_helpers`, mooring/helpers) with the shared function. Two of the old copies did **not** comma-split, so a serial like `16430, R01-024` produced `16430R01-024` in some filenames and `16430` in others — the same instrument under two names. Now uniform.
- Routed stage1's other serial derivations (cal-section matching, `SENSOR_*` variable suffixes, raw-file auto-discovery, and the `--serials` filter) through `safe_serial` too, so every serial-derived token in stage1 agrees with the output filename.
- New `tests/unit/test_paths.py` locking cross-site agreement (the stage1 case is a separate `needs_seasenselib`-gated test so the suite still runs without seasenselib).
- Stub template (`cli.py`) gained a serial-cleaning note.

### Re-run staleness helper  *(utilities.py, stage1.py, report/_html_helpers.py)*

- New `utilities.should_skip_regeneration` (3-mode: force / skip_existing / mtime).
- stage1 skip now compares output mtime against its **raw input** only. The mooring YAML is deliberately *not* a staleness source — comment/spacing edits should not trigger reprocessing.
- Deduped `report/_html_helpers._should_skip` onto the shared helper.
- Helper tests added (`test_utilities.py`).
- **Deferred:** stage3/stack/grid skip wiring (they still skip on `output.exists()`).

### Variable-drop logging  *(mooring/stack.py, grid.py)*

- `stack.py` and `grid.py` emit a NOTE listing stage-3 variables excluded from the stacked/gridded output instead of dropping them silently.
- `grid.py` computes the eligible-variable set once and splits it into kept vs excluded in a single pass, so the gridded list and the "excluded" NOTE cannot drift.

### Success reporting  *(stage1/2/3)*

- Stages report a `succeeded/total` instrument count and print an explicit "No instruments matched — nothing processed" message (returning `False`) when no instruments match.
- **Partial success counts as success** (`success_count > 0`) across all three stages. An earlier iteration briefly required *all* instruments to succeed (`== total_count`); that was reverted after review — a missing/corrupt raw file for one instrument should not fail the whole mooring run or flip the CLI exit code. The record summary already reports which instruments succeeded and which failed.