### PR TITLE
[MAJOR] remove `basedir`, finish `paths.py`

### DIFF
--- a/MIGRATION-BASEDIR.md
+++ b/MIGRATION-BASEDIR.md
@@ -1,9 +1,9 @@
 # Migrating from --basedir to --raw-dir / --proc-dir
 
-The `--basedir` flag is deprecated.  All subcommands now accept
-`--raw-dir` and `--proc-dir` instead.  `--basedir` still works and
-will continue to work indefinitely, but it prints a `DeprecationWarning`
-on every invocation.
+The `--basedir` flag has been **removed**.  All subcommands now require
+`--raw-dir` and `--proc-dir` instead.  Passing `--basedir` prints a migration
+message naming the replacement and exits without processing.  This document
+explains how to convert an old `--basedir` layout to the current one.
 
 ---
 

--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -673,15 +673,11 @@ be installed for GIF output.
 Deprecated flags
 ----------------
 
-``--basedir DIR``
-~~~~~~~~~~~~~~~~~
+``--basedir DIR`` (removed)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``--basedir`` flag is accepted by ``process``, ``stack``, ``grid``,
-``report``, and ``run`` for backward compatibility.  It expects raw files
-at ``{basedir}/raw/{instrument}/{mooring}/`` (instrument-first layout)
-and the YAML at ``{basedir}/proc/{mooring}/``.
-
-Using ``--basedir`` emits a deprecation warning.  New deployments should
-use ``--raw-dir`` and ``--proc-dir`` with the mooring-first layout instead.
+The ``--basedir`` flag has been **removed**.  Passing it prints a migration
+message naming the replacement and exits without processing.  Use
+``--raw-dir`` and ``--proc-dir`` with the mooring-first layout instead.
 
 See :doc:`migration` for step-by-step migration instructions.

--- a/docs/source/legacy.rst
+++ b/docs/source/legacy.rst
@@ -52,9 +52,9 @@ For all current processing use:
 
 .. code-block:: bash
 
-   oceanarray process <mooring> --basedir /path/to/data   # Stages 1–3
-   oceanarray stack   <mooring> --basedir /path/to/data
-   oceanarray grid    <mooring> --basedir /path/to/data
-   oceanarray report  <mooring> --basedir /path/to/data --instruments --stack --grid
+   oceanarray process <mooring> --raw-dir /path/to/data/raw --proc-dir /path/to/data/proc   # Stages 1–3
+   oceanarray stack   <mooring> --proc-dir /path/to/data/proc
+   oceanarray grid    <mooring> --proc-dir /path/to/data/proc
+   oceanarray report  <mooring> --proc-dir /path/to/data/proc --instruments --stack --grid
 
 See :doc:`processing_framework` for the full pipeline description.

--- a/docs/source/methods/time_gridding.rst
+++ b/docs/source/methods/time_gridding.rst
@@ -17,9 +17,9 @@ Python API
 
 .. code-block:: python
 
-   from oceanarray.mooring_level import MooringStacker
+   from oceanarray.mooring.stack import MooringStacker
 
-   MooringStacker(base_dir).stack(mooring_name, dt_seconds=60, force=False)
+   MooringStacker(proc_dir=proc_dir).stack(mooring_name, dt_seconds=60, force=False)
 
 Purpose
 -------

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -133,17 +133,13 @@ and you want to migrate to::
 
 ----
 
-``--basedir`` still works
---------------------------
+``--basedir`` has been removed
+------------------------------
 
-The ``--basedir`` flag is still accepted and produces a deprecation warning
-rather than an error.  There is no urgent need to migrate all existing
-scripts immediately.  The flag may be removed in a future major version.
-
-When using ``--basedir``, raw files are expected in the instrument-first
-layout (``{basedir}/raw/{instrument}/{mooring}/``), so existing data
-directories do not need to be reorganised if you continue to use
-``--basedir`` for now.
+The ``--basedir`` flag no longer runs.  Passing it prints a migration message
+naming the replacement and exits without processing, so existing scripts that
+use it must be updated to ``--raw-dir`` + ``--proc-dir`` and the raw data moved
+to the mooring-first layout (see the mapping above).
 
 ----
 

--- a/oceanarray/cli.py
+++ b/oceanarray/cli.py
@@ -3,72 +3,70 @@
 import argparse
 import sys
 from pathlib import Path
+from . import paths
 from .utilities import _status
 from ._version import __version__
 
 
-def _resolve_basedir(basedir: str) -> str:
-    """Strip trailing 'moor' component if user passed data/moor/ instead of data/."""
-    p = Path(basedir)
-    if p.name == "moor":
-        return str(p.parent)
-    return str(p)
-
-
-def _get_proc_root(basedir: str) -> Path:
-    """Return basedir/proc, falling back to basedir/moor/proc for legacy layouts."""
-    base = Path(basedir)
-    proc = base / "proc"
-    if proc.is_dir():
-        return proc
-    legacy = base / "moor" / "proc"
-    return legacy if legacy.is_dir() else proc
-
-
 def _parse_dirs(
     args: "argparse.Namespace",
-) -> "tuple[Path | None, Path, bool]":
+) -> "tuple[Path | None, Path]":
     """Resolve raw and proc directories from CLI args.
 
     Returns
     -------
     raw_dir : Path or None
-        Cruise-level raw directory (``--raw-dir``). None in legacy mode.
+        Cruise-level raw directory (``--raw-dir``). None when a command does not
+        read raw files (stack, grid, report).
     proc_root : Path
         Cruise-level processed output directory.
-    legacy : bool
-        True when ``--basedir`` was used (deprecated path).
+
+    Raises
+    ------
+    SystemExit
+        If ``--basedir`` is supplied (removed; prints a migration message), or if
+        ``--proc-dir`` is not given.
 
     """
-    import warnings
-
     basedir = getattr(args, "basedir", None)
     raw_dir = getattr(args, "raw_dir", None)
     proc_dir = getattr(args, "proc_dir", None)
 
-    if raw_dir or proc_dir:
-        if not proc_dir:
-            raise SystemExit("ERROR: --proc-dir is required when --raw-dir is given.")  # noqa: TRY003
-        return Path(raw_dir) if raw_dir else None, Path(proc_dir), False
-
-    if not basedir:
+    if basedir:
         raise SystemExit(  # noqa: TRY003
-            "ERROR: supply either --raw-dir + --proc-dir (recommended) "
-            "or --basedir (deprecated)."
+            "ERROR: --basedir has been removed. Use --raw-dir + --proc-dir "
+            "(the mooring directory is now <proc-dir>/<mooring>, not "
+            "<basedir>/moor/proc/<mooring>). See MIGRATION-BASEDIR.md at the "
+            "repository root."
         )
-    basedir = _resolve_basedir(basedir)
-    warnings.warn(
-        "--basedir is deprecated; switch to --raw-dir and --proc-dir. "
-        "See MIGRATION-BASEDIR.md at the repository root.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    return None, _get_proc_root(basedir), True
+
+    if not proc_dir:
+        raise SystemExit(  # noqa: TRY003
+            "ERROR: --proc-dir is required (and --raw-dir for stage 1)."
+        )
+    return Path(raw_dir) if raw_dir else None, Path(proc_dir)
 
 
-def _print_report(basedir: "str | None", mooring: str, legacy: bool = True) -> None:
-    """Print a per-instrument summary of stage1/stage2/stage3 NetCDF files for a mooring.
+def _parse_dirs_checked(
+    args: "argparse.Namespace",
+) -> "tuple[Path | None, Path]":
+    """Parse dirs and reject an old-layout ``--proc-dir`` for a mooring command.
 
+    Like :func:`_parse_dirs`, but also runs :func:`paths.require_current_layout`
+    on ``<proc-dir>/<args.mooring>`` so a legacy ``moor/proc`` (or ``proc``)
+    directory raises the migration error up front rather than failing later with
+    "no files found".  Use for every mooring-scoped subcommand; ``report --array``
+    is the exception (its positional is a YAML path, not a mooring name).
+    """
+    raw_dir, proc_root = _parse_dirs(args)
+    paths.require_current_layout(proc_root, args.mooring)
+    return raw_dir, proc_root
+
+
+def _print_report(proc_dir: Path) -> None:
+    """Print a per-instrument summary of stage1/stage2/stage3 NetCDF files.
+
+    *proc_dir* is the mooring-level processed directory (``<proc-dir>/<mooring>``).
     For each instrument, reports: serial number, record count (raw from stage1 vs
     processed from stage2/stage3), time span, nominal depth, sampling interval, and
     which geophysical variables are present (temperature, salinity, velocity, etc.).
@@ -76,11 +74,6 @@ def _print_report(basedir: "str | None", mooring: str, legacy: bool = True) -> N
     import datetime
     import numpy as np
     import xarray as xr
-
-    if legacy and basedir is not None:
-        proc_dir = _get_proc_root(basedir) / mooring
-    else:
-        proc_dir = Path(basedir) if basedir else Path(".")
 
     # Collect all processed files; prefer _stage3 > _use as the "best" file per serial
     use_files = sorted(proc_dir.rglob("*_stage2.nc"))
@@ -174,8 +167,7 @@ def cmd_process(args: argparse.Namespace) -> int:
     from .instrument.stage2 import Stage2Processor
     from .instrument.stage3 import Stage3Processor
 
-    raw_dir, proc_root, legacy = _parse_dirs(args)
-    basedir = _resolve_basedir(args.basedir) if legacy else None
+    raw_dir, proc_root = _parse_dirs_checked(args)
 
     # If --stage was not explicitly set and --report is the only action, skip processing
     stages = args.stage if (args.stage is not None or not args.report) else []
@@ -188,10 +180,9 @@ def cmd_process(args: argparse.Namespace) -> int:
 
     if 1 in stages:
         _status("section", f"Stage 1: {args.mooring}")
-        if legacy:
-            proc = MooringProcessor(basedir)
-        else:
-            proc = MooringProcessor(raw_dir=str(raw_dir), proc_dir=str(proc_root))
+        if raw_dir is None:
+            raise SystemExit("ERROR: --raw-dir is required for stage 1.")  # noqa: TRY003
+        proc = MooringProcessor(raw_dir=str(raw_dir), proc_dir=str(proc_root))
         ok = proc.process_mooring(args.mooring, serials=serials, force=args.force)
         if not ok:
             print("Stage 1 failed.")
@@ -199,10 +190,7 @@ def cmd_process(args: argparse.Namespace) -> int:
 
     if 2 in stages:
         _status("section", f"Stage 2: {args.mooring}")
-        if legacy:
-            s2 = Stage2Processor(basedir)
-        else:
-            s2 = Stage2Processor(proc_dir=str(proc_root))
+        s2 = Stage2Processor(proc_dir=str(proc_root))
         ok = s2.process_mooring(args.mooring, serials=serials, force=args.force)
         if not ok:
             print("Stage 2 failed.")
@@ -215,10 +203,7 @@ def cmd_process(args: argparse.Namespace) -> int:
             + (" — DRY RUN" if dry else "")
             + " ==="
         )
-        if legacy:
-            s3 = Stage3Processor(basedir)
-        else:
-            s3 = Stage3Processor(proc_dir=str(proc_root))
+        s3 = Stage3Processor(proc_dir=str(proc_root))
         ok = s3.process_mooring(
             args.mooring, serials=serials, force=args.force, dry_run=dry
         )
@@ -228,9 +213,7 @@ def cmd_process(args: argparse.Namespace) -> int:
 
     if args.report:
         _status("section", f"Record Summary: {args.mooring}")
-        _print_report(
-            basedir or str(proc_root / args.mooring), args.mooring, legacy=legacy
-        )
+        _print_report(proc_root / args.mooring)
 
     if args.plot:
         import matplotlib
@@ -242,11 +225,7 @@ def cmd_process(args: argparse.Namespace) -> int:
         from .plotters import plot_aquadopp_raw
 
         _status("section", f"Plotting: {args.mooring}")
-        proc_dir = (
-            _get_proc_root(basedir) / args.mooring
-            if legacy
-            else proc_root / args.mooring
-        )
+        proc_dir = proc_root / args.mooring
 
         for nc in sorted((proc_dir / "microcat").glob("*_stage2.nc")):
             ds = xr.open_dataset(nc, decode_timedelta=False)
@@ -276,7 +255,7 @@ def cmd_plot(args: argparse.Namespace) -> int:
     from .plotters import plot_mooring_timeseries
     from .config import parameters as P
 
-    _, proc_root, _ = _parse_dirs(args)
+    _, proc_root = _parse_dirs_checked(args)
 
     if args.colormap:
         P.DEFAULT_COLORMAP = args.colormap
