### PR TITLE
[FIX] unify QC flags onto the OceanSITES table

### DIFF
--- a/oceanarray/config/parameters.py
+++ b/oceanarray/config/parameters.py
@@ -106,6 +106,15 @@ QC_FLAG_MEANINGS = (
 # (5, 6 — not used in OceanSITES) fall back to priority 0.
 QC_MERGE_PRIORITY = {9: 7, 4: 6, 3: 5, 8: 4, 7: 3, 2: 2, 1: 1, 0: 0}
 
+# Precomputed lookup arrays (immutable; built once at import) so the merge
+# functions and flag-attr writers don't rebuild them on every call.
+# QC_MERGE_PRIORITY_LUT[flag] gives the merge priority for flags 0-9.
+QC_MERGE_PRIORITY_LUT = np.array(
+    [QC_MERGE_PRIORITY.get(f, 0) for f in range(10)], dtype="int8"
+)
+# flag_values as int8 (CF wants it to match the int8 flag variable dtype).
+QC_FLAG_VALUES_I8 = np.array(QC_FLAG_VALUES, dtype="int8")
+
 # ---------------------------------------------------------------------------
 # QARTOD gross-range test thresholds (global ocean defaults).
 #

--- a/oceanarray/config/parameters.py
+++ b/oceanarray/config/parameters.py
@@ -86,11 +86,13 @@ INSTRUMENT_COLORS = {
 # Applied to *_qc companion variables in _stage2.nc and stage 3 output.
 # ---------------------------------------------------------------------------
 QC_CONVENTION = "OceanSITES reference table 2"
-QC_FLAG_VALUES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+# Codes 5 (value_changed) and 6 are "not used" in OceanSITES table 2, so they are
+# omitted here — declaring them legal invites flags nothing downstream understands.
+# flag_meanings words correspond position-for-position with flag_values.
+QC_FLAG_VALUES = [0, 1, 2, 3, 4, 7, 8, 9]
 QC_FLAG_MEANINGS = (
-    "no_qc_performed good_data probably_good_data probably_bad_data "
-    "bad_data value_changed not_in_use nominal_value "
-    "interpolated_value missing_value"
+    "unknown good_data probably_good_data potentially_correctable_bad_data "
+    "bad_data nominal_value interpolated_value missing_value"
 )
 
 # ---------------------------------------------------------------------------

--- a/oceanarray/config/parameters.py
+++ b/oceanarray/config/parameters.py
@@ -95,6 +95,17 @@ QC_FLAG_MEANINGS = (
     "bad_data nominal_value interpolated_value missing_value"
 )
 
+# Merge priority for combining two QC flags (worst wins). The single source of
+# truth for flag ordering — both instrument.qc._merge_flags and
+# mooring.helpers._worst_flag derive their lookup arrays from this dict.
+# Weakest to strongest:
+#   unknown(0) < good(1) < probably_good(2) < nominal(7) < interpolated(8)
+#   < potentially_correctable_bad(3) < bad(4) < missing(9)
+# unknown(0) is the weakest (opposite of QARTOD, which ranks its UNKNOWN=2 above
+# GOOD): a point reads unknown only when nothing evaluated it. Unlisted codes
+# (5, 6 — not used in OceanSITES) fall back to priority 0.
+QC_MERGE_PRIORITY = {9: 7, 4: 6, 3: 5, 8: 4, 7: 3, 2: 2, 1: 1, 0: 0}
+
 # ---------------------------------------------------------------------------
 # QARTOD gross-range test thresholds (global ocean defaults).
 #

--- a/oceanarray/instrument/coordinate.py
+++ b/oceanarray/instrument/coordinate.py
@@ -343,7 +343,6 @@ def apply_adcp_seabed_qc(
     ds: xr.Dataset,
     water_depth_m: float,
     lat: float,
-    qc_attrs: Dict[str, Any],
     fail_margin_m: float = 20.0,
     log_fn: Any = None,
 ) -> xr.Dataset:
@@ -374,8 +373,6 @@ def apply_adcp_seabed_qc(
         If ≤ 0 the function is a no-op.
     lat : float
         Mooring latitude in decimal degrees, used by ``gsw.p_from_z``.
-    qc_attrs : dict
-        OceanSITES flag attribute dict written to ``seabed_qc``.
     fail_margin_m : float
         Margin below the seabed (in metres) that separates suspect (3) from bad (4).
         Default 20 m.  Bins between 0 and *fail_margin_m* below the seabed receive
@@ -426,7 +423,6 @@ def apply_adcp_seabed_qc(
                 f"(p={p_fail:.1f} dbar): flag 4 (bad). "
                 "Standalone — not merged into velocity_qc."
             ),
-            **qc_attrs,
         },
     )
 
@@ -443,7 +439,6 @@ def apply_adcp_seabed_qc(
 def apply_adcp_surface_qc(
     ds: xr.Dataset,
     lat: float,
-    qc_attrs: Dict[str, Any],
     suspect_margin_m: float = 20.0,
     log_fn: Any = None,
 ) -> xr.Dataset:
@@ -472,8 +467,6 @@ def apply_adcp_surface_qc(
         Stage 3 ADCP dataset containing ``bin_pressure(time, N_BINS)`` in dbar.
     lat : float
         Mooring latitude in decimal degrees, used by ``gsw.p_from_z``.
-    qc_attrs : dict
-        OceanSITES flag attribute dict written to ``surface_qc``.
     suspect_margin_m : float
         Depth (m) below the surface that defines the suspect zone.  Bins with
         0 < bin_pressure < p_from_z(-suspect_margin_m) receive flag 3; bins
@@ -517,7 +510,6 @@ def apply_adcp_surface_qc(
                 f"bins at or above surface (bin_pressure ≤ 0 dbar): flag 4 (bad). "
                 "Standalone — not merged into velocity_qc."
             ),
-            **qc_attrs,
         },
     )
 
@@ -535,7 +527,6 @@ def apply_adcp_velocity_qc(
     prcnt_gd_bad: float,
     prcnt_gd_suspect: float,
     error_vel_threshold: float,
-    qc_attrs: Dict[str, Any],
     log_fn: Any = None,
 ) -> xr.Dataset:
     """Apply QC to ADCP 2D velocity variables (time × N_BINS).
@@ -600,8 +591,6 @@ def apply_adcp_velocity_qc(
         (suspect). Percent.
     error_vel_threshold : float
         |error_velocity| above this → flag 4 (bad). m s⁻¹.
-    qc_attrs : dict
-        OceanSITES flag attribute dict written to every ``*_qc`` variable.
     log_fn : callable, optional
         Logging callback.
 
@@ -653,7 +642,6 @@ def apply_adcp_velocity_qc(
             flags,
             attrs={
                 "long_name": f"quality flag for {varname}",
-                **qc_attrs,
                 **threshold_attrs,
             },
         )
@@ -698,7 +686,6 @@ def apply_adcp_velocity_qc(
                     f"bad<{prcnt_gd_bad}%, suspect<{prcnt_gd_suspect}%. "
                     "Standalone — not merged into velocity_qc."
                 ),
-                **qc_attrs,
             },
         )
 
@@ -726,7 +713,6 @@ def apply_adcp_velocity_qc(
                     "Standalone — not merged into velocity_qc."
                 ),
                 "qc_threshold_fail_m_s": float(error_vel_threshold),
-                **qc_attrs,
             },
         )
 

--- a/oceanarray/instrument/pressure.py
+++ b/oceanarray/instrument/pressure.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import xarray as xr
 
+from oceanarray.instrument.qc import set_qc_attrs
+
 
 HAB_THRESHOLD = 2.0  # metres — use near-neighbour below this Δhab
 
@@ -165,7 +167,6 @@ def interpolate_pressure(
     sources: List[Dict[str, Any]],
     target_time: np.ndarray,
     pressure_bad_flag: bool,
-    qc_attrs: Dict[str, Any],
     log_fn: Optional[Any] = None,
 ) -> tuple[xr.Dataset, str]:
     """Interpolate pressure from sources onto target; return (ds, method_str).
@@ -201,8 +202,6 @@ def interpolate_pressure(
     pressure_bad_flag : bool
         When True, the original pressure is preserved as ``pressure_orig``
         and ``pressure_orig_qc`` before being replaced.
-    qc_attrs : dict
-        OceanSITES flag attribute dict written to ``pressure_qc``.
     log_fn : callable, optional
         Logging callback.
 
@@ -271,8 +270,12 @@ def interpolate_pressure(
         ds["pressure_orig_qc"] = xr.Variable(
             "time",
             np.full(len(ds["time"]), pressure_qc_val, dtype=np.int8),
-            attrs={"long_name": "quality flag for pressure_orig", **qc_attrs},
+            attrs={"long_name": "quality flag for pressure_orig"},
         )
+        # pressure_orig_qc is excluded from the stage3 flag-attr sweep (it keeps the
+        # pre-interpolation flag, kept distinct from the interpolated pressure_qc),
+        # so attach its OceanSITES flag attributes here.
+        set_qc_attrs(ds, "pressure_orig")
         ds = ds.drop_vars("pressure")
 
     ds["pressure"] = xr.Variable(
@@ -289,7 +292,7 @@ def interpolate_pressure(
     ds["pressure_qc"] = xr.Variable(
         "time",
         np.full(len(ds["time"]), 8, dtype=np.int8),
-        attrs={"long_name": "quality flag for pressure", **qc_attrs},
+        attrs={"long_name": "quality flag for pressure"},
     )
     return ds, method
 

--- a/oceanarray/instrument/qc.py
+++ b/oceanarray/instrument/qc.py
@@ -80,9 +80,8 @@ def _merge_flags(*flag_arrays: np.ndarray) -> np.ndarray:
     Returns element-wise flag with highest priority (worst quality).
     Works on arrays of any shape (1-D time series or 2-D time×N_BINS).
     """
-    # Lookup table priority[flag] for flags 0-9, derived from _QC_PRIORITY so the
-    # ordering lives in exactly one place; unlisted flags (5, 6) → 0.
-    _priority = np.array([_QC_PRIORITY.get(f, 0) for f in range(10)], dtype=np.int8)
+    # priority[flag] for flags 0-9, from the shared single-source LUT.
+    _priority = P.QC_MERGE_PRIORITY_LUT
     result = np.asarray(flag_arrays[0], dtype=np.int8).copy()
     for fa in flag_arrays[1:]:
         fa = np.asarray(fa, dtype=np.int8)
@@ -107,7 +106,8 @@ def _ingest_qartod(result: Any) -> np.ndarray:
         arr = np.asarray(result, dtype=float)
         flags = np.where(np.isnan(arr), 9, arr)
     flags = np.asarray(flags).astype(np.int8)
-    return np.where(flags == 2, np.int8(0), flags).astype(np.int8)
+    # np.where over an int8 array and an int8 scalar is already int8.
+    return np.where(flags == 2, np.int8(0), flags)
 
 
 def set_qc_attrs(
@@ -139,8 +139,7 @@ def set_qc_attrs(
 
     """
     attrs: Dict[str, Any] = {
-        "long_name": f"quality flag for {var}",
-        "flag_values": np.array(P.QC_FLAG_VALUES, dtype="int8"),
+        "flag_values": P.QC_FLAG_VALUES_I8,
         "flag_meanings": P.QC_FLAG_MEANINGS,
         "conventions": P.QC_CONVENTION,
     }
@@ -149,7 +148,11 @@ def set_qc_attrs(
         attrs["standard_name"] = f"{std} status_flag"
     if extra:
         attrs.update(extra)
-    ds[f"{var}_qc"].attrs.update(attrs)
+    qc = ds[f"{var}_qc"]
+    qc.attrs.update(attrs)
+    # Preserve an author-supplied long_name (e.g. a standalone diagnostic flag
+    # like seabed_qc); only fill it when absent.
+    qc.attrs.setdefault("long_name", f"quality flag for {var}")
     return ds
 
 

--- a/oceanarray/instrument/qc.py
+++ b/oceanarray/instrument/qc.py
@@ -8,15 +8,12 @@ from typing import Any, Dict, Optional
 import numpy as np
 import xarray as xr
 
+from oceanarray import parameters as P
 
-# Priority order for merging QC flags (higher priority wins = worse quality).
-# OceanSITES table 2, weakest to strongest:
-#   unknown(0) < good(1) < probably_good(2) < nominal(7) < interpolated(8)
-#   < potentially_correctable_bad(3) < bad(4) < missing(9)
-# Note unknown(0) is the *weakest* here (opposite of QARTOD, which ranks its
-# UNKNOWN=2 above GOOD): a point reads unknown only when nothing evaluated it.
-# Flag 7 (nominal_value) has no producer yet; it is slotted for completeness.
-_QC_PRIORITY: Dict[int, int] = {9: 7, 4: 6, 3: 5, 8: 4, 7: 3, 2: 2, 1: 1, 0: 0}
+# Merge priority for combining QC flags (higher priority wins = worse quality).
+# Single source of truth: parameters.QC_MERGE_PRIORITY, shared with
+# mooring.helpers._worst_flag so the two merge paths cannot drift.
+_QC_PRIORITY: Dict[int, int] = P.QC_MERGE_PRIORITY
 
 # CF standard names and canonical long_names for known physics variables.
 # Applied as a normalization pass just before writing _stage3.nc so that all
@@ -141,8 +138,6 @@ def set_qc_attrs(
         *ds*, modified in place.
 
     """
-    from oceanarray import parameters as P
-
     attrs: Dict[str, Any] = {
         "long_name": f"quality flag for {var}",
         "flag_values": np.array(P.QC_FLAG_VALUES, dtype="int8"),
@@ -215,8 +210,6 @@ def load_qc_config(
     ``tilt`` is stripped from the gross-range dict before returning so it is
     not passed to the QARTOD gross-range test runner.
     """
-    from oceanarray import parameters as P
-
     gr = copy.deepcopy(P.QC_GROSS_RANGE)
     sp = copy.deepcopy(P.QC_SPIKE)
     tilt = copy.deepcopy(P.QC_TILT)

--- a/oceanarray/instrument/qc.py
+++ b/oceanarray/instrument/qc.py
@@ -250,7 +250,6 @@ def load_qc_config(
 def apply_tilt_qc(
     ds: xr.Dataset,
     tilt_cfg: Dict[str, Any],
-    qc_attrs: Dict[str, Any],
 ) -> tuple[xr.Dataset, int, int]:
     """Flag velocity variables when pitch or roll exceeds QC thresholds.
 
@@ -352,7 +351,7 @@ def apply_tilt_qc(
         ds[qc_varname] = xr.Variable(
             ds[varname].dims,
             new_flags,
-            attrs={"long_name": f"quality flag for {varname}", **qc_attrs},
+            attrs={"long_name": f"quality flag for {varname}"},
         )
 
     return ds, n_suspect, n_bad
@@ -428,7 +427,6 @@ def compute_salinity_data(
 
 def merge_salinity_parent_qc(
     ds: xr.Dataset,
-    qc_attrs: Dict[str, Any],
 ) -> xr.Dataset:
     """Merge parent (T/C/P) QC flags into salinity_qc after QC tests have run.
 
@@ -471,7 +469,6 @@ def merge_salinity_parent_qc(
             **existing_attrs,
             "long_name": "quality flag for salinity",
             "comment": "QARTOD gross-range + worst of T/C/P parent flags",
-            **qc_attrs,
         },
     )
     return ds
@@ -481,7 +478,6 @@ def apply_qc_tests(
     ds: xr.Dataset,
     gross_range: Dict[str, Any],
     spike: Dict[str, Any],
-    qc_attrs: Dict[str, Any],
     flat_line: Optional[Dict[str, Any]] = None,
 ) -> xr.Dataset:
     """Apply QARTOD gross-range, spike, and flat-line tests, writing ``*_qc`` variables.
@@ -636,7 +632,6 @@ def apply_qc_tests(
             new_flags,
             attrs={
                 "long_name": f"quality flag for {varname}",
-                **qc_attrs,
                 **threshold_attrs,
             },
         )
@@ -647,7 +642,6 @@ def apply_qc_tests(
 def apply_enu_velocity_qc(
     ds: xr.Dataset,
     gr_cfg: Dict[str, Any],
-    qc_attrs: Dict[str, Any],
 ) -> xr.Dataset:
     """Apply QARTOD gross-range QC to ENU velocity vars and propagate w flags.
 
@@ -667,7 +661,7 @@ def apply_enu_velocity_qc(
         if k in ("east_velocity", "north_velocity", "up_velocity")
     }
     if enu_gr:
-        ds = apply_qc_tests(ds, enu_gr, {}, qc_attrs)
+        ds = apply_qc_tests(ds, enu_gr, {})
 
     if "up_velocity_qc" in ds.data_vars:
         up_flags = ds["up_velocity_qc"].values.astype(np.int8)

--- a/oceanarray/instrument/qc.py
+++ b/oceanarray/instrument/qc.py
@@ -9,9 +9,14 @@ import numpy as np
 import xarray as xr
 
 
-# Priority order for merging QC flags (higher priority = worse data quality).
-# 9=missing, 4=bad, 3=suspect, 8=interpolated, 2=prob-good, 1=good
-_QC_PRIORITY: Dict[int, int] = {9: 6, 4: 5, 3: 4, 8: 3, 2: 2, 1: 1, 0: 0}
+# Priority order for merging QC flags (higher priority wins = worse quality).
+# OceanSITES table 2, weakest to strongest:
+#   unknown(0) < good(1) < probably_good(2) < nominal(7) < interpolated(8)
+#   < potentially_correctable_bad(3) < bad(4) < missing(9)
+# Note unknown(0) is the *weakest* here (opposite of QARTOD, which ranks its
+# UNKNOWN=2 above GOOD): a point reads unknown only when nothing evaluated it.
+# Flag 7 (nominal_value) has no producer yet; it is slotted for completeness.
+_QC_PRIORITY: Dict[int, int] = {9: 7, 4: 6, 3: 5, 8: 4, 7: 3, 2: 2, 1: 1, 0: 0}
 
 # CF standard names and canonical long_names for known physics variables.
 # Applied as a normalization pass just before writing _stage3.nc so that all
@@ -78,15 +83,79 @@ def _merge_flags(*flag_arrays: np.ndarray) -> np.ndarray:
     Returns element-wise flag with highest priority (worst quality).
     Works on arrays of any shape (1-D time series or 2-D time×N_BINS).
     """
-    # Lookup table: priority[flag] for flags 0-9
-    # _QC_PRIORITY: {9:6, 4:5, 3:4, 8:3, 2:2, 1:1, 0:0}; unlisted flags → 0
-    _priority = np.array([0, 1, 2, 4, 5, 0, 0, 0, 3, 6], dtype=np.int8)
+    # Lookup table priority[flag] for flags 0-9, derived from _QC_PRIORITY so the
+    # ordering lives in exactly one place; unlisted flags (5, 6) → 0.
+    _priority = np.array([_QC_PRIORITY.get(f, 0) for f in range(10)], dtype=np.int8)
     result = np.asarray(flag_arrays[0], dtype=np.int8).copy()
     for fa in flag_arrays[1:]:
         fa = np.asarray(fa, dtype=np.int8)
         replace = _priority[fa.clip(0, 9)] > _priority[result.clip(0, 9)]
         result = np.where(replace, fa, result).astype(np.int8)
     return result
+
+
+def _ingest_qartod(result: Any) -> np.ndarray:
+    """Normalise one ioos_qc test result onto the OceanSITES flag table.
+
+    Folds the three steps every QARTOD test needs into one place: fill missing
+    entries with 9 (handling both ioos_qc return types — a masked array or a
+    plain ndarray, depending on version), cast to int8, and remap QARTOD
+    ``UNKNOWN(2)`` — "could not evaluate", e.g. ``spike_test`` at a record edge or
+    beside a gap — to OceanSITES ``unknown(0)``. Applied *before* merging, so a
+    point a test could not evaluate never asserts ``probably_good_data(2)``.
+    """
+    if hasattr(result, "filled"):
+        flags = result.filled(9)
+    else:
+        arr = np.asarray(result, dtype=float)
+        flags = np.where(np.isnan(arr), 9, arr)
+    flags = np.asarray(flags).astype(np.int8)
+    return np.where(flags == 2, np.int8(0), flags).astype(np.int8)
+
+
+def set_qc_attrs(
+    ds: xr.Dataset, var: str, extra: Optional[Dict[str, Any]] = None
+) -> xr.Dataset:
+    """Attach the OceanSITES flag attributes to ``{var}_qc`` in place.
+
+    The single owner of QC-flag metadata: call this wherever a ``_qc`` variable
+    is created or updated so the CF flag attributes cannot be forgotten. The flag
+    table is sourced from :mod:`oceanarray.parameters` (one source of truth) and
+    the full legal set is declared, not only the values present. The status-flag
+    ``standard_name`` (``"{parent} status_flag"``) is attached only when the parent
+    variable has a ``standard_name`` — it is skipped, never fabricated, when the
+    parent has none (``standard_name`` is an optional CF attribute).
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing both ``var`` and its ``{var}_qc`` companion.
+    var : str
+        Name of the data variable whose ``_qc`` companion is annotated.
+    extra : dict of str to Any, optional
+        Additional attributes to attach (e.g. QC threshold provenance).
+
+    Returns
+    -------
+    xarray.Dataset
+        *ds*, modified in place.
+
+    """
+    from oceanarray import parameters as P
+
+    attrs: Dict[str, Any] = {
+        "long_name": f"quality flag for {var}",
+        "flag_values": np.array(P.QC_FLAG_VALUES, dtype="int8"),
+        "flag_meanings": P.QC_FLAG_MEANINGS,
+        "conventions": P.QC_CONVENTION,
+    }
+    std = ds[var].attrs.get("standard_name") if var in ds.variables else None
+    if std:
+        attrs["standard_name"] = f"{std} status_flag"
+    if extra:
+        attrs.update(extra)
+    ds[f"{var}_qc"].attrs.update(attrs)
+    return ds
 
 
 def _deep_merge(base: Dict, override: Dict) -> Dict:
@@ -466,29 +535,27 @@ def apply_qc_tests(
 
         if varname in gross_range:
             cfg = gross_range[varname]
-            gr_flags = (
-                qartod.gross_range_test(
-                    inp=data,
-                    fail_span=tuple(cfg["fail_span"]),
-                    suspect_span=tuple(cfg.get("suspect_span", cfg["fail_span"])),
+            flags_list.append(
+                _ingest_qartod(
+                    qartod.gross_range_test(
+                        inp=data,
+                        fail_span=tuple(cfg["fail_span"]),
+                        suspect_span=tuple(cfg.get("suspect_span", cfg["fail_span"])),
+                    )
                 )
-                .filled(9)
-                .astype(np.int8)
             )
-            flags_list.append(gr_flags)
 
         if varname in spike:
             cfg = spike[varname]
-            sp_flags = (
-                qartod.spike_test(
-                    inp=data,
-                    suspect_threshold=cfg.get("suspect_threshold"),
-                    fail_threshold=cfg.get("fail_threshold"),
+            flags_list.append(
+                _ingest_qartod(
+                    qartod.spike_test(
+                        inp=data,
+                        suspect_threshold=cfg.get("suspect_threshold"),
+                        fail_threshold=cfg.get("fail_threshold"),
+                    )
                 )
-                .filled(9)
-                .astype(np.int8)
             )
-            flags_list.append(sp_flags)
 
         if varname in _flat and "time" in ds:
             fl_cfg = _flat[varname]
@@ -527,14 +594,7 @@ def apply_qc_tests(
                     stacklevel=2,
                 )
                 continue
-            # flat_line_test may return a masked array or plain ndarray depending
-            # on the ioos_qc version; handle both.
-            fl_flags = (
-                _fl_result.filled(9)
-                if hasattr(_fl_result, "filled")
-                else np.where(np.isnan(_fl_result.astype(float)), 9, _fl_result)
-            ).astype(np.int8)
-            flags_list.append(fl_flags)
+            flags_list.append(_ingest_qartod(_fl_result))
 
         new_flags = _merge_flags(*flags_list)
 

--- a/oceanarray/instrument/stage3.py
+++ b/oceanarray/instrument/stage3.py
@@ -660,6 +660,23 @@ class Stage3Processor:
             existing = ds.attrs.get("history", "")
             ds.attrs["history"] = f"{existing}; {entry}" if existing else entry
 
+            # Record the QC treatment so it can be reconstructed from the output
+            # file alone: the flag convention, the worst-wins merge ordering, and
+            # the QARTOD -> OceanSITES ingest remap applied to every _qc variable.
+            from oceanarray import parameters as P
+
+            _priority_order = " < ".join(
+                str(f)
+                for f, _ in sorted(P.QC_MERGE_PRIORITY.items(), key=lambda kv: kv[1])
+            )
+            ds.attrs["qc_flag_convention"] = P.QC_CONVENTION
+            ds.attrs["qc_merge_rule"] = (
+                "worst flag wins; priority weakest to strongest: " + _priority_order
+            )
+            ds.attrs["qc_ingest_remap"] = (
+                "QARTOD not_evaluated(2) -> OceanSITES unknown(0) at test ingest"
+            )
+
             # Derive O2 % saturation and AOU when dissolved_oxygen + T/S/P are present.
             ds = derive_oxygen_saturation(ds)
 
@@ -674,7 +691,14 @@ class Stage3Processor:
             # Normalize every _qc variable onto the OceanSITES flag table (single
             # source of truth) and attach the status_flag standard_name — done
             # after the CF pass above so each parent's standard_name is available.
-            for _qv in [v for v in ds.data_vars if v.endswith("_qc")]:
+            # Skip *_orig_qc: those preserve the pre-interpolation flag (e.g. a bad
+            # original pressure = 4) and must stay distinct from the interpolated
+            # {var}_qc (e.g. 8), so they keep their own attrs.
+            for _qv in [
+                v
+                for v in ds.data_vars
+                if v.endswith("_qc") and not v.endswith("_orig_qc")
+            ]:
                 set_qc_attrs(ds, _qv[:-3])
 
             ds = drop_all_zero_vars(ds, ["amplitude_beam", "analog_input_"])

--- a/oceanarray/instrument/stage3.py
+++ b/oceanarray/instrument/stage3.py
@@ -72,6 +72,7 @@ from oceanarray.instrument.qc import (
     ensure_conductivity_units,
     load_qc_config,
     merge_salinity_parent_qc,
+    set_qc_attrs,
     unify_velocity_qc,
 )
 from oceanarray.instrument.coordinate import (
@@ -669,6 +670,12 @@ class Stage3Processor:
                     for _k, _v in _cf.items():
                         if _k not in ds[_vname].attrs:
                             ds[_vname].attrs[_k] = _v
+
+            # Normalize every _qc variable onto the OceanSITES flag table (single
+            # source of truth) and attach the status_flag standard_name — done
+            # after the CF pass above so each parent's standard_name is available.
+            for _qv in [v for v in ds.data_vars if v.endswith("_qc")]:
+                set_qc_attrs(ds, _qv[:-3])
 
             ds = drop_all_zero_vars(ds, ["amplitude_beam", "analog_input_"])
             cast_output_dtypes(ds).to_netcdf(l3_path)

--- a/oceanarray/instrument/stage3.py
+++ b/oceanarray/instrument/stage3.py
@@ -334,19 +334,9 @@ class Stage3Processor:
                 src["ds"] = None
 
         # ── Process every instrument ────────────────────────────────────
-        from oceanarray import parameters as P
-
-        _qc_attrs = {
-            "flag_values": P.QC_FLAG_VALUES,
-            "flag_meanings": P.QC_FLAG_MEANINGS,
-            "conventions": P.QC_CONVENTION,
-        }
-
         success_count = 0
         for info in instruments:
-            ok = self._process_instrument(
-                info, sources, targets, _qc_attrs, force=force
-            )
+            ok = self._process_instrument(info, sources, targets, force=force)
             if ok:
                 success_count += 1
 
@@ -370,7 +360,6 @@ class Stage3Processor:
         info: Dict[str, Any],
         sources: List[Dict[str, Any]],
         targets: List[Dict[str, Any]],
-        qc_attrs: Dict[str, Any],
         force: bool = False,
     ) -> bool:
         """Apply Stage 3 processing to one instrument's Stage 2 NetCDF.
@@ -381,7 +370,7 @@ class Stage3Processor:
            have pressure interpolated from *sources* (neighbours on the mooring).
         2. Conductivity unit normalisation and practical salinity computation
            (CTD/microcat instruments only).
-        3. QARTOD QC tests (gross-range, spike) using thresholds from *qc_attrs*.
+        3. QARTOD QC tests (gross-range, spike) using thresholds from the config.
         4. BEAM→ENU or XYZ→ENU coordinate transformation with magnetic declination
            correction (current meters / Aquadopp).
         5. Tilt QC — velocity flagged suspect/bad when pitch or roll exceed
@@ -442,7 +431,6 @@ class Stage3Processor:
                     sources,
                     target_time,
                     pressure_bad_flag,
-                    qc_attrs,
                     log_fn=self._log,
                 )
                 history_notes.append(
@@ -465,11 +453,9 @@ class Stage3Processor:
             if is_adcp:
                 _ENU_KEYS = {"east_velocity", "north_velocity", "up_velocity"}
                 gr_cfg_scalar = {k: v for k, v in gr_cfg.items() if k not in _ENU_KEYS}
-                ds = apply_qc_tests(
-                    ds, gr_cfg_scalar, sp_cfg, qc_attrs, flat_line=fl_cfg
-                )
+                ds = apply_qc_tests(ds, gr_cfg_scalar, sp_cfg, flat_line=fl_cfg)
             else:
-                ds = apply_qc_tests(ds, gr_cfg, sp_cfg, qc_attrs, flat_line=fl_cfg)
+                ds = apply_qc_tests(ds, gr_cfg, sp_cfg, flat_line=fl_cfg)
 
             # ── Post-QC pressure check ─────────────────────────────────
             # If QC (e.g. flat-line test) just flagged ALL pressure values as
@@ -517,7 +503,6 @@ class Stage3Processor:
                             _other_sources,
                             target_time,
                             pressure_bad_flag=True,
-                            qc_attrs=qc_attrs,
                             log_fn=self._log,
                         )
                         history_notes.append(
@@ -532,7 +517,7 @@ class Stage3Processor:
                         )
 
             # ── Fold T/C/P parent QC into salinity_qc ─────────────────
-            ds = merge_salinity_parent_qc(ds, qc_attrs)
+            ds = merge_salinity_parent_qc(ds)
 
             # ── BEAM / XYZ → ENU coordinate transform ─────────────────
             # Must run before tilt QC so east/north/up_velocity exist to be flagged.
@@ -566,7 +551,6 @@ class Stage3Processor:
                         prcnt_gd_bad=adcp_qc["percent_good_bad"],
                         prcnt_gd_suspect=adcp_qc["percent_good_suspect"],
                         error_vel_threshold=adcp_qc["error_velocity_threshold"],
-                        qc_attrs=qc_attrs,
                         log_fn=self._log,
                     )
                     ds = compute_adcp_bin_pressure(ds, info["lat"], log_fn=self._log)
@@ -574,17 +558,15 @@ class Stage3Processor:
                         ds,
                         water_depth_m=info.get("water_depth_m", 0.0),
                         lat=info["lat"],
-                        qc_attrs=qc_attrs,
                         log_fn=self._log,
                     )
                     ds = apply_adcp_surface_qc(
                         ds,
                         lat=info["lat"],
-                        qc_attrs=qc_attrs,
                         log_fn=self._log,
                     )
                 else:
-                    ds = apply_enu_velocity_qc(ds, gr_cfg, qc_attrs)
+                    ds = apply_enu_velocity_qc(ds, gr_cfg)
 
             # ── Tilt QC ────────────────────────────────────────────────
             # Flags all velocity variables when pitch+roll tilt exceeds threshold.
@@ -598,7 +580,7 @@ class Stage3Processor:
                     "tilt QC skipped for ADCP (percent_good+error_velocity QC applied instead)"
                 )
             else:
-                ds, n_tilt_susp, n_tilt_bad = apply_tilt_qc(ds, tilt_cfg, qc_attrs)
+                ds, n_tilt_susp, n_tilt_bad = apply_tilt_qc(ds, tilt_cfg)
                 if n_tilt_susp or n_tilt_bad:
                     history_notes.append(
                         f"tilt QC (tilt≥{tilt_cfg['suspect_threshold']}°→suspect, "

--- a/oceanarray/mooring/helpers.py
+++ b/oceanarray/mooring/helpers.py
@@ -111,10 +111,8 @@ def _worst_flag(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     NaN inputs are treated as flag 9 (missing value) so that levels with no
     data are never silently promoted to flag 0 ("unknown").
     """
-    # rank[flag_value] gives priority; higher rank = worse flag
-    _rank = np.array(
-        [P.QC_MERGE_PRIORITY.get(f, 0) for f in range(10)], dtype=np.int8
-    )
+    # rank[flag_value] gives priority; higher rank = worse flag (shared LUT).
+    _rank = P.QC_MERGE_PRIORITY_LUT
     a = np.where(np.isfinite(a), a, 9.0)
     b = np.where(np.isfinite(b), b, 9.0)
     ai = np.clip(np.round(a).astype(np.int8), 0, 9)

--- a/oceanarray/mooring/helpers.py
+++ b/oceanarray/mooring/helpers.py
@@ -102,13 +102,19 @@ def _apply_qc_mask(src_v: np.ndarray, ds: "xr.Dataset", vname: str) -> np.ndarra
 
 
 def _worst_flag(a: np.ndarray, b: np.ndarray) -> np.ndarray:
-    """Element-wise worst QC flag (9 > 4 > 3 > 8 > 2 > 1 > 0).
+    """Element-wise worst QC flag on the OceanSITES priority ordering.
 
+    Worst-wins using ``parameters.QC_MERGE_PRIORITY`` (weakest to strongest:
+    ``unknown(0) < good(1) < probably_good(2) < nominal(7) < interpolated(8)
+    < potentially_correctable_bad(3) < bad(4) < missing(9)``) — the same table
+    ``instrument.qc._merge_flags`` uses, so the two merge paths cannot drift.
     NaN inputs are treated as flag 9 (missing value) so that levels with no
-    data are never silently promoted to flag 0 ("no QC performed").
+    data are never silently promoted to flag 0 ("unknown").
     """
     # rank[flag_value] gives priority; higher rank = worse flag
-    _rank = np.array([0, 1, 2, 4, 5, 6, 6, 6, 3, 7], dtype=np.int8)
+    _rank = np.array(
+        [P.QC_MERGE_PRIORITY.get(f, 0) for f in range(10)], dtype=np.int8
+    )
     a = np.where(np.isfinite(a), a, 9.0)
     b = np.where(np.isfinite(b), b, 9.0)
     ai = np.clip(np.round(a).astype(np.int8), 0, 9)

--- a/oceanarray/mooring/stack.py
+++ b/oceanarray/mooring/stack.py
@@ -490,14 +490,12 @@ class MooringStacker:
                     {
                         "long_name": "Combined velocity QC flag (worst of east/north/up)",
                         "comment": (
-                            "OceanSITES flag: 1=good, 2=prob_good, 3=suspect, 4=bad, "
-                            "9=missing.  Apply to east/north/up_velocity before use."
+                            "Worst OceanSITES flag across east/north/up_velocity; "
+                            "apply to the velocity components before use."
                         ),
-                        "flag_values": "0 1 2 3 4 9",
-                        "flag_meanings": (
-                            "no_qc_performed good_data probably_good_data "
-                            "probably_bad_data bad_data missing_value"
-                        ),
+                        "flag_values": np.array(P.QC_FLAG_VALUES, dtype="int8"),
+                        "flag_meanings": P.QC_FLAG_MEANINGS,
+                        "conventions": P.QC_CONVENTION,
                     },
                 )
 

--- a/oceanarray/mooring/stack.py
+++ b/oceanarray/mooring/stack.py
@@ -494,7 +494,7 @@ class MooringStacker:
                             "Worst OceanSITES flag across east/north/up_velocity; "
                             "apply to the velocity components before use."
                         ),
-                        "flag_values": np.array(P.QC_FLAG_VALUES, dtype="int8"),
+                        "flag_values": P.QC_FLAG_VALUES_I8,
                         "flag_meanings": P.QC_FLAG_MEANINGS,
                         "conventions": P.QC_CONVENTION,
                     },

--- a/oceanarray/mooring/stack.py
+++ b/oceanarray/mooring/stack.py
@@ -481,9 +481,10 @@ class MooringStacker:
                 else (0, 0)
             )
             if n_lev_v > 0:
-                vel_flag = np.ones((n_lev_v, n_t_v), dtype=np.float64)  # 1 = good
+                # int8 so flag_values (also int8) matches the variable dtype (CF).
+                vel_flag = np.ones((n_lev_v, n_t_v), dtype=np.int8)  # 1 = good
                 for _qk in _vel_qc_keys:
-                    vel_flag = _worst_flag(vel_flag, stacked[_qk]).astype(np.float64)
+                    vel_flag = _worst_flag(vel_flag, stacked[_qk]).astype(np.int8)
                 data_vars["velocity_flag"] = xr.Variable(
                     ("N_LEVELS", "time"),
                     vel_flag,

--- a/oceanarray/report/_html_helpers.py
+++ b/oceanarray/report/_html_helpers.py
@@ -163,15 +163,19 @@ _QC_COLORS: Dict[int, str] = {
     2: "#a8e6cf",
     3: "#f39c12",
     4: "#e74c3c",
+    7: "#9b59b6",
     8: "#3498db",
     9: "#bdc3c7",
 }
+# Short display glosses of parameters.QC_FLAG_MEANINGS (OceanSITES table 2).
+# Keep the codes and wording consistent with that table.
 _QC_LABELS: Dict[int, str] = {
-    0: "no QC",
+    0: "unknown",
     1: "good",
     2: "prob. good",
-    3: "suspect",
+    3: "corr. bad",
     4: "bad",
+    7: "nominal",
     8: "interp.",
     9: "missing",
 }

--- a/tests/unit/test_stage3.py
+++ b/tests/unit/test_stage3.py
@@ -113,6 +113,23 @@ def test_merge_flags_oceansites_ordering():
     np.testing.assert_array_equal(result, [8, 4, 1, 4])
 
 
+def test_merge_priority_single_source():
+    """qc._merge_flags and mooring.helpers._worst_flag share ONE priority table.
+
+    Guards against the two merge paths drifting: both derive from
+    parameters.QC_MERGE_PRIORITY, so they must agree on every combination.
+    """
+    from oceanarray import parameters as P
+    from oceanarray.instrument.qc import _QC_PRIORITY
+    from oceanarray.mooring.helpers import _worst_flag
+
+    assert _QC_PRIORITY is P.QC_MERGE_PRIORITY
+    a = np.array([1, 8, 0, 3], dtype=np.int8)
+    b = np.array([8, 4, 1, 8], dtype=np.int8)
+    # _worst_flag must match _merge_flags element-wise for the same inputs.
+    np.testing.assert_array_equal(_worst_flag(a, b), _merge_flags(a, b))
+
+
 # ---------------------------------------------------------------------------
 # _tilt_from_span
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_stage3.py
+++ b/tests/unit/test_stage3.py
@@ -236,7 +236,7 @@ def test_apply_qc_tests_good_data():
     from oceanarray import parameters as P
 
     gr = {"pressure": P.QC_GROSS_RANGE["pressure"]}
-    result = _apply_qc_tests(ds, gr, {}, {})
+    result = _apply_qc_tests(ds, gr, {})
     assert "pressure_qc" in result.data_vars
     assert np.all(result["pressure_qc"].values == 1)
 
@@ -247,7 +247,7 @@ def test_apply_qc_tests_gross_range_flags_bad():
     from oceanarray import parameters as P
 
     gr = {"pressure": P.QC_GROSS_RANGE["pressure"]}
-    result = _apply_qc_tests(ds, gr, {}, {})
+    result = _apply_qc_tests(ds, gr, {})
     flags = result["pressure_qc"].values
     assert flags[10] == 4, f"expected BAD at index 10, got {flags[10]}"
     assert np.sum(flags == 4) == 1
@@ -259,7 +259,7 @@ def test_apply_qc_tests_threshold_attrs_stored():
     from oceanarray import parameters as P
 
     gr = {"pressure": P.QC_GROSS_RANGE["pressure"]}
-    result = _apply_qc_tests(ds, gr, {}, {})
+    result = _apply_qc_tests(ds, gr, {})
     attrs = result["pressure_qc"].attrs
     assert "qc_gross_range_fail_min" in attrs
     assert "qc_gross_range_fail_max" in attrs
@@ -280,7 +280,7 @@ def test_apply_qc_tests_flat_line_flags_fail():
     gr = {"pressure": P.QC_GROSS_RANGE["pressure"]}
     # Use package default tolerance (0.001), NOT 0.0 — see note above
     fl = {"pressure": P.QC_FLAT_LINE["pressure"]}
-    result = _apply_qc_tests(ds, gr, {}, {}, flat_line=fl)
+    result = _apply_qc_tests(ds, gr, {}, flat_line=fl)
     flags = result["pressure_qc"].values
     assert np.any(flags == 4), "expected at least one FAIL flag for stuck pressure"
 
@@ -301,7 +301,7 @@ def test_merge_salinity_parent_qc_bad_temp_propagates():
         },
         coords={"time": time},
     )