@@ -319,7 +298,11 @@ def cmd_report(args: argparse.Namespace) -> int:
     """
     from pathlib import Path
 
-    _, proc_root, _ = _parse_dirs(args)
+    raw_dir, proc_root = _parse_dirs(args)
+    # Array mode treats the positional as a YAML path, not a mooring name, so the
+    # per-mooring layout check does not apply there.
+    if not getattr(args, "array", False):
+        paths.require_current_layout(proc_root, args.mooring)
 
     sig_level = getattr(args, "sig_level", None)
     if sig_level is not None:
@@ -385,18 +368,13 @@ def cmd_report(args: argparse.Namespace) -> int:
 
     from .report import MooringReport
 
-    raw_dir, proc_root, legacy = _parse_dirs(args)
-    basedir = _resolve_basedir(args.basedir) if legacy else None
     _status("section", f"Report: {args.mooring}")
     serials = getattr(args, "serial", None)
-    if legacy:
-        reporter = MooringReport(basedir, report_dir=report_dir)
-    else:
-        reporter = MooringReport(
-            proc_dir=str(proc_root),
-            raw_dir=str(raw_dir) if raw_dir else None,
-            report_dir=report_dir,
-        )
+    reporter = MooringReport(
+        proc_dir=str(proc_root),
+        raw_dir=str(raw_dir) if raw_dir else None,
+        report_dir=report_dir,
+    )
     all_reports = getattr(args, "all_reports", False)
     result = reporter.generate(
         args.mooring,
@@ -441,13 +419,8 @@ def cmd_stack(args: argparse.Namespace) -> int:
     from .utilities import extract_inline_instruments
     import yaml as _yaml
 
-    _, proc_root, legacy = _parse_dirs(args)
-    basedir = _resolve_basedir(args.basedir) if legacy else None
-    proc_dir = (
-        Path(_get_proc_root(basedir)) / args.mooring
-        if legacy
-        else proc_root / args.mooring
-    )
+    _, proc_root = _parse_dirs_checked(args)
+    proc_dir = proc_root / args.mooring
 
     if getattr(args, "dry_run", False):
         _status("section", f"Stack (dry run): {args.mooring}")
@@ -489,10 +462,7 @@ def cmd_stack(args: argparse.Namespace) -> int:
         return 0
 
     _status("section", f"Stack: {args.mooring}")
-    if legacy:
-        stacker = MooringStacker(basedir)
-    else:
-        stacker = MooringStacker(proc_dir=str(proc_root))
+    stacker = MooringStacker(proc_dir=str(proc_root))
     ok = stacker.stack(
         args.mooring,
         dt_seconds=args.dt,
@@ -513,16 +483,11 @@ def cmd_grid(args: argparse.Namespace) -> int:
     """
     from .mooring.grid import MooringGridder
 
-    _, proc_root, legacy = _parse_dirs(args)
-    basedir = _resolve_basedir(args.basedir) if legacy else None
+    _, proc_root = _parse_dirs_checked(args)
 
     if getattr(args, "dry_run", False):
         _status("section", f"Grid (dry run): {args.mooring}")
-        proc_dir = (
-            Path(_get_proc_root(basedir)) / args.mooring
-            if legacy
-            else proc_root / args.mooring
-        )
+        proc_dir = proc_root / args.mooring
         stack_nc = proc_dir / f"{args.mooring}_stack.nc"
         out_nc = proc_dir / f"{args.mooring}_grid.nc"
         print(f"Input:  {stack_nc}  ({'EXISTS' if stack_nc.exists() else 'MISSING'})")
@@ -537,9 +502,7 @@ def cmd_grid(args: argparse.Namespace) -> int:
         return 0
 
     _status("section", f"Grid: {args.mooring}")
-    gridder = (
-        MooringGridder(basedir) if legacy else MooringGridder(proc_dir=str(proc_root))
-    )
+    gridder = MooringGridder(proc_dir=str(proc_root))
     ok = gridder.grid(
         args.mooring,
         p_start=args.pmin,
@@ -656,11 +619,8 @@ def cmd_animate(args: argparse.Namespace) -> int:
 
     from .plotters import animate_hodograph
 
-    _, proc_root, legacy = _parse_dirs(args)
-    basedir = _resolve_basedir(args.basedir) if legacy else None
-    proc_dir = (
-        _get_proc_root(basedir) / args.mooring if legacy else proc_root / args.mooring
-    )
+    _, proc_root = _parse_dirs_checked(args)
+    proc_dir = proc_root / args.mooring
     serials = args.serial or []
 
     # Build {stem: best_nc} — stage3 preferred over stage2
@@ -901,8 +861,9 @@ def cmd_logsheet(args: "argparse.Namespace") -> int:
 def _add_dir_args(p: "argparse.ArgumentParser", raw_needed: bool = True) -> None:
     """Add directory arguments to a subparser.
 
-    Adds ``--raw-dir`` / ``--proc-dir`` (new layout) and the deprecated
-    ``--basedir`` flag.  When *raw_needed* is False (e.g. for ``stack``,
+    Adds ``--raw-dir`` / ``--proc-dir``, plus a hidden ``--basedir`` flag that
+    only exists to emit a migration message (see :func:`_parse_dirs`).  When
+    *raw_needed* is False (e.g. for ``stack``,
     ``grid``, ``report``, ``animate`` which operate on already-processed NetCDF
     files) ``--raw-dir`` is silently omitted and the argument defaults to None.
     Stage 1 processing requires raw instrument files and therefore sets
@@ -918,12 +879,14 @@ def _add_dir_args(p: "argparse.ArgumentParser", raw_needed: bool = True) -> None
 
     """
     grp = p.add_mutually_exclusive_group()
+    # --basedir is removed: it is accepted (undiscoverable in --help) only so we
+    # can print a migration message instead of an argparse "unrecognized argument"
+    # error.  See _parse_dirs.
     grp.add_argument(
         "--basedir",
         default=None,
         metavar="DIR",
-        help="[DEPRECATED] Root data directory (contains proc/). "
-        "Use --raw-dir + --proc-dir instead.",
+        help=argparse.SUPPRESS,
     )
     if raw_needed:
         p.add_argument(
@@ -1122,7 +1085,7 @@ def build_parser() -> argparse.ArgumentParser:
         "  oceanarray run MOORING --raw-dir /data/raw --proc-dir /data/proc --dp 20 --force\n"
         "\n"
         "Legacy (deprecated):\n"
-        "  oceanarray run MOORING --basedir /data --dp 20 --force\n"
+        "  oceanarray run MOORING --raw-dir /data/raw --proc-dir /data/proc --dp 20 --force\n"
         "  See MIGRATION-BASEDIR.md for migration instructions.\n"
     )
     parser = argparse.ArgumentParser(
@@ -1212,7 +1175,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         dest="outdir",
         metavar="DIR",
-        help="Directory for the HTML report (default: proc/{mooring}/ inside basedir)",
+        help="Directory for the HTML report (default: {proc-dir}/{mooring}/report/)",
     )
     p_report.add_argument(
         "--report-dir",
@@ -1729,4 +1692,8 @@ def main() -> None:
             )
         if _other_unknowns:
             parser.error(f"unrecognized arguments: {' '.join(_other_unknowns)}")
-    sys.exit(args.func(args))
+    try:
+        sys.exit(args.func(args))
+    except paths.LegacyLayoutError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/oceanarray/config/validation.py
+++ b/oceanarray/config/validation.py
@@ -3,8 +3,8 @@
 The ``instrument`` field in each clamp/instruments entry is used as a
 subdirectory name when reading raw files and writing processed output::
 
-    <basedir>/raw/<instrument>/<mooring_name>/<filename>
-    <basedir>/proc/<mooring_name>/<instrument>/<output>.nc
+    <raw-dir>/<mooring_name>/<instrument>/<filename>
+    <proc-dir>/<mooring_name>/<instrument>/<output>.nc
 
 Valid instrument names and their typical file types
 ----------------------------------------------------

--- a/oceanarray/instrument/stage1.py
+++ b/oceanarray/instrument/stage1.py
@@ -19,6 +19,7 @@ from oceanarray.utilities import (
     should_skip_regeneration,
 )
 from oceanarray import parameters as P
+from oceanarray import paths
 from oceanarray.paths import safe_serial
 
 # Suppress noisy INFO/WARNING messages from seasenselib/pycnv.
@@ -212,37 +213,21 @@ class MooringProcessor:
         "sbe-ascii": ["depth", "latitude", "longitude"],
     }
 
-    def __init__(
-        self,
-        base_dir: Optional[str] = None,
-        *,
-        raw_dir: Optional[str] = None,
-        proc_dir: Optional[str] = None,
-    ) -> None:
-        """Initialize processor with base directory (legacy) or raw_dir + proc_dir (new).
+    def __init__(self, *, raw_dir: str, proc_dir: str) -> None:
+        """Initialize the processor with cruise-level raw and proc directories.
 
         Parameters
         ----------
-        base_dir : str, optional
-            Legacy: cruise-level base directory (must contain a ``proc/`` subdirectory).
-        raw_dir : str, optional
-            Cruise-level raw data directory. Pipeline appends ``/{mooring}/`` internally.
-            Required together with ``proc_dir`` when not using ``base_dir``.
-        proc_dir : str, optional
-            Cruise-level processed output directory. Pipeline appends ``/{mooring}/``.
-            Required together with ``raw_dir`` when not using ``base_dir``.
+        raw_dir : str
+            Cruise-level raw data directory. The pipeline appends ``/{mooring}/``
+            internally (see :func:`oceanarray.paths.raw_mooring_dir`).
+        proc_dir : str
+            Cruise-level processed output directory. The pipeline appends
+            ``/{mooring}/`` internally (see :func:`oceanarray.paths.mooring_proc_dir`).
 
         """
-        if base_dir is not None:
-            self.base_dir: Optional[Path] = Path(base_dir)
-            self._raw_dir: Optional[Path] = None
-            self._proc_dir: Optional[Path] = None
-            self._legacy = True
-        else:
-            self.base_dir = None
-            self._raw_dir = Path(raw_dir) if raw_dir else None
-            self._proc_dir = Path(proc_dir) if proc_dir else None
-            self._legacy = False
+        self._raw_dir = Path(raw_dir)
+        self._proc_dir = Path(proc_dir)
         self.log_file = None
 
     def _setup_logging(self, mooring_name: str, output_path: Path) -> None:
@@ -273,8 +258,8 @@ class MooringProcessor:
                 print(*args, **kwargs, file=f)
 
     def _rel(self, path: Path) -> str:
-        """Return a short display path relative to base_dir, proc_dir, or raw_dir."""
-        roots = [r for r in (self.base_dir, self._proc_dir, self._raw_dir) if r]
+        """Return a short display path relative to proc_dir or raw_dir."""
+        roots = [r for r in (self._proc_dir, self._raw_dir) if r]
         for root in roots:
             try:
                 return str(path.relative_to(root))
@@ -1206,14 +1191,15 @@ class MooringProcessor:
         """Generate output filename for processed data."""
         file_type = instrument_config.get("file_type", "")
         filename = instrument_config.get("filename", "")
-        serial = self._safe_serial(instrument_config.get("serial", 0))
 
         # Handle special tag for ADCP matlab files
         tag = ""
         if file_type == "adcp-matlab":
             tag = self._find_file_tag(filename)
 
-        output_filename = f"{mooring_name}_{serial}{tag}_stage1.nc"
+        output_filename = paths.stage_output_name(
+            mooring_name, instrument_config.get("serial", 0), 1, tag
+        )
         return output_dir / output_filename
 
     def _get_netcdf_writer_params(self) -> Dict[str, Any]:
@@ -1512,7 +1498,8 @@ class MooringProcessor:
                     )
                     input_file = _nortek_alt
         else:
-            # Legacy layout: {base_dir}/raw/{instrument}/{mooring}/filename
+            # YAML 'directory:' absolute-path override:
+            # {directory}/{instrument}/{mooring}/filename
             input_file = input_dir / dir_name / mooring_name / filename
 
         # Create output directory
@@ -1781,18 +1768,11 @@ class MooringProcessor:
             bool: True if processing completed successfully, False otherwise
 
         """
-        # Set up paths — legacy (base_dir) or new (raw_dir + proc_dir)
-        if self._legacy:
-            if output_path is None:
-                proc = self.base_dir / "proc"
-                if not proc.is_dir():
-                    legacy_proc = self.base_dir / "moor" / "proc"
-                    proc = legacy_proc if legacy_proc.is_dir() else proc
-                output_path = proc / mooring_name
-            else:
-                output_path = Path(output_path) / mooring_name
+        # Output directory: {proc_dir}/{mooring}/
+        if output_path is None:
+            output_path = paths.mooring_proc_dir(self._proc_dir, mooring_name)
         else:
-            output_path = self._proc_dir / mooring_name
+            output_path = Path(output_path) / mooring_name
 
         output_path.mkdir(parents=True, exist_ok=True)
 
@@ -1812,25 +1792,19 @@ class MooringProcessor:
             self._log_print(f"ERROR: Failed to load configuration: {e}")
             return False
 
-        # Set up input directory
-        if self._legacy:
-            # Old layout: {base_dir}/{directory}/{instrument}/{mooring}/filename
-            input_dir = self.base_dir / yaml_data.get("directory", "raw")
+        # Set up input directory — {raw_dir}/{mooring}/{instrument}/filename.
+        # A YAML 'directory:' entry acts as an absolute-path override.
+        yaml_dir_override = yaml_data.get("directory")
+        if yaml_dir_override and Path(yaml_dir_override).is_absolute():
+            input_dir = Path(yaml_dir_override)
+            self._log_print(
+                f"WARNING: using 'directory: {yaml_dir_override}' from YAML "
+                f"as raw root override (ignoring --raw-dir)"
+            )
             raw_mooring_dir = None
         else:
-            # New layout: {raw_dir}/{mooring}/{instrument}/filename
-            # directory: in YAML acts as absolute-path override
-            yaml_dir_override = yaml_data.get("directory")
-            if yaml_dir_override and Path(yaml_dir_override).is_absolute():
-                input_dir = Path(yaml_dir_override)
-                self._log_print(
-                    f"WARNING: using 'directory: {yaml_dir_override}' from YAML "
-                    f"as raw root override (ignoring --raw-dir)"
-                )
-                raw_mooring_dir = None
-            else:
-                input_dir = None
-                raw_mooring_dir = self._raw_dir / mooring_name
+            input_dir = None
+            raw_mooring_dir = paths.raw_mooring_dir(self._raw_dir, mooring_name)
 
         if input_dir is not None and not input_dir.exists():
             self._log_print(f"ERROR: Input directory not found: {input_dir}")
@@ -1889,71 +1863,3 @@ class MooringProcessor:
         # Partial success is still success: instruments that processed are written
         # and the record summary reports which succeeded and which failed.
         return success_count > 0
-
-
-def stage1_mooring(
-    mooring_name: str, basedir: str, output_path: Optional[str] = None
-) -> bool:
-    """Process a single mooring's data (backwards compatibility function).
-
-    Args:
-        mooring_name: Name of the mooring to process
-        basedir: Base directory containing the data
-        output_path: Optional output path override
-
-    Returns:
-        bool: True if processing completed successfully
-
-    """
-    processor = MooringProcessor(basedir)
-    return processor.process_mooring(mooring_name, output_path)
-
-
-def process_multiple_moorings(mooring_list: List[str], basedir: str) -> Dict[str, bool]:
-    """Process multiple moorings.
-
-    Args:
-        mooring_list: List of mooring names to process
-        basedir: Base directory containing the data
-
-    Returns:
-        Dict mapping mooring names to success status
-
-    """
-    processor = MooringProcessor(basedir)
-    results = {}
-
-    for mooring_name in mooring_list:
-        print(f"\n{'=' * 50}")
-        print(f"Processing mooring {mooring_name}")
-        print(f"{'=' * 50}")
-
-        results[mooring_name] = processor.process_mooring(mooring_name)
-
-    return results
-
-
-# Example usage
-if __name__ == "__main__":
-    # Your mooring list
-    moorlist = [
-        "dsA_1_2018",
-        "dsB_1_2018",
-        "dsC_1_2018",
-        "dsD_1_2018",
-        "dsE_1_2018",
-        "dsF_1_2018",
-    ]
-
-    basedir = "/Users/eddifying/Dropbox/data/ifmro_mixsed/ds_data_eleanor/"
-
-    # Process all moorings
-    results = process_multiple_moorings(moorlist, basedir)
-
-    # Print summary
-    print(f"\n{'=' * 50}")
-    print("PROCESSING SUMMARY")
-    print(f"{'=' * 50}")
-    for mooring, success in results.items():
-        status = "SUCCESS" if success else "FAILED"
-        print(f"{mooring}: {status}")

--- a/oceanarray/instrument/stage2.py
+++ b/oceanarray/instrument/stage2.py
@@ -47,6 +47,7 @@ import xarray as xr
 import yaml
 from seasenselib.writers import NetCdfWriter
 
+from oceanarray import paths
 from oceanarray.utilities import (
     _status,
     cast_output_dtypes,
@@ -279,12 +280,7 @@ def _find_nonnull_bounds(
 class Stage2Processor:
     """Handles Stage 2 processing: clock correction and temporal trimming."""
 
-    def __init__(
-        self,
-        base_dir: Optional[str] = None,
-        *,
-        proc_dir: Optional[str] = None,
-    ) -> None:
+    def __init__(self, *, proc_dir: str) -> None:
         """Apply clock-drift correction and trim records to the deployment window.
 
         Reads stage1 CF-NetCDF files, corrects instrument clock offsets using a
@@ -294,29 +290,21 @@ class Stage2Processor:
 
         Parameters
         ----------
-        base_dir : str, optional
-            Legacy: cruise-level base directory containing a ``proc/`` subdirectory.
-        proc_dir : str, optional
-            Cruise-level processed output directory. Pipeline appends ``/{mooring}/``.
+        proc_dir : str
+            Cruise-level processed output directory. The pipeline appends
+            ``/{mooring}/`` internally (see :func:`oceanarray.paths.mooring_proc_dir`).
 
         """
-        if base_dir is not None:
-            self.base_dir: Optional[Path] = Path(base_dir)
-            self._proc_dir: Optional[Path] = None
-            self._legacy = True
-        else:
-            self.base_dir = None
-            self._proc_dir = Path(proc_dir) if proc_dir else None
-            self._legacy = False
+        self._proc_dir = Path(proc_dir)
         self.log_file = None
 
     def _rel(self, path: Path) -> str:
-        """Return a short display path relative to base_dir or proc_dir."""
-        for root in (r for r in (self.base_dir, self._proc_dir) if r):
+        """Return a short display path relative to proc_dir."""
+        if self._proc_dir:
             try:
-                return str(path.relative_to(root))
+                return str(path.relative_to(self._proc_dir))
             except ValueError:
-                continue
+                pass
         return path.name
 
     def _setup_logging(self, mooring_name: str, output_path: Path) -> None:
@@ -1015,18 +1003,11 @@ class Stage2Processor:
             bool: True if processing completed successfully
 
         """
-        # Set up paths
-        if self._legacy:
-            if output_path is None:
-                proc = self.base_dir / "proc"
-                if not proc.is_dir():
-                    legacy_proc = self.base_dir / "moor" / "proc"
-                    proc = legacy_proc if legacy_proc.is_dir() else proc
-                proc_dir = proc / mooring_name
-            else:
-                proc_dir = Path(output_path) / mooring_name
+        # Set up paths — {proc_dir}/{mooring}/
+        if output_path is None:
+            proc_dir = paths.mooring_proc_dir(self._proc_dir, mooring_name)
         else:
-            proc_dir = self._proc_dir / mooring_name
+            proc_dir = Path(output_path) / mooring_name
 
         if not proc_dir.exists():
             print(f"ERROR: Processing directory not found: {proc_dir}")
@@ -1100,66 +1081,3 @@ class Stage2Processor:
         # Partial success is still success: instruments that processed are written
         # and the record summary reports which succeeded and which failed.
         return success_count > 0
-
-
-def stage2_mooring(
-    mooring_name: str, basedir: str, output_path: Optional[str] = None
-) -> bool:
-    """Process Stage 2 for a single mooring (backwards compatibility function).
-
-    Args:
-        mooring_name: Name of the mooring to process
-        basedir: Base directory containing the data
-        output_path: Optional output path override
-
-    Returns:
-        bool: True if processing completed successfully
-
-    """
-    processor = Stage2Processor(basedir)
-    return processor.process_mooring(mooring_name, output_path)
-
-
-def process_multiple_moorings_stage2(
-    mooring_list: List[str], basedir: str
-) -> Dict[str, bool]:
-    """Process Stage 2 for multiple moorings.
-
-    Args:
-        mooring_list: List of mooring names to process
-        basedir: Base directory containing the data
-
-    Returns:
-        Dict mapping mooring names to success status
-
-    """
-    processor = Stage2Processor(basedir)
-    results = {}
-
-    for mooring_name in mooring_list:
-        print(f"\n{'=' * 50}")
-        print(f"Processing Stage 2 for mooring {mooring_name}")
-        print(f"{'=' * 50}")
-
-        results[mooring_name] = processor.process_mooring(mooring_name)
-
-    return results
-
-
-# Example usage
-if __name__ == "__main__":
-    # Your mooring list
-    moorlist = ["dsE_1_2018"]
-
-    basedir = "/Users/eddifying/Dropbox/data/ifmro_mixsed/ds_data_eleanor/"
-
-    # Process all moorings
-    results = process_multiple_moorings_stage2(moorlist, basedir)
-
-    # Print summary
-    print(f"\n{'=' * 50}")
-    print("STAGE 2 PROCESSING SUMMARY")
-    print(f"{'=' * 50}")
-    for mooring, success in results.items():
-        status = "SUCCESS" if success else "FAILED"
-        print(f"{mooring}: {status}")

--- a/oceanarray/instrument/stage3.py
+++ b/oceanarray/instrument/stage3.py
@@ -50,6 +50,7 @@ import numpy as np
 import xarray as xr
 import yaml
 
+from oceanarray import paths
 from oceanarray.paths import safe_serial
 from oceanarray.utilities import (
     cast_output_dtypes,
@@ -92,9 +93,8 @@ class Stage3Processor:
 
     def __init__(
         self,
-        base_dir: Optional[str] = None,
         *,
-        proc_dir: Optional[str] = None,
+        proc_dir: str,
     ) -> None:
         """Apply QC flags, coordinate rotation, and derived variables to mooring data.
 
@@ -107,20 +107,12 @@ class Stage3Processor:
 
         Parameters
         ----------
-        base_dir : str, optional
-            Legacy: cruise-level base directory containing a ``proc/`` subdirectory.
-        proc_dir : str, optional
-            Cruise-level processed output directory. Pipeline appends ``/{mooring}/``.
+        proc_dir : str
+            Cruise-level processed output directory. The pipeline appends
+            ``/{mooring}/`` internally (see :func:`oceanarray.paths.mooring_proc_dir`).
 
         """
-        if base_dir is not None:
-            self.base_dir: Optional[Path] = Path(base_dir)
-            self._proc_dir: Optional[Path] = None
-            self._legacy = True
-        else:
-            self.base_dir = None
-            self._proc_dir = Path(proc_dir) if proc_dir else None
-            self._legacy = False
+        self._proc_dir = Path(proc_dir)
         self.log_file = None
 
     def _setup_logging(self, mooring_name: str, output_path: Path) -> None:
@@ -138,13 +130,7 @@ class Stage3Processor:
                 pass
 
     def _get_proc_dir(self, mooring_name: str) -> Path:
-        if not self._legacy and self._proc_dir is not None:
-            return self._proc_dir / mooring_name
-        proc = self.base_dir / "proc"
-        if not proc.is_dir():
-            legacy = self.base_dir / "moor" / "proc"
-            proc = legacy if legacy.is_dir() else proc
-        return proc / mooring_name
+        return paths.mooring_proc_dir(self._proc_dir, mooring_name)
 
     # ------------------------------------------------------------------
     def process_mooring(

--- a/oceanarray/mooring/grid.py
+++ b/oceanarray/mooring/grid.py
@@ -6,8 +6,8 @@ import numpy as np
 import xarray as xr
 import yaml
 from seasenselib.writers import NetCdfWriter
+from oceanarray import paths
 from oceanarray.utilities import _status, cast_output_dtypes
-from oceanarray.mooring.helpers import _get_proc_dir
 
 
 class MooringGridder:
@@ -15,9 +15,8 @@ class MooringGridder:
 
     def __init__(
         self,
-        base_dir: Optional[str] = None,
         *,
-        proc_dir: Optional[str] = None,
+        proc_dir: str,
     ) -> None:
         """Interpolate a mooring stack onto a regular pressure grid.
 
@@ -28,34 +27,24 @@ class MooringGridder:
 
         Parameters
         ----------
-        base_dir : str, optional
-            Legacy: cruise-level base directory containing a ``proc/`` subdirectory.
-        proc_dir : str, optional
-            Cruise-level processed output directory. Pipeline appends ``/{mooring}/``.
+        proc_dir : str
+            Cruise-level processed output directory. The pipeline appends
+            ``/{mooring}/`` internally (see :func:`oceanarray.paths.mooring_proc_dir`).
 
         """
-        if base_dir is not None:
-            self.base_dir: Optional[Path] = Path(base_dir)
-            self._proc_dir: Optional[Path] = None
-            self._legacy = True
-        else:
-            self.base_dir = None
-            self._proc_dir = Path(proc_dir) if proc_dir else None
-            self._legacy = False
+        self._proc_dir = Path(proc_dir)
 
     def _resolve_proc_dir(self, mooring_name: str) -> Path:
         """Return the mooring-level proc directory."""
-        if not self._legacy and self._proc_dir is not None:
-            return self._proc_dir / mooring_name
-        return _get_proc_dir(self.base_dir, mooring_name)
+        return paths.mooring_proc_dir(self._proc_dir, mooring_name)
 
     def _rel(self, path: Path) -> str:
-        """Return a short display path relative to base_dir or proc_dir."""
-        for root in (r for r in (self.base_dir, self._proc_dir) if r):
+        """Return a short display path relative to proc_dir."""
+        if self._proc_dir:
             try:
-                return str(path.relative_to(root))
+                return str(path.relative_to(self._proc_dir))
             except ValueError:
-                continue
+                pass
         return path.name
 
     def grid(
@@ -296,9 +285,17 @@ class MooringGridder:
 class TimeGriddingProcessor:
     """Handles Step 1 processing: time gridding and optional filtering of mooring instruments."""
 
-    def __init__(self, base_dir: str) -> None:
-        """Initialize processor with base directory."""
-        self.base_dir = Path(base_dir)
+    def __init__(self, *, proc_dir: str) -> None:
+        """Initialize the processor with the cruise-level proc directory.
+
+        Parameters
+        ----------
+        proc_dir : str
+            Cruise-level processed output directory. The pipeline appends
+            ``/{mooring}/`` internally (see :func:`oceanarray.paths.mooring_proc_dir`).
+
+        """
+        self._proc_dir = Path(proc_dir)
         self.log_file = None
 
     def _setup_logging(self, mooring_name: str, output_path: Path) -> None:
@@ -1026,9 +1023,9 @@ class TimeGriddingProcessor:
             bool: True if processing completed successfully
 
         """
-        # Set up paths
+        # Set up paths — {proc_dir}/{mooring}/
         if output_path is None:
-            proc_dir = self.base_dir / "moor" / "proc" / mooring_name
+            proc_dir = paths.mooring_proc_dir(self._proc_dir, mooring_name)
         else:
             proc_dir = Path(output_path) / mooring_name
 
@@ -1128,7 +1125,7 @@ class TimeGriddingProcessor:
 
 def time_gridding_mooring(
     mooring_name: str,
-    basedir: str,
+    proc_dir: str,
     output_path: Optional[str] = None,
     file_suffix: str = "_stage2",
     filter_type: Optional[str] = None,
@@ -1138,7 +1135,7 @@ def time_gridding_mooring(
 
     Args:
         mooring_name: Name of the mooring to process
-        basedir: Base directory containing the data
+        proc_dir: Cruise-level processed output directory (appends /{mooring}/)
         output_path: Optional output path override
         file_suffix: Suffix for input files ('_stage2' or '_raw')
         filter_type: Optional time filtering to apply ('lowpass', 'detide', 'bandpass')
@@ -1148,7 +1145,7 @@ def time_gridding_mooring(
         bool: True if processing completed successfully
 
     """
-    processor = TimeGriddingProcessor(basedir)
+    processor = TimeGriddingProcessor(proc_dir=proc_dir)
     return processor.process_mooring(
         mooring_name,
         output_path,
@@ -1160,7 +1157,7 @@ def time_gridding_mooring(
 
 def process_multiple_moorings_time_gridding(
     mooring_list: List[str],
-    basedir: str,
+    proc_dir: str,
     file_suffix: str = "_stage2",
     filter_type: Optional[str] = None,
     filter_params: Optional[Dict[str, Any]] = None,
@@ -1169,7 +1166,7 @@ def process_multiple_moorings_time_gridding(
 
     Args:
         mooring_list: List of mooring names to process
-        basedir: Base directory containing the data
+        proc_dir: Cruise-level processed output directory (appends /{mooring}/)
         file_suffix: Suffix for input files ('_stage2' or '_raw')
         filter_type: Optional time filtering to apply ('lowpass', 'detide', 'bandpass')
         filter_params: Optional parameters for filtering
@@ -1178,7 +1175,7 @@ def process_multiple_moorings_time_gridding(
         Dict mapping mooring names to success status
 
     """
-    processor = TimeGriddingProcessor(basedir)
+    processor = TimeGriddingProcessor(proc_dir=proc_dir)
     results = {}
 
     for mooring_name in mooring_list:

--- a/oceanarray/mooring/helpers.py
+++ b/oceanarray/mooring/helpers.py
@@ -123,14 +123,6 @@ def _times_to_float(t: np.ndarray) -> np.ndarray:
     return t.astype("datetime64[ns]").astype(np.float64)
 
 
-def _get_proc_dir(base_dir: Path, mooring_name: str) -> Path:
-    proc = base_dir / "proc"
-    if not proc.is_dir():
-        legacy = base_dir / "moor" / "proc"
-        proc = legacy if legacy.is_dir() else proc
-    return proc / mooring_name
-
-
 def _best_nc(
     proc_dir: Path, instr_type: str, mooring_name: str, serial: str
 ) -> Optional[Path]:

--- a/oceanarray/mooring/stack.py
+++ b/oceanarray/mooring/stack.py
@@ -1,7 +1,7 @@
 """MooringStacker: interpolate all instruments on a mooring onto a common time grid."""
 
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 import numpy as np
 import xarray as xr
 import yaml
@@ -13,11 +13,11 @@ from oceanarray.utilities import (
     extract_inline_instruments,
     parse_latlon,
 )
+from oceanarray import paths
 from oceanarray.mooring.helpers import (
     STACK_VARS,
     _safe_serial,
     _worst_flag,
-    _get_proc_dir,
     _best_nc,
     _detect_interval_s,
     _make_adcp_head_ds,
@@ -62,9 +62,8 @@ class MooringStacker:
 
     def __init__(
         self,
-        base_dir: Optional[str] = None,
         *,
-        proc_dir: Optional[str] = None,
+        proc_dir: str,
     ) -> None:
         """Resample all instruments from a mooring onto a common time axis.
 
@@ -75,34 +74,24 @@ class MooringStacker:
 
         Parameters
         ----------
-        base_dir : str, optional
-            Legacy: cruise-level base directory containing a ``proc/`` subdirectory.
-        proc_dir : str, optional
-            Cruise-level processed output directory. Pipeline appends ``/{mooring}/``.
+        proc_dir : str
+            Cruise-level processed output directory. The pipeline appends
+            ``/{mooring}/`` internally (see :func:`oceanarray.paths.mooring_proc_dir`).
 
         """
-        if base_dir is not None:
-            self.base_dir: Optional[Path] = Path(base_dir)
-            self._proc_dir: Optional[Path] = None
-            self._legacy = True
-        else:
-            self.base_dir = None
-            self._proc_dir = Path(proc_dir) if proc_dir else None
-            self._legacy = False
+        self._proc_dir = Path(proc_dir)
 
     def _resolve_proc_dir(self, mooring_name: str) -> Path:
         """Return the mooring-level proc directory."""
-        if not self._legacy and self._proc_dir is not None:
-            return self._proc_dir / mooring_name
-        return _get_proc_dir(self.base_dir, mooring_name)
+        return paths.mooring_proc_dir(self._proc_dir, mooring_name)
 
     def _rel(self, path: Path) -> str:
-        """Return a short display path relative to base_dir or proc_dir."""
-        for root in (r for r in (self.base_dir, self._proc_dir) if r):
+        """Return a short display path relative to proc_dir."""
+        if self._proc_dir:
             try:
-                return str(path.relative_to(root))
+                return str(path.relative_to(self._proc_dir))
             except ValueError:
-                continue
+                pass
         return path.name
 
     def stack(

--- a/oceanarray/paths.py
+++ b/oceanarray/paths.py
@@ -7,6 +7,7 @@ logic is defined once rather than copied per stage.
 """
 
 import re
+import sys
 from pathlib import Path
 from typing import Any, Union
 
@@ -87,15 +88,16 @@ def stage_output_name(mooring: str, serial: Any, stage: int, tag: str = "") -> s
 
 
 def require_current_layout(proc_root: _PathLike, mooring: str) -> None:
-    """Raise if *proc_root* uses the removed legacy ``moor/proc`` layout.
+    """Raise if *proc_root* points at a removed legacy layout, naming the fix.
 
     Under the current layout the mooring directory is ``proc_root/<mooring>``.
-    The removed ``basedir`` layout nested it under
-    ``proc_root/moor/proc/<mooring>``.  When the current-layout directory is
-    absent but the legacy one is present, raise a message that names the fix
-    rather than letting processing fail later with "no files found".  If
-    neither exists this returns normally — a genuinely empty run is not this
-    function's concern.
+    The removed ``basedir`` mode nested it one level down — under either
+    ``proc_root/moor/proc/<mooring>`` or ``proc_root/proc/<mooring>`` (both
+    shapes the old ``cli._get_proc_root`` accepted).  When the current-layout
+    directory is absent but a legacy one is present, raise an error that names
+    the directory to use instead, rather than letting processing fail later with
+    "no files found".  If neither exists this returns normally — a genuinely
+    empty run is not this function's concern.
 
     Parameters
     ----------
@@ -107,21 +109,34 @@ def require_current_layout(proc_root: _PathLike, mooring: str) -> None:
     Raises
     ------
     LegacyLayoutError
-        If the legacy ``moor/proc/<mooring>`` directory exists but the
-        current ``<mooring>`` directory does not.
+        If a legacy ``<proc_root>/moor/proc/<mooring>`` or
+        ``<proc_root>/proc/<mooring>`` directory exists but the current
+        ``<proc_root>/<mooring>`` directory does not.
 
     """
     proc_root = Path(proc_root)
+    legacy_roots = (proc_root / "moor" / "proc", proc_root / "proc")
     if (proc_root / mooring).is_dir():
+        # Current layout is present.  Warn (do not fail) if a stale legacy copy
+        # also exists — a half-finished migration leaves two competing trees and
+        # the legacy one is silently ignored.
+        for legacy_root in legacy_roots:
+            if (legacy_root / mooring).is_dir():
+                print(
+                    f"WARNING: both the current '{proc_root / mooring}' and a "
+                    f"legacy '{legacy_root / mooring}' directory exist; the legacy "
+                    f"copy is ignored. Remove it to avoid confusion.",
+                    file=sys.stderr,
+                )
+                break
         return
-    legacy = proc_root / "moor" / "proc" / mooring
-    if legacy.is_dir():
-        raise LegacyLayoutError(  # noqa: TRY003
-            f"'{proc_root}' looks like a legacy 'moor/proc' layout, which is no "
-            f"longer supported (the 'basedir' option was removed). Point "
-            f"--proc-dir at '{proc_root / 'moor' / 'proc'}', or migrate the "
-            f"directory to the current layout (see MIGRATION-BASEDIR.md)."
-        )
+    for legacy_root in legacy_roots:
+        if (legacy_root / mooring).is_dir():
+            raise LegacyLayoutError(  # noqa: TRY003
+                f"--proc-dir points at an old-layout directory (found "
+                f"'{legacy_root / mooring}'). Use --proc-dir {legacy_root} "
+                f"instead (see MIGRATION-BASEDIR.md)."
+            )
 
 
 def safe_serial(serial: Any) -> str:

--- a/oceanarray/paths.py
+++ b/oceanarray/paths.py
@@ -1,13 +1,127 @@
 """Filesystem path and filename conventions for the oceanarray pipeline.
 
-Single source of truth for turning instrument serial numbers into
-filename-safe tokens.  As the pipeline's path handling is consolidated
-(removing ``basedir``), folder resolution and the output filename pattern
-are intended to move here too.
+Single source of truth for folder resolution, the stage output-filename
+pattern, and turning instrument serial numbers into filename-safe tokens.
+Every processing stage derives its read/write locations from here so the
+logic is defined once rather than copied per stage.
 """
 
 import re
-from typing import Any
+from pathlib import Path
+from typing import Any, Union
+
+_PathLike = Union[str, Path]
+
+
+class LegacyLayoutError(RuntimeError):
+    """Raised when a directory uses the removed ``moor/proc`` (``basedir``) layout."""
+
+
+def mooring_proc_dir(proc_root: _PathLike, mooring: str) -> Path:
+    """Return the mooring-level processed-data directory.
+
+    Under the current layout this is ``proc_root/<mooring>``.
+
+    Parameters
+    ----------
+    proc_root : str or Path
+        Cruise-level processed-data root (the ``--proc-dir`` value).
+    mooring : str
+        Mooring name.
+
+    Returns
+    -------
+    Path
+        ``proc_root/<mooring>``.
+
+    """
+    return Path(proc_root) / mooring
+
+
+def raw_mooring_dir(raw_root: _PathLike, mooring: str) -> Path:
+    """Return the mooring-level raw-data directory.
+
+    Under the current layout this is ``raw_root/<mooring>``.
+
+    Parameters
+    ----------
+    raw_root : str or Path
+        Cruise-level raw-data root (the ``--raw-dir`` value).
+    mooring : str
+        Mooring name.
+
+    Returns
+    -------
+    Path
+        ``raw_root/<mooring>``.
+
+    """
+    return Path(raw_root) / mooring
+
+
+def stage_output_name(mooring: str, serial: Any, stage: int, tag: str = "") -> str:
+    """Return the stage output filename for one instrument.
+
+    The pattern is ``{mooring}_{serial}{tag}_stage{N}.nc``.  The serial is
+    cleaned with :func:`safe_serial`, so the raw YAML value may be passed
+    directly.
+
+    Parameters
+    ----------
+    mooring : str
+        Mooring name.
+    serial : Any
+        Raw instrument serial (cleaned internally via :func:`safe_serial`).
+    stage : int
+        Processing stage number (1, 2, or 3).
+    tag : str, optional
+        Extra filename tag (e.g. the ADCP-matlab file tag). Default ``""``.
+
+    Returns
+    -------
+    str
+        The output filename, e.g. ``"dsG3_16430_stage1.nc"``.
+
+    """
+    return f"{mooring}_{safe_serial(serial)}{tag}_stage{stage}.nc"
+
+
+def require_current_layout(proc_root: _PathLike, mooring: str) -> None:
+    """Raise if *proc_root* uses the removed legacy ``moor/proc`` layout.
+
+    Under the current layout the mooring directory is ``proc_root/<mooring>``.
+    The removed ``basedir`` layout nested it under
+    ``proc_root/moor/proc/<mooring>``.  When the current-layout directory is
+    absent but the legacy one is present, raise a message that names the fix
+    rather than letting processing fail later with "no files found".  If
+    neither exists this returns normally — a genuinely empty run is not this
+    function's concern.
+
+    Parameters
+    ----------
+    proc_root : str or Path
+        Cruise-level processed-data root (the ``--proc-dir`` value).
+    mooring : str
+        Mooring name.
+
+    Raises
+    ------
+    LegacyLayoutError
+        If the legacy ``moor/proc/<mooring>`` directory exists but the
+        current ``<mooring>`` directory does not.
+
+    """
+    proc_root = Path(proc_root)
+    if (proc_root / mooring).is_dir():
+        return
+    legacy = proc_root / "moor" / "proc" / mooring
+    if legacy.is_dir():
+        raise LegacyLayoutError(  # noqa: TRY003
+            f"'{proc_root}' looks like a legacy 'moor/proc' layout, which is no "
+            f"longer supported (the 'basedir' option was removed). Point "
+            f"--proc-dir at '{proc_root / 'moor' / 'proc'}', or migrate the "
+            f"directory to the current layout (see MIGRATION-BASEDIR.md)."
+        )
 
 
 def safe_serial(serial: Any) -> str:

--- a/oceanarray/plotter.py
+++ b/oceanarray/plotter.py
@@ -639,7 +639,7 @@ def plot_mooring_timeseries(
     Parameters
     ----------
     proc_dir : Path
-        Path to the mooring's proc directory (e.g. ``<basedir>/proc``).
+        Path to the mooring's proc directory (e.g. ``<proc-dir>/<mooring>``).
     mooring : str
         Mooring name, e.g. ``dsG3_1_2026``.
     var_y : str

--- a/oceanarray/report/_grid.py
+++ b/oceanarray/report/_grid.py
@@ -394,13 +394,13 @@ def generate_grid_page(
     ctx: Dict[str, Any],
     out_dir: Path,
     force: bool,
-    base_dir: Path,
+    display_root: Path,
     skip_existing: bool = False,
 ) -> None:
     """Generate a grid report HTML page with T/S pcolormesh figures."""
     out_path = out_dir / f"{mooring_name}_grid_report.html"
     if _should_skip(out_path, force, skip_existing, grid_path):
-        _status("skip", str(out_path.relative_to(base_dir)))
+        _status("skip", str(out_path.relative_to(display_root)))
         return
 
     try:
@@ -561,6 +561,6 @@ def generate_grid_page(
             proc_machine=ctx.get("proc_machine", ""),
         )
         out_path.write_text(html, encoding="utf-8")
-        _status("file", str(out_path.relative_to(base_dir)))
+        _status("file", str(out_path.relative_to(display_root)))
     except Exception as exc:
         print(f"  ERROR generating grid report: {exc}")

--- a/oceanarray/report/_html_helpers.py
+++ b/oceanarray/report/_html_helpers.py
@@ -33,14 +33,6 @@ def _safe_serial(serial: Any) -> str:
     return safe_serial(serial)
 
 
-def _get_proc_dir(base_dir: Path, mooring_name: str) -> Path:
-    proc = base_dir / "proc"
-    if not proc.is_dir():
-        legacy = base_dir / "moor" / "proc"
-        proc = legacy if legacy.is_dir() else proc
-    return proc / mooring_name
-
-
 def _parse_dt(s: Optional[str]) -> Optional[datetime]:
     """Parse clock timestamp: HH:MM:SS, YYYYMMDDTHH:MM:SS, or standard ISO."""
     if not s:
@@ -112,17 +104,6 @@ def _resolve_clock(entry: Dict[str, Any]) -> Dict[str, Any]:
         "instrument_time": _fmt_clock_str(str(inst_str)) if inst_str else None,
         "has_correction": offset_s != 0 or (drift_s is not None and drift_s != 0),
     }
-
-
-def _raw_file_path(
-    base_dir: Path,
-    raw_subdir: str,
-    instr_type: str,
-    mooring_name: str,
-    filename: str,
-) -> Path:
-    """Reconstruct the raw input file path exactly as stage1.py does."""
-    return base_dir / raw_subdir / instr_type / mooring_name / filename
 
 
 def _check_readable(file_path: Path, file_type: str) -> Tuple[bool, str]:

--- a/oceanarray/report/_instrument.py
+++ b/oceanarray/report/_instrument.py
@@ -174,6 +174,12 @@ _INSTRUMENT_HTML_TEMPLATE = """\
     <td class="num">{{ raw_file.size }}</td>
     <td>{{ raw_file.mtime }}</td>
   </tr>
+  {% elif raw_file.unknown %}
+  <tr>
+    <td>Raw</td>
+    <td class="mono">{{ raw_file.name }}</td>
+    <td colspan="2">&mdash; not checked (no --raw-dir)</td>
+  </tr>
   {% else %}
   <tr>
     <td>Raw</td>
@@ -551,7 +557,6 @@ def generate_instrument_pages(
     proc_dir: Path,
     out_dir: Path,
     force: bool,
-    base_dir: Path,
     serials: Optional[List[str]] = None,
     raw_dir: Optional[Path] = None,
     skip_existing: bool = False,
@@ -580,9 +585,6 @@ def generate_instrument_pages(
         Per-instrument pages are placed in ``out_dir/instrument/``.
     force : bool
         If True, regenerate pages that already exist.
-    base_dir : Path
-        Legacy cruise-level base directory.  Used to resolve raw file paths in
-        legacy mode (when *raw_dir* is None).
     serials : list of str, optional
         If provided, only generate pages for instruments whose serial number is in
         this list.  Useful for regenerating a single instrument without reprocessing
@@ -590,7 +592,7 @@ def generate_instrument_pages(
     raw_dir : Path, optional
         Cruise-level raw data directory for the new directory layout.  When given,
         raw file existence is checked at ``{raw_dir}/{mooring}/{instr_type}/filename``.
-        When None, *base_dir* is used instead (legacy layout).
+        When None, the raw file is not located on disk.
     skip_existing : bool
         If True, skip pages whose output file is newer than the source NetCDF.
 
@@ -698,25 +700,23 @@ def generate_instrument_pages(
 
         # File listing — raw source and stage1/2/3 NC files
         raw_filename = instr.get("filename", "")
-        if raw_filename:
-            if raw_dir is not None:
-                # New layout: {raw_dir}/{mooring}/{instrument}/filename
-                raw_file_path = raw_dir / mooring_name / instr_type / raw_filename
-            else:
-                # Legacy layout: {base_dir}/{directory}/{instrument}/filename
-                raw_file_path = (
-                    base_dir
-                    / str(cfg.get("directory", "raw")).rstrip("/")
-                    / instr_type
-                    / raw_filename
-                )
+        if raw_filename and raw_dir is not None:
+            # New layout: {raw_dir}/{mooring}/{instrument}/filename
+            raw_file = _file_info(raw_dir / mooring_name / instr_type / raw_filename)
+        elif raw_filename:
+            # No raw_dir configured: the raw file's location is unknown.  Do NOT
+            # probe the filesystem — a bare filename resolves against the current
+            # working directory and would misreport existence.  Mark it "not
+            # checked" rather than guess.
+            raw_file = {
+                "exists": False,
+                "unknown": True,
+                "name": raw_filename,
+                "size": "",
+                "mtime": "",
+            }
         else:
-            raw_file_path = Path("no_raw_file")
-        raw_file = (
-            _file_info(raw_file_path)
-            if raw_filename
-            else {"exists": False, "name": raw_filename or "—", "size": "", "mtime": ""}
-        )
+            raw_file = {"exists": False, "name": "—", "size": "", "mtime": ""}
         stage_files = _stage_file_details(proc_dir, instr_type, mooring_name, serial)
 
         ctx = {

--- a/oceanarray/report/_mooring.py
+++ b/oceanarray/report/_mooring.py
@@ -10,17 +10,17 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import yaml
 
+from oceanarray import paths
+
 from ._html_helpers import (
     _check_readable,
     _duration_str,
     _find_array_report_href,
     _fmt_dt,
-    _get_proc_dir,
     _load_pdf_b64,
     _instrument_report_exists,
     _nav_buttons_html,
     _parse_dt,
-    _raw_file_path,
     _read_instrument_info,
     _read_qc_summary,
     _read_sensor_info,
@@ -1010,19 +1010,16 @@ class MooringReport:
 
     def __init__(
         self,
-        base_dir: Optional[str] = None,
         *,
-        proc_dir: Optional[str] = None,
+        proc_dir: str,
         raw_dir: Optional[str] = None,
         report_dir: Optional[str] = None,
     ) -> None:
-        """Initialize with base_dir (legacy) or proc_dir + optional raw_dir (new).
+        """Initialize with the cruise-level proc directory and optional raw/report dirs.
 
         Parameters
         ----------
-        base_dir : str, optional
-            Legacy: cruise-level base directory containing a ``proc/`` subdirectory.
-        proc_dir : str, optional
+        proc_dir : str
             Cruise-level processed output directory. Pipeline appends ``/{mooring}/``.
         raw_dir : str, optional
             Cruise-level raw data directory.  When provided, the report checks whether
@@ -1037,31 +1034,21 @@ class MooringReport:
             when both are supplied.
 
         """
-        if base_dir is not None:
-            self.base_dir: Optional[Path] = Path(base_dir)
-            self._proc_dir: Optional[Path] = None
-            self._raw_dir: Optional[Path] = None
-            self._legacy = True
-        else:
-            self.base_dir = None
-            self._proc_dir = Path(proc_dir) if proc_dir else None
-            self._raw_dir = Path(raw_dir) if raw_dir else None
-            self._legacy = False
+        self._proc_dir = Path(proc_dir) if proc_dir else None
+        self._raw_dir = Path(raw_dir) if raw_dir else None
         self._report_dir: Optional[Path] = Path(report_dir) if report_dir else None
 
     def _resolve_proc_dir(self, mooring_name: str) -> Path:
         """Return the mooring-level proc directory."""
-        if not self._legacy and self._proc_dir is not None:
-            return self._proc_dir / mooring_name
-        return _get_proc_dir(self.base_dir, mooring_name)
+        return paths.mooring_proc_dir(self._proc_dir, mooring_name)
 
     def _rel(self, path: Path) -> str:
-        """Return a short display path relative to base_dir or proc_dir."""
-        for root in (r for r in (self.base_dir, self._proc_dir) if r):
+        """Return a short display path relative to proc_dir."""
+        if self._proc_dir:
             try:
-                return str(path.relative_to(root))
+                return str(path.relative_to(self._proc_dir))
             except ValueError:
-                continue
+                pass
         return path.name
 
     def generate(
@@ -1102,8 +1089,8 @@ class MooringReport:
         with open(yaml_path) as f:
             cfg = yaml.safe_load(f)
 
-        # Resolve the base_dir used for raw file lookups in instrument pages
-        report_base_dir = self.base_dir or self._proc_dir or proc_dir.parent
+        # Display root for pretty-printing paths in the instrument/grid/stack pages.
+        display_root = self._proc_dir or proc_dir.parent
 
         ctx = self._build_context(mooring_name, cfg, proc_dir, yaml_path, out_dir)
         html = self._render(ctx)
@@ -1118,7 +1105,6 @@ class MooringReport:
                 proc_dir,
                 out_dir,
                 force,
-                report_base_dir,
                 serials=serials,
                 raw_dir=self._raw_dir,
                 skip_existing=skip_existing,
@@ -1142,7 +1128,7 @@ class MooringReport:
                     ctx,
                     out_dir,
                     force,
-                    report_base_dir,
+                    display_root,
                     skip_existing=skip_existing,
                 )
             else:
@@ -1157,7 +1143,7 @@ class MooringReport:
                     ctx,
                     out_dir,
                     force,
-                    report_base_dir,
+                    display_root,
                     skip_existing=skip_existing,
                 )
             else:
@@ -1176,7 +1162,6 @@ class MooringReport:
         deploy_dt = _parse_dt(cfg.get("deployment_time"))
         recover_dt = _parse_dt(cfg.get("recovery_time"))
         waterdepth = cfg.get("waterdepth")
-        raw_subdir = str(cfg.get("directory", "raw")).rstrip("/")
 
         instrument_list = list(cfg.get("clamp", cfg.get("instruments", [])))
         instrument_list += extract_inline_instruments(cfg.get("inline", []))
@@ -1210,25 +1195,23 @@ class MooringReport:
             file_type = entry.get("file_type", "")
             yaml_interval_s = entry.get("sample_interval_seconds")
 
-            if filename:
-                if self._legacy:
-                    raw_path = _raw_file_path(
-                        self.base_dir, raw_subdir, instr_type, mooring_name, filename
-                    )
-                    raw_path_str = str(raw_path.relative_to(self.base_dir))
-                elif self._raw_dir is not None:
-                    # New layout: {raw_dir}/{mooring}/{instrument}/filename
-                    raw_path = self._raw_dir / mooring_name / instr_type / filename
-                    raw_path_str = str(raw_path.relative_to(self._raw_dir))
-                else:
-                    raw_path = Path(filename)
-                    raw_path_str = filename
+            if filename and self._raw_dir is not None:
+                # New layout: {raw_dir}/{mooring}/{instrument}/filename
+                raw_path = self._raw_dir / mooring_name / instr_type / filename
+                raw_path_str = str(raw_path.relative_to(self._raw_dir))
                 raw_exists = raw_path.exists()
                 readable, readable_note = (
                     _check_readable(raw_path, file_type)
                     if raw_exists
                     else (False, "file missing")
                 )
+            elif filename:
+                # No raw_dir configured: the raw file's location is unknown.  Do
+                # NOT probe the filesystem — a bare filename resolves against the
+                # current working directory and would misreport existence.
+                raw_path_str = filename
+                raw_exists = False
+                readable, readable_note = (False, "not checked (no --raw-dir)")
             else:
                 # Try auto-guessing filename from standard naming conventions
                 # (same logic as MooringProcessor._guess_instrument_filename).

--- a/oceanarray/report/_stack.py
+++ b/oceanarray/report/_stack.py
@@ -598,13 +598,13 @@ def generate_stack_page(
     ctx: Dict[str, Any],
     out_dir: Path,
     force: bool,
-    base_dir: Path,
+    display_root: Path,
     skip_existing: bool = False,
 ) -> None:
     """Generate a stack report HTML page with pressure and T time series."""
     out_path = out_dir / f"{mooring_name}_stack_report.html"
     if _should_skip(out_path, force, skip_existing, stack_path):
-        _status("skip", str(out_path.relative_to(base_dir)))
+        _status("skip", str(out_path.relative_to(display_root)))
         return
 
     try:
@@ -942,6 +942,6 @@ def generate_stack_page(
             proc_machine=ctx.get("proc_machine", ""),
         )
         out_path.write_text(html, encoding="utf-8")
-        _status("file", str(out_path.relative_to(base_dir)))
+        _status("file", str(out_path.relative_to(display_root)))
     except Exception as exc:
         print(f"  ERROR generating stack report: {exc}")

--- a/tests/integration/test_stage1.py
+++ b/tests/integration/test_stage1.py
@@ -17,18 +17,18 @@ class TestRealDataProcessing:
         """Set up test environment with real CNV data."""
         base_dir = tmp_path / "test_data"
 
-        # Create directory structure matching real layout:
-        # input_dir / instrument / mooring_name / filename
-        raw_dir = (
-            base_dir / "moor" / "raw" / "test_deployment" / "microcat" / "test_mooring"
-        )
-        proc_dir = base_dir / "moor" / "proc" / "test_mooring"
-        raw_dir.mkdir(parents=True)
+        # Current layout: {raw_dir}/{mooring}/{instrument}/filename and
+        # {proc_dir}/{mooring}/.
+        raw_root = base_dir / "raw"
+        proc_root = base_dir / "proc"
+        raw_mooring = raw_root / "test_mooring" / "microcat"
+        proc_dir = proc_root / "test_mooring"
+        raw_mooring.mkdir(parents=True)
         proc_dir.mkdir(parents=True)
 
         # Copy the real test data file
         test_data_source = Path("data/test_data.cnv")
-        test_data_dest = raw_dir / "test_data.cnv"
+        test_data_dest = raw_mooring / "test_data.cnv"
 
         if test_data_source.exists():
             test_data_dest.write_text(test_data_source.read_text())
@@ -47,7 +47,6 @@ class TestRealDataProcessing:
             "recovery_time": "2018-08-26T20:47:24",
             "seabed_latitude": "60 00.000 N",
             "seabed_longitude": "030 00.000 W",
-            "directory": "moor/raw/test_deployment/",
             "instruments": [
                 {
                     "instrument": "microcat",
@@ -67,8 +66,8 @@ class TestRealDataProcessing:
             yaml.dump(yaml_data, f)
 
         return {
-            "base_dir": base_dir,
-            "raw_dir": raw_dir,
+            "raw_root": raw_root,
+            "proc_root": proc_root,
             "proc_dir": proc_dir,
             "config_file": config_file,
             "data_file": test_data_dest,
@@ -78,7 +77,9 @@ class TestRealDataProcessing:
     def test_process_real_sbe_file(self, test_data_setup):
         """Test processing with real SBE CNV file."""
         setup = test_data_setup
-        processor = MooringProcessor(str(setup["base_dir"]))
+        processor = MooringProcessor(
+            raw_dir=str(setup["raw_root"]), proc_dir=str(setup["proc_root"])
+        )
 
         result = processor.process_mooring("test_mooring")
 
@@ -110,7 +111,9 @@ class TestRealDataProcessing:
 
         setup["data_file"].unlink()
 
-        processor = MooringProcessor(str(setup["base_dir"]))
+        processor = MooringProcessor(
+            raw_dir=str(setup["raw_root"]), proc_dir=str(setup["proc_root"])
+        )
         result = processor.process_mooring("test_mooring")
 
         assert result is False
@@ -123,7 +126,9 @@ class TestRealDataProcessing:
     def test_process_existing_output(self, test_data_setup):
         """Test processing when output file already exists."""
         setup = test_data_setup
-        processor = MooringProcessor(str(setup["base_dir"]))
+        processor = MooringProcessor(
+            raw_dir=str(setup["raw_root"]), proc_dir=str(setup["proc_root"])
+        )
 
         result1 = processor.process_mooring("test_mooring")
         assert result1 is True
@@ -138,10 +143,11 @@ class TestRealDataProcessing:
     def test_process_missing_config(self, tmp_path):
         """Test processing mooring with missing config file."""
         base_dir = tmp_path / "test_data"
-        proc_dir = base_dir / "moor" / "proc" / "test_mooring"
-        proc_dir.mkdir(parents=True)
+        raw_root = base_dir / "raw"
+        proc_root = base_dir / "proc"
+        (proc_root / "test_mooring").mkdir(parents=True)
 
-        processor = MooringProcessor(str(base_dir))
+        processor = MooringProcessor(raw_dir=str(raw_root), proc_dir=str(proc_root))
         result = processor.process_mooring("test_mooring")
 
         assert result is False

--- a/tests/integration/test_stage2.py
+++ b/tests/integration/test_stage2.py
@@ -32,7 +32,8 @@ class TestRealDataProcessing:
             )
 
         base_dir = tmp_path / "test_data"
-        proc_dir = base_dir / "moor" / "proc" / "test_mooring"
+        proc_root = base_dir / "proc"
+        proc_dir = proc_root / "test_mooring"
         microcat_dir = proc_dir / "microcat"
         microcat_dir.mkdir(parents=True)
 
@@ -43,7 +44,7 @@ class TestRealDataProcessing:
         test_yaml_file.write_text(yaml_config_file.read_text())
 
         return {
-            "base_dir": base_dir,
+            "proc_root": proc_root,
             "proc_dir": proc_dir,
             "raw_file": test_raw_file,
             "yaml_file": test_yaml_file,
@@ -52,7 +53,7 @@ class TestRealDataProcessing:
     def test_process_real_data_full_workflow(self, test_data_setup):
         """Test complete Stage 2 processing with real data - Version 2.0."""
         setup = test_data_setup
-        processor = Stage2Processor(str(setup["base_dir"]))
+        processor = Stage2Processor(proc_dir=str(setup["proc_root"]))
 
         result = processor.process_mooring("test_mooring")
 
@@ -101,7 +102,7 @@ class TestRealDataProcessing:
         with open(setup["yaml_file"], "w") as f:
             yaml.dump(config, f)
 
-        processor = Stage2Processor(str(setup["base_dir"]))
+        processor = Stage2Processor(proc_dir=str(setup["proc_root"]))
         result = processor.process_mooring("test_mooring")
 
         assert result is True
@@ -125,7 +126,7 @@ class TestRealDataProcessing:
 
         setup["raw_file"].unlink()
 
-        processor = Stage2Processor(str(setup["base_dir"]))
+        processor = Stage2Processor(proc_dir=str(setup["proc_root"]))
         result = processor.process_mooring("test_mooring")
 
         assert result is False
@@ -138,10 +139,10 @@ class TestRealDataProcessing:
     def test_process_missing_config(self, tmp_path):
         """Test processing with missing config file."""
         base_dir = tmp_path / "test_data"
-        proc_dir = base_dir / "moor" / "proc" / "test_mooring"
-        proc_dir.mkdir(parents=True)
+        proc_root = base_dir / "proc"
+        (proc_root / "test_mooring").mkdir(parents=True)
 
-        processor = Stage2Processor(str(base_dir))
+        processor = Stage2Processor(proc_dir=str(proc_root))
         result = processor.process_mooring("test_mooring")
 
         assert result is False

--- a/tests/integration/test_time_gridding.py
+++ b/tests/integration/test_time_gridding.py
@@ -68,7 +68,8 @@ class TestTimeGriddingIntegration:
     def test_data_setup(self, tmp_path):
         """Set up test environment with mock instrument files."""
         base_dir = tmp_path / "test_data"
-        proc_dir = base_dir / "moor" / "proc" / "test_mooring"
+        proc_root = base_dir / "proc"
+        proc_dir = proc_root / "test_mooring"
         proc_dir.mkdir(parents=True)
 
         yaml_data = {
@@ -105,7 +106,7 @@ class TestTimeGriddingIntegration:
             ds.to_netcdf(filepath)
 
         return {
-            "base_dir": base_dir,
+            "proc_root": proc_root,
             "proc_dir": proc_dir,
             "config_file": config_file,
             "yaml_data": yaml_data,
@@ -114,7 +115,7 @@ class TestTimeGriddingIntegration:
     def test_full_time_gridding_processing(self, test_data_setup):
         """Test complete time gridding processing workflow."""
         setup = test_data_setup
-        processor = TimeGriddingProcessor(str(setup["base_dir"]))
+        processor = TimeGriddingProcessor(proc_dir=str(setup["proc_root"]))
 
         result = processor.process_mooring("test_mooring")
 
@@ -153,7 +154,7 @@ class TestTimeGriddingIntegration:
         with open(setup["config_file"], "w") as f:
             yaml.dump(yaml_data, f)
 
-        processor = TimeGriddingProcessor(str(setup["base_dir"]))
+        processor = TimeGriddingProcessor(proc_dir=str(setup["proc_root"]))
         result = processor.process_mooring("test_mooring")
 
         assert result is True
@@ -167,7 +168,7 @@ class TestTimeGriddingIntegration:
     def test_different_sampling_rates_warning(self, test_data_setup):
         """Test warnings about different sampling rates."""
         setup = test_data_setup
-        processor = TimeGriddingProcessor(str(setup["base_dir"]))
+        processor = TimeGriddingProcessor(proc_dir=str(setup["proc_root"]))
 
         result = processor.process_mooring("test_mooring")
         assert result is True
@@ -180,7 +181,7 @@ class TestTimeGriddingIntegration:
     def test_filtering_parameter_detide(self, test_data_setup):
         """Test filtering integration with detide filter (not yet implemented)."""
         setup = test_data_setup
-        processor = TimeGriddingProcessor(str(setup["base_dir"]))
+        processor = TimeGriddingProcessor(proc_dir=str(setup["proc_root"]))
 
         result = processor.process_mooring("test_mooring", filter_type="detide")
 
@@ -195,8 +196,8 @@ class TestTimeGriddingIntegration:
 
     def test_no_valid_datasets(self, tmp_path):
         """Test handling when no valid datasets are found."""
-        base_dir = tmp_path / "test_data"
-        proc_dir = base_dir / "moor" / "proc" / "test_mooring"
+        proc_root = tmp_path / "test_data"
+        proc_dir = proc_root / "test_mooring"
         proc_dir.mkdir(parents=True)
 
         yaml_data = {
@@ -208,7 +209,7 @@ class TestTimeGriddingIntegration:
         with open(config_file, "w") as f:
             yaml.dump(yaml_data, f)
 
-        processor = TimeGriddingProcessor(str(base_dir))
+        processor = TimeGriddingProcessor(proc_dir=str(proc_root))
         result = processor.process_mooring("test_mooring")
 
         assert result is False
@@ -216,7 +217,7 @@ class TestTimeGriddingIntegration:
     def test_custom_variables_to_keep(self, test_data_setup):
         """Test processing with custom variable selection."""
         setup = test_data_setup
-        processor = TimeGriddingProcessor(str(setup["base_dir"]))
+        processor = TimeGriddingProcessor(proc_dir=str(setup["proc_root"]))
 
         result = processor.process_mooring("test_mooring", vars_to_keep=["temperature"])
         assert result is True

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -7,9 +7,18 @@ stage1/stage3/report filenames but ``"16430"`` via the stack path — the same
 instrument landing under two different filenames.
 """
 
+from pathlib import Path
+
 import pytest
 
-from oceanarray.paths import safe_serial
+from oceanarray.paths import (
+    LegacyLayoutError,
+    mooring_proc_dir,
+    raw_mooring_dir,
+    require_current_layout,
+    safe_serial,
+    stage_output_name,
+)
 
 
 @pytest.mark.parametrize(
@@ -57,3 +66,45 @@ def test_stage1_call_site_agrees():
     assert MooringProcessor._safe_serial("16430, R01-024") == safe_serial(
         "16430, R01-024"
     )
+
+
+def test_mooring_and_raw_dirs():
+    """Folder helpers append the mooring name to the cruise-level root."""
+    assert mooring_proc_dir("/data/proc", "dsG3") == Path("/data/proc/dsG3")
+    assert raw_mooring_dir("/data/raw", "dsG3") == Path("/data/raw/dsG3")
+    # str and Path roots behave identically
+    assert mooring_proc_dir(Path("/data/proc"), "dsG3") == mooring_proc_dir(
+        "/data/proc", "dsG3"
+    )
+
+
+@pytest.mark.parametrize(
+    ("mooring", "serial", "stage", "tag", "expected"),
+    [
+        ("dsG3", "16430", 1, "", "dsG3_16430_stage1.nc"),
+        ("dsG3", "16430, R01-024", 1, "", "dsG3_16430_stage1.nc"),  # serial cleaned
+        ("dsG3", 7507, 2, "", "dsG3_7507_stage2.nc"),  # int serial
+        ("wb2", "1234", 3, "_burst", "wb2_1234_burst_stage3.nc"),  # tag
+    ],
+)
+def test_stage_output_name(mooring, serial, stage, tag, expected):
+    """Output name follows {mooring}_{serial}{tag}_stage{N}.nc with a cleaned serial."""
+    assert stage_output_name(mooring, serial, stage, tag) == expected
+
+
+def test_require_current_layout_ok_when_current(tmp_path):
+    """No error when the current-layout mooring dir exists."""
+    (tmp_path / "dsG3").mkdir()
+    assert require_current_layout(tmp_path, "dsG3") is None
+
+
+def test_require_current_layout_ok_when_empty(tmp_path):
+    """No error when neither layout is present — an empty run is not this check's job."""
+    assert require_current_layout(tmp_path, "dsG3") is None
+
+
+def test_require_current_layout_raises_on_legacy(tmp_path):
+    """Legacy moor/proc/<mooring> present but current absent → clear error."""
+    (tmp_path / "moor" / "proc" / "dsG3").mkdir(parents=True)
+    with pytest.raises(LegacyLayoutError, match="legacy 'moor/proc' layout"):
+        require_current_layout(tmp_path, "dsG3")

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -103,8 +103,27 @@ def test_require_current_layout_ok_when_empty(tmp_path):
     assert require_current_layout(tmp_path, "dsG3") is None
 
 
-def test_require_current_layout_raises_on_legacy(tmp_path):
-    """Legacy moor/proc/<mooring> present but current absent → clear error."""
+def test_require_current_layout_warns_when_both_present(tmp_path, capsys):
+    """Current + stale legacy dir both present → warn (don't fail); legacy ignored."""
+    (tmp_path / "dsG3").mkdir()
     (tmp_path / "moor" / "proc" / "dsG3").mkdir(parents=True)
-    with pytest.raises(LegacyLayoutError, match="legacy 'moor/proc' layout"):
+    assert require_current_layout(tmp_path, "dsG3") is None
+    err = capsys.readouterr().err
+    assert "both the current" in err and "legacy" in err
+
+
+def test_require_current_layout_raises_on_moor_proc(tmp_path):
+    """Legacy moor/proc/<mooring> present but current absent → error names the fix."""
+    (tmp_path / "moor" / "proc" / "dsG3").mkdir(parents=True)
+    with pytest.raises(LegacyLayoutError) as exc:
         require_current_layout(tmp_path, "dsG3")
+    # The message must name the directory to point --proc-dir at.
+    assert str(tmp_path / "moor" / "proc") in str(exc.value)
+
+
+def test_require_current_layout_raises_on_proc(tmp_path):
+    """The other legacy variant, proc/<mooring>, is also detected and named."""
+    (tmp_path / "proc" / "dsG3").mkdir(parents=True)
+    with pytest.raises(LegacyLayoutError) as exc:
+        require_current_layout(tmp_path, "dsG3")
+    assert str(tmp_path / "proc") in str(exc.value)

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -18,7 +18,6 @@ from oceanarray.report._html_helpers import (
     _fmt_dt,
     _fmt_minmax,
     _fmt_size,
-    _get_proc_dir,
     _parse_dt,
     _parse_history,
     _read_nc_metadata,
@@ -137,19 +136,6 @@ class TestHtmlHelpers:
 
     def test_safe_serial_dot_stripped(self):
         assert _safe_serial("3.14") == "314"
-
-    # _get_proc_dir
-    def test_get_proc_dir_new_layout(self, tmp_path):
-        proc = tmp_path / "proc"
-        proc.mkdir()
-        result = _get_proc_dir(tmp_path, "TEST_M1")
-        assert result == proc / "TEST_M1"
-
-    def test_get_proc_dir_legacy_layout(self, tmp_path):
-        legacy = tmp_path / "moor" / "proc"
-        legacy.mkdir(parents=True)
-        result = _get_proc_dir(tmp_path, "TEST_M1")
-        assert result == legacy / "TEST_M1"
 
     # _parse_dt
     def test_parse_dt_iso(self):
@@ -493,7 +479,6 @@ class TestPageGenerators:
             setup["proc_dir"],
             setup["out_dir"],
             False,
-            setup["tmp_path"],
         )
         pages = list((setup["out_dir"] / "instrument").glob("*.html"))
         assert len(pages) >= 1
@@ -517,7 +502,6 @@ class TestPageGenerators:
             setup["proc_dir"],
             setup["out_dir"],
             False,
-            setup["tmp_path"],
         )
         pages = list((setup["out_dir"] / "instrument").glob("*.html"))
         assert any("1234" in p.name for p in pages)
@@ -560,7 +544,6 @@ class TestPageGenerators:
             proc_dir,
             out_dir,
             False,
-            tmp_path,
         )
 
     # generate_stack_page

--- a/tests/unit/test_stage1.py
+++ b/tests/unit/test_stage1.py
@@ -2,7 +2,6 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
@@ -11,11 +10,7 @@ import yaml
 
 pytest.importorskip("seasenselib", reason="seasenselib not installed")
 
-from oceanarray.instrument.stage1 import (
-    MooringProcessor,
-    process_multiple_moorings,
-    stage1_mooring,
-)
+from oceanarray.instrument.stage1 import MooringProcessor
 
 pytestmark = pytest.mark.needs_seasenselib
 
@@ -34,7 +29,7 @@ class TestMooringProcessor:
         """Create a MooringProcessor instance for testing."""
         import logging
 
-        p = MooringProcessor(str(temp_dir))
+        p = MooringProcessor(raw_dir=str(temp_dir), proc_dir=str(temp_dir))
         yield p
         # Close any FileHandlers added to library loggers by _setup_logging so
         # Windows can delete the temp directory when the fixture tears down.
@@ -76,13 +71,14 @@ class TestMooringProcessor:
 
     def test_init(self, temp_dir):
         """Test MooringProcessor initialization."""
-        processor = MooringProcessor(str(temp_dir))
-        assert processor.base_dir == temp_dir
+        processor = MooringProcessor(raw_dir=str(temp_dir), proc_dir=str(temp_dir))
+        assert processor._proc_dir == temp_dir
+        assert processor._raw_dir == temp_dir
         assert processor.log_file is None
 
     def test_supported_file_types_completeness(self):
         """Test that SUPPORTED_FILE_TYPES contains expected format keys for seasenselib.read()."""
-        processor = MooringProcessor("/tmp")
+        processor = MooringProcessor(raw_dir="/tmp", proc_dir="/tmp")
         expected_types = [
             "sbe-cnv",
             "sbe-ascii",
@@ -279,50 +275,19 @@ class TestMooringProcessor:
         assert updated_ds.attrs["recovery_time"] == "YYYY-mm-ddTHH:MM:ss"
 
 
-class TestConvenienceFunctions:
-    """Test convenience functions."""
-
-    @patch("oceanarray.instrument.stage1.MooringProcessor")
-    def test_stage1_mooring(self, mock_processor_class):
-        """Test backwards compatibility function."""
-        mock_processor = Mock()
-        mock_processor.process_mooring.return_value = True
-        mock_processor_class.return_value = mock_processor
-
-        result = stage1_mooring("test_mooring", "/test/dir")
-
-        assert result is True
-        mock_processor_class.assert_called_once_with("/test/dir")
-        mock_processor.process_mooring.assert_called_once_with("test_mooring", None)
-
-    @patch("oceanarray.instrument.stage1.MooringProcessor")
-    def test_process_multiple_moorings(self, mock_processor_class):
-        """Test batch processing function."""
-        mock_processor = Mock()
-        mock_processor.process_mooring.side_effect = [True, False, True]
-        mock_processor_class.return_value = mock_processor
-
-        moorings = ["mooring1", "mooring2", "mooring3"]
-        results = process_multiple_moorings(moorings, "/test/dir")
-
-        expected = {"mooring1": True, "mooring2": False, "mooring3": True}
-        assert results == expected
-        assert mock_processor.process_mooring.call_count == 3
-
-
 class TestErrorHandling:
     """Test error handling scenarios."""
 
     def test_invalid_reader_type(self, tmp_path):
         """Test handling of invalid reader type."""
-        processor = MooringProcessor(str(tmp_path))
+        processor = MooringProcessor(raw_dir=str(tmp_path), proc_dir=str(tmp_path))
 
         with pytest.raises(ValueError, match="Unknown file type"):
             processor._read_file("invalid-type", "test.dat")
 
     def test_yaml_parsing_error(self, tmp_path):
         """Test handling of invalid YAML file."""
-        processor = MooringProcessor(str(tmp_path))
+        processor = MooringProcessor(raw_dir=str(tmp_path), proc_dir=str(tmp_path))
 
         invalid_yaml = tmp_path / "invalid.yaml"
         invalid_yaml.write_text("invalid: yaml: content: [")

--- a/tests/unit/test_stage2.py
+++ b/tests/unit/test_stage2.py
@@ -5,7 +5,6 @@ Version: 2.0 - Fixed clock offset tests with proper array comparison and immutab
 
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
@@ -18,8 +17,6 @@ from oceanarray.instrument.stage2 import (
     Stage2Processor,
     _parse_clock_str,
     detect_deployment_window,
-    process_multiple_moorings_stage2,
-    stage2_mooring,
 )
 
 pytestmark = pytest.mark.needs_seasenselib
@@ -37,7 +34,7 @@ class TestStage2Processor:
     @pytest.fixture
     def processor(self, temp_dir):
         """Create a Stage2Processor instance for testing."""
-        return Stage2Processor(str(temp_dir))
+        return Stage2Processor(proc_dir=str(temp_dir))
 
     @pytest.fixture
     def sample_yaml_data(self):
@@ -84,8 +81,8 @@ class TestStage2Processor:
 
     def test_init(self, temp_dir):
         """Test Stage2Processor initialization."""
-        processor = Stage2Processor(str(temp_dir))
-        assert processor.base_dir == temp_dir
+        processor = Stage2Processor(proc_dir=str(temp_dir))
+        assert processor._proc_dir == temp_dir
         assert processor.log_file is None
 
     def test_setup_logging(self, processor, temp_dir):
@@ -365,12 +362,12 @@ class TestErrorHandling:
 
     def test_invalid_yaml_file(self, tmp_path):
         """Test handling of invalid YAML file."""
-        processor = Stage2Processor(str(tmp_path))
+        processor = Stage2Processor(proc_dir=str(tmp_path))
 
-        proc_dir = tmp_path / "moor" / "proc" / "test_mooring"
-        proc_dir.mkdir(parents=True)
+        mooring_dir = tmp_path / "test_mooring"
+        mooring_dir.mkdir(parents=True)
 
-        invalid_yaml = proc_dir / "test_mooring.mooring.yaml"
+        invalid_yaml = mooring_dir / "test_mooring.mooring.yaml"
         invalid_yaml.write_text("invalid: yaml: content: [")
 
         result = processor.process_mooring("test_mooring")
@@ -378,41 +375,9 @@ class TestErrorHandling:
 
     def test_processing_directory_not_found(self, tmp_path):
         """Test handling when processing directory doesn't exist."""
-        processor = Stage2Processor(str(tmp_path))
+        processor = Stage2Processor(proc_dir=str(tmp_path))
         result = processor.process_mooring("nonexistent_mooring")
         assert result is False
-
-
-class TestConvenienceFunctions:
-    """Test convenience functions - Version 2.0."""
-
-    @patch("oceanarray.instrument.stage2.Stage2Processor")
-    def test_stage2_mooring(self, mock_processor_class):
-        """Test backwards compatibility function."""
-        mock_processor = Mock()
-        mock_processor.process_mooring.return_value = True
-        mock_processor_class.return_value = mock_processor
-
-        result = stage2_mooring("test_mooring", "/test/dir")
-
-        assert result is True
-        mock_processor_class.assert_called_once_with("/test/dir")
-        # stage2_mooring passes output_path as second arg (None by default)
-        mock_processor.process_mooring.assert_called_once_with("test_mooring", None)
-
-    @patch("oceanarray.instrument.stage2.Stage2Processor")
-    def test_process_multiple_moorings_stage2(self, mock_processor_class):
-        """Test batch processing function."""
-        mock_processor = Mock()
-        mock_processor.process_mooring.side_effect = [True, False, True]
-        mock_processor_class.return_value = mock_processor
-
-        moorings = ["mooring1", "mooring2", "mooring3"]
-        results = process_multiple_moorings_stage2(moorings, "/test/dir")
-
-        expected = {"mooring1": True, "mooring2": False, "mooring3": True}
-        assert results == expected
-        assert mock_processor.process_mooring.call_count == 3
 
 
 class TestParseClockStr:
@@ -476,7 +441,7 @@ class TestResolveClockDrift:
 
     @pytest.fixture
     def processor(self, tmp_path):
-        return Stage2Processor(str(tmp_path))
+        return Stage2Processor(proc_dir=str(tmp_path))
 
     def test_option_b_standard_iso_instrument_slow(self, processor):
         cfg = {

--- a/tests/unit/test_time_gridding.py
+++ b/tests/unit/test_time_gridding.py
@@ -82,7 +82,7 @@ class TestTimeGriddingProcessor:
     @pytest.fixture
     def processor(self, temp_dir):
         """Create a TimeGriddingProcessor instance for testing."""
-        return TimeGriddingProcessor(str(temp_dir))
+        return TimeGriddingProcessor(proc_dir=str(temp_dir))
 
     @pytest.fixture
     def sample_yaml_data(self):
@@ -121,8 +121,8 @@ class TestTimeGriddingProcessor:
 
     def test_init(self, temp_dir):
         """Test TimeGriddingProcessor initialization."""
-        processor = TimeGriddingProcessor(str(temp_dir))
-        assert processor.base_dir == temp_dir
+        processor = TimeGriddingProcessor(proc_dir=str(temp_dir))
+        assert processor._proc_dir == temp_dir
         assert processor.log_file is None
 
     def test_setup_logging(self, processor, temp_dir):
@@ -342,7 +342,7 @@ class TestConvenienceFunctions:
         result = time_gridding_mooring("test_mooring", "/test/dir", file_suffix="_use")
 
         assert result is True
-        mock_processor_class.assert_called_once_with("/test/dir")
+        mock_processor_class.assert_called_once_with(proc_dir="/test/dir")
 
     @patch("oceanarray.mooring.grid.TimeGriddingProcessor")
     def test_process_multiple_moorings_time_gridding(self, mock_processor_class):
@@ -366,32 +366,31 @@ class TestErrorHandling:
 
     def test_missing_config_file(self, tmp_path):
         """Test handling of missing configuration file."""
-        base_dir = tmp_path / "test_data"
-        proc_dir = base_dir / "moor" / "proc" / "test_mooring"
-        proc_dir.mkdir(parents=True)
+        proc_root = tmp_path / "test_data"
+        (proc_root / "test_mooring").mkdir(parents=True)
 
-        processor = TimeGriddingProcessor(str(base_dir))
+        processor = TimeGriddingProcessor(proc_dir=str(proc_root))
         result = processor.process_mooring("test_mooring")
 
         assert result is False
 
     def test_invalid_yaml_file(self, tmp_path):
         """Test handling of invalid YAML file."""
-        base_dir = tmp_path / "test_data"
-        proc_dir = base_dir / "moor" / "proc" / "test_mooring"
-        proc_dir.mkdir(parents=True)
+        proc_root = tmp_path / "test_data"
+        mooring_dir = proc_root / "test_mooring"
+        mooring_dir.mkdir(parents=True)
 
-        invalid_yaml = proc_dir / "test_mooring.mooring.yaml"
+        invalid_yaml = mooring_dir / "test_mooring.mooring.yaml"
         invalid_yaml.write_text("invalid: yaml: content: [")
 
-        processor = TimeGriddingProcessor(str(base_dir))
+        processor = TimeGriddingProcessor(proc_dir=str(proc_root))
         result = processor.process_mooring("test_mooring")
 
         assert result is False
 
     def test_processing_directory_not_found(self, tmp_path):
         """Test handling when processing directory doesn't exist."""
-        processor = TimeGriddingProcessor(str(tmp_path))
+        processor = TimeGriddingProcessor(proc_dir=str(tmp_path))
         result = processor.process_mooring("nonexistent_mooring")
 
         assert result is False


### PR DESCRIPTION

## Summary

Removes the deprecated `basedir` folder mode and the dual-layout (`proc` vs `moor/proc`) resolution logic that was copy-pasted across the pipeline. Path and filename derivation now lives in one place — `oceanarray/paths.py` — so each stage computes its read/write locations from a single source instead of its own copy.

Follows on from PR #51, which had already consolidated serial cleaning into `paths.safe_serial`.

## Breaking changes

- **`--basedir` is removed.** All subcommands now require `--proc-dir` (and `--raw-dir` for stage 1). Passing `--basedir` prints a migration message and exits 1 without processing. Scripts/aliases using `--basedir` must be updated.
- **The old `moor/proc` / `proc` directory layout is no longer supported.** Data must be in the mooring-first layout: `{proc-dir}/{mooring}/` and `{raw-dir}/{mooring}/{instrument}/`. Pointing `--proc-dir` at an old-layout tree raises a `LegacyLayoutError` naming the directory to use instead (see MIGRATION-BASEDIR.md).
- **Processor constructors are now keyword-only and required:** `MooringProcessor(*, raw_dir, proc_dir)`, `Stage2Processor(*, proc_dir)`, `Stage3Processor(*, proc_dir)`, `MooringStacker(*, proc_dir)`, `MooringGridder(*, proc_dir)`, `MooringReport(*, proc_dir, raw_dir=None, ...)`, `TimeGriddingProcessor(*, proc_dir)`. Any positional / `base_dir=` construction now raises `TypeError`.
- **Public functions removed:** `stage1_mooring`, `process_multiple_moorings`, `stage2_mooring`, `process_multiple_moorings_stage2`. Use the `oceanarray` CLI or construct the processors directly.
- **`time_gridding_mooring` / `process_multiple_moorings_time_gridding`:** second parameter renamed `basedir` → `proc_dir` and its meaning changed (it is now the proc root, not a cruise base dir). **Positional callers get different runtime behaviour with no error** — update call sites.
- **Report generators:** `generate_instrument_pages` dropped its `base_dir` positional parameter; `generate_grid_page` / `generate_stack_page` renamed `base_dir` → `display_root` (breaks keyword callers).
- **Internal helpers removed:** `mooring/helpers._get_proc_dir`, `report/_html_helpers._get_proc_dir`, `report/_html_helpers._raw_file_path`.

## Changes

### `paths.py` owns folder + filename derivation

- `mooring_proc_dir(proc_root, mooring)` → `proc_root/<mooring>`; `raw_mooring_dir(...)` (caller appends the instrument segment).
- `stage_output_name(mooring, serial, stage, tag="")` — owns the `{mooring}_{serial}{tag}_stage{N}.nc` pattern; cleans the serial via `safe_serial`.
- `require_current_layout(proc_root, mooring)` + `LegacyLayoutError` — "fail loudly": detects both removed legacy shapes (`moor/proc/<mooring>` and `proc/<mooring>`) and raises an error that names the directory to point `--proc-dir` at, instead of failing later with "no files found". Wired into every mooring command (`process`, `report`, `stack`, `grid`, `plot`, `animate`; `run` via its sub-dispatch); `main()` catches `LegacyLayoutError` and exits 1 with the message (no traceback).

### `--basedir` removed from the CLI

- Hidden from `--help` (`argparse.SUPPRESS`); when supplied, `_parse_dirs` exits with a migration message. No legacy processing mode runs. `--proc-dir` is required (and `--raw-dir` for stage 1); the silent cwd fallback is gone.
- `_parse_dirs` slimmed to a 2-tuple; `_resolve_basedir` / `_get_proc_root` deleted; `_print_report` takes the mooring proc dir directly; all `if legacy:` construction blocks collapsed; help text and examples updated.

### Every processor converted to `raw_dir`/`proc_dir`

- **stage1** (`MooringProcessor`), **stage2** (`Stage2Processor`), **stage3** (`Stage3Processor`), **stack** (`MooringStacker`), **grid** (`MooringGridder`), **report** (`MooringReport`) — all take the new dirs (required, keyword-only), route through `paths.mooring_proc_dir`, and drop `base_dir`/`_legacy`/dual-layout branches.
- **`report/_instrument.py`** — the live legacy raw-file-lookup branch removed; the unused `base_dir` parameter dropped.
- **`report/_stack.py` / `_grid.py`** — the `base_dir` param there was only a display root for `relative_to`, not layout logic; renamed to `display_root`.
- **`TimeGriddingProcessor`** (a second, purely-legacy class in `grid.py`, not wired into the CLI) converted to `proc_dir`; its two `time_gridding` convenience shims converted `basedir`→`proc_dir` (kept — they carry real filtering params, unlike the stage1/2 shims).

### Removed dead `basedir` API surface

- Module-level basedir-only "backwards compatibility" shims: `stage1_mooring`, `process_multiple_moorings`, `stage2_mooring`, `process_multiple_moorings_stage2` (referenced only by their own mock tests).
- The `if __name__ == "__main__":` demo blocks in stage1/stage2 that hardcoded a personal Dropbox path and a fixed mooring list.
- The dual-layout helpers `mooring/helpers._get_proc_dir`, `report/_html_helpers._get_proc_dir`, and `_html_helpers._raw_file_path`.