-    result = _merge_salinity_parent_qc(ds, {})
+    result = _merge_salinity_parent_qc(ds)
     assert result["salinity_qc"].values[2] == 4
 
 
@@ -316,7 +316,7 @@ def test_merge_salinity_parent_qc_pressure_flag8_ok():
         },
         coords={"time": time},
     )
-    result = _merge_salinity_parent_qc(ds, {})
+    result = _merge_salinity_parent_qc(ds)
     # flag 8 on pressure → salinity_qc should remain 1 (GOOD) not 8
     assert np.all(result["salinity_qc"].values == 1), (
         f"pressure flag=8 should not degrade salinity; got {result['salinity_qc'].values}"

--- a/tests/unit/test_stage3.py
+++ b/tests/unit/test_stage3.py
@@ -100,6 +100,19 @@ def test_merge_flags_three_arrays():
     np.testing.assert_array_equal(result, [1, 3, 4])
 
 
+def test_merge_flags_oceansites_ordering():
+    """OceanSITES ordering: interpolated(8) beats good(1) but loses to bad(4);
+    unknown(0) is the weakest flag, so good(1) beats unknown(0)."""
+    good = np.array([1, 1, 1, 8], dtype=np.int8)
+    other = np.array([8, 4, 0, 4], dtype=np.int8)
+    result = _merge_flags(good, other)
+    #   1 vs 8 -> 8 (interpolated overrides good)
+    #   1 vs 4 -> 4 (bad overrides good)
+    #   1 vs 0 -> 1 (good beats unknown; unknown is weakest)
+    #   8 vs 4 -> 4 (bad overrides interpolated)
+    np.testing.assert_array_equal(result, [8, 4, 1, 4])
+
+
 # ---------------------------------------------------------------------------
 # _tilt_from_span
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_stage3.py
+++ b/tests/unit/test_stage3.py
@@ -130,6 +130,22 @@ def test_merge_priority_single_source():
     np.testing.assert_array_equal(_worst_flag(a, b), _merge_flags(a, b))
 
 
+def test_set_qc_attrs_preserves_author_long_name():
+    """set_qc_attrs fills long_name only when absent — never clobbers a standalone
+    diagnostic flag's own long_name (e.g. seabed_qc), but still attaches the table."""
+    from oceanarray.instrument.qc import set_qc_attrs
+
+    ds = xr.Dataset(
+        {"seabed_qc": ("time", np.array([1, 1], dtype=np.int8))},
+        coords={"time": [0, 1]},
+    )
+    ds["seabed_qc"].attrs["long_name"] = "Seabed proximity QC flag"
+    set_qc_attrs(ds, "seabed")
+    assert ds["seabed_qc"].attrs["long_name"] == "Seabed proximity QC flag"
+    assert "flag_meanings" in ds["seabed_qc"].attrs
+    assert np.asarray(ds["seabed_qc"].attrs["flag_values"]).dtype == np.int8
+
+
 # ---------------------------------------------------------------------------
 # _tilt_from_span
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

The package carried three different QC flag tables: `parameters.py` declared the Argo table (with `value_changed`/`not_in_use` at 5/6, which OceanSITES doesn't have), `stack.py` declared a CF-invalid `flag_values` string, and `qc.py` restated its merge priority as a hand-written array that duplicated the priority dict. Meanwhile the QARTOD tests (via `ioos_qc`) emit QARTOD-scale flags that were stored and then labelled with OceanSITES meanings — so a point a test *couldn't evaluate* (QARTOD `2 = not_evaluated`) was being asserted as OceanSITES `2 = probably_good_data`. This branch reconciles everything onto the OceanSITES Reference Table 2 and lands the QARTOD output onto it honestly.

## Changes

- **`parameters.py` → OceanSITES Reference Table 2.** `QC_FLAG_VALUES` is now `{0,1,2,3,4,7,8,9}` with the exact meanings transcribed from the in-repo manual (`docs/source/oceanSITES_manual.rst`). The non-OceanSITES `5 (value_changed)` and `6 (not_in_use)` are dropped — the header already claimed "Reference Table 2" while the values were Argo's.

- **One merge-priority table for the whole package.** The ordering now lives in `parameters.QC_MERGE_PRIORITY` (OceanSITES: `unknown(0)` weakest through `missing(9)` strongest, with `nominal_value(7)` given a real slot instead of tying with `unknown`). Both `instrument.qc._merge_flags` and `mooring.helpers._worst_flag` (the stack's velocity merge) derive their lookup arrays from it, so the two merge paths cannot drift — previously each had its own hand-written array and they disagreed on flags 3/5/6/7.

- **`qc.py` `_ingest_qartod` — QARTOD → OceanSITES at ingest.** Each `ioos_qc` test result is normalised as it comes out: fill missing with 9, cast to int8, and remap QARTOD `UNKNOWN(2)` → OceanSITES `unknown(0)`. Applied before the merge, so an un-evaluated point never asserts `probably_good_data`. This one helper also absorbs the `.filled(9)`/`.astype`/masked-vs-ndarray handling the three test sites each repeated.

- **`qc.py` `set_qc_attrs` + stage3 sweep — one owner of flag attrs.** A single helper sources the flag table from `parameters` and attaches `long_name` (only when absent — an author-supplied one, e.g. on a diagnostic `seabed_qc`, is preserved), the `status_flag` `standard_name` (skipped, never fabricated, when the parent has no `standard_name`), int8 `flag_values`, `flag_meanings`, and `conventions`. It is applied as a sweep over every `_qc` variable at the end of `stage3._process_instrument` (after the CF `standard_name` pass, so each parent's `standard_name` is available), plus explicitly on the sweep-excluded `pressure_orig_qc`. Every output `_qc` variable now carries the canonical attrs; previously they lacked `standard_name` entirely.

- **Removed the redundant `qc_attrs` threading.** With `set_qc_attrs` as the single owner, the `_qc_attrs = {flag_values, flag_meanings, conventions}` dict that stage3 threaded through `apply_qc_tests` / `apply_tilt_qc` / `merge_salinity_parent_qc` / `apply_enu_velocity_qc` / `interpolate_pressure` / the three ADCP QC functions (7 `**qc_attrs` splats, ~15 call sites across `qc.py`/`pressure.py`/`coordinate.py`/`stage3.py`) is deleted — that parameter, its splats, and the dict are gone. The separate `threshold_attrs` provenance survives (`set_qc_attrs` uses `.update()`).

- **`stack.py` `velocity_flag` — canonical attrs + int8.** The CF-invalid `"0 1 2 3 4 9"` string and Argo-worded `flag_meanings` are replaced with `np.array(P.QC_FLAG_VALUES, dtype="int8")`, `P.QC_FLAG_MEANINGS`, `P.QC_CONVENTION`; the variable itself is now int8 so its dtype matches `flag_values` (CF); the QARTOD-worded "3=suspect" comment is dropped.

- **QC provenance recorded in the output.** stage3 writes three global attributes so the treatment is reconstructable from the file alone: `qc_flag_convention`, `qc_merge_rule` (the worst-wins priority order, `0 < 1 < 2 < 7 < 8 < 3 < 4 < 9`), and `qc_ingest_remap` (the QARTOD `not_evaluated(2)` → OceanSITES `unknown(0)` mapping).

- **`report/_html_helpers.py` QC labels/colors** brought in line with the OceanSITES table (`0`→"unknown", `3`→"corr. bad", added `7`→"nominal") so the HTML QC overlays no longer disagree with the stored `flag_meanings`.

- **`pressure_orig_qc` preserved.** The normalization sweep skips `*_orig_qc` variables so the pre-interpolation original-pressure flag (e.g. `4 = bad`) stays distinct from the interpolated `pressure_qc` (`8`).

## Breaking changes

- **Output `flag_meanings` / `flag_values` change on every stage3 `.nc` and the stack `velocity_flag`.** They are now OceanSITES: e.g. flag 3 is `potentially_correctable_bad_data` (was Argo's `probably_bad_data`), flag 0 is `unknown` (was `no_qc_performed`), and `5,6` are no longer declared legal. `flag_values` is now an int8 array (was a Python list in stage3, a space-delimited string in stack). Files already on disk keep their old attrs.

- **Stored flag values shift for un-evaluated points.** QARTOD `not_evaluated (2)` is now stored as OceanSITES `unknown (0)`. Because OceanSITES ranks `unknown` at the bottom of the merge (opposite of QARTOD), a record's first/last sample and points beside a gap — where `spike_test` returns "unknown" but gross-range and flat-line pass — now read `good (1)` where they previously read `2`. A point reads `0 (unknown)` only when nothing evaluated it. The `qc_merge_rule` and `qc_ingest_remap` global attributes record this so the treatment is reconstructable from the file.