### PR TITLE
[FEAT] Add `process()` public API and STAGES registry

### DIFF
--- a/oceanarray/__init__.py
+++ b/oceanarray/__init__.py
@@ -5,6 +5,7 @@ of oceanographic time series data from moorings and instruments.
 """
 
 from oceanarray.config import parameters
+from oceanarray.processors import process
 
 __all__ = [
     # Subpackages (canonical locations)
@@ -12,9 +13,12 @@ __all__ = [
     "config",
     "instrument",
     "mooring",
+    "processors",
     "tools",
     # Top-level modules
     "parameters",
     "plotters",
     "utilities",
+    # Public API
+    "process",
 ]

--- a/oceanarray/processors/__init__.py
+++ b/oceanarray/processors/__init__.py
@@ -1,0 +1,331 @@
+"""Pipeline stage registry and public ``process()`` entry point.
+
+The :data:`STAGES` tuple is the single source of truth for pipeline ordering,
+scope, and dispatch.  It is used by :func:`process`, the CLI, the re-run rule
+(plan §7), and the parametrised re-run tests (test plan §7d).
+
+Example usage::
+
+    import oceanarray
+
+    oceanarray.process("dsG3_1_2026", proc_dir="/data/proc")               # all five stages
+    oceanarray.process("dsG3_1_2026", stage=1, proc_dir="/data/proc",
+                       raw_dir="/data/raw")                                  # stage 1 only
+    oceanarray.process("dsG3_1_2026", stage="grid", proc_dir="/data/proc")  # grid only
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import PathLike
+from pathlib import Path
+from typing import Any, Callable, Literal, Optional
+
+__all__ = [
+    "Stage",
+    "STAGES",
+    "resolve_stage",
+    "process",
+]
+
+Scope = Literal["instrument", "mooring"]
+
+
+@dataclass(frozen=True)
+class Stage:
+    """One pipeline stage.
+
+    Parameters
+    ----------
+    name : str
+        Canonical stage name used on the CLI and in log messages.  For the
+        numbered stages this matches the output filename suffix
+        (``*_stage3.nc``); ``stack`` and ``grid`` write ``stack.nc`` and
+        ``grid.nc``.
+    number : int or None
+        Position for the numbered stages; ``None`` for ``stack`` and ``grid``.
+        This is what makes ``stage=1`` resolvable and ``stage=4`` a
+        ``ValueError`` rather than a silent wrong dispatch.
+    scope : Scope
+        Whether the stage runs once per instrument (``"instrument"``) or once
+        per mooring (``"mooring"``).  Drives which staleness sources the re-run
+        rule consults (plan §7).
+    run : Callable
+        Normalised entry point: ``run(mooring, proc_dir, *, force, **kw) -> bool``.
+
+    """
+
+    name: str
+    number: Optional[int]
+    scope: Scope
+    run: Callable[..., bool]
+
+
+# ---------------------------------------------------------------------------
+# Normalised wrappers — thin shims over the existing class-based API so that
+# STAGES can store a uniform (mooring, proc_dir, *, force, **kw) -> bool signature.
+# ---------------------------------------------------------------------------
+
+
+def _run_stage1(
+    mooring: str,
+    proc_dir: Path,
+    *,
+    raw_dir: Optional[Path] = None,
+    force: bool = False,
+    serials: Optional[list[str]] = None,
+    **_kw: Any,
+) -> bool:
+    """Run stage 1 (raw → CF-NetCDF) for *mooring*.
+
+    Parameters
+    ----------
+    mooring : str
+        Mooring name.
+    proc_dir : Path
+        Processing root directory (parent that contains per-mooring subdirectories).
+    raw_dir : Path, optional
+        Raw-data root.  Required for stage 1.
+    force : bool
+        Re-run even when output is newer than inputs.
+    serials : list of str, optional
+        Restrict to these serial numbers.
+
+    """
+    from oceanarray.instrument.stage1 import MooringProcessor
+
+    if raw_dir is None:
+        raise ValueError("stage1 requires raw_dir")  # noqa: TRY003
+    proc = MooringProcessor(raw_dir=str(raw_dir), proc_dir=str(proc_dir))
+    return bool(proc.process_mooring(mooring, serials=serials, force=force))
+
+
+def _run_stage2(
+    mooring: str,
+    proc_dir: Path,
+    *,
+    force: bool = False,
+    serials: Optional[list[str]] = None,
+    **_kw: Any,
+) -> bool:
+    """Run stage 2 (deployment trim + clock-drift correction) for *mooring*.
+
+    Parameters
+    ----------
+    mooring : str
+        Mooring name.
+    proc_dir : Path
+        Processing root directory.
+    force : bool
+        Re-run even when output is newer than inputs.
+    serials : list of str, optional
+        Restrict to these serial numbers.
+
+    """
+    from oceanarray.instrument.stage2 import Stage2Processor
+
+    return bool(
+        Stage2Processor(proc_dir=str(proc_dir)).process_mooring(
+            mooring, serials=serials, force=force
+        )
+    )
+
+
+def _run_stage3(
+    mooring: str,
+    proc_dir: Path,
+    *,
+    force: bool = False,
+    serials: Optional[list[str]] = None,
+    **_kw: Any,
+) -> bool:
+    """Run stage 3 (QC, coordinate rotation, derived vars) for *mooring*.
+
+    Parameters
+    ----------
+    mooring : str
+        Mooring name.
+    proc_dir : Path
+        Processing root directory.
+    force : bool
+        Re-run even when output is newer than inputs.
+    serials : list of str, optional
+        Restrict to these serial numbers.
+
+    """
+    from oceanarray.instrument.stage3 import Stage3Processor
+
+    return bool(
+        Stage3Processor(proc_dir=str(proc_dir)).process_mooring(
+            mooring, serials=serials, force=force
+        )
+    )
+
+
+def _run_stack(
+    mooring: str,
+    proc_dir: Path,
+    *,
+    force: bool = False,
+    dt_seconds: int = 60,
+    **_kw: Any,
+) -> bool:
+    """Run the stack stage (multi-instrument → common time grid) for *mooring*.
+
+    Parameters
+    ----------
+    mooring : str
+        Mooring name.
+    proc_dir : Path
+        Processing root directory.
+    force : bool
+        Re-run even when output is newer than inputs.
+    dt_seconds : int
+        Target sampling interval in seconds (default 60).
+
+    """
+    from oceanarray.mooring.stack import MooringStacker
+
+    return bool(
+        MooringStacker(proc_dir=str(proc_dir)).stack(
+            mooring, dt_seconds=dt_seconds, force=force
+        )
+    )
+
+
+def _run_grid(
+    mooring: str,
+    proc_dir: Path,
+    *,
+    force: bool = False,
+    p_start: float = 200.0,
+    p_end: float = 1000.0,
+    dp: float = 20.0,
+    **_kw: Any,
+) -> bool:
+    """Run the grid stage (pressure-level interpolation) for *mooring*.
+
+    Parameters
+    ----------
+    mooring : str
+        Mooring name.
+    proc_dir : Path
+        Processing root directory.
+    force : bool
+        Re-run even when output is newer than inputs.
+    p_start : float
+        Shallowest pressure level in dbar.
+    p_end : float
+        Deepest pressure level in dbar.
+    dp : float
+        Pressure step in dbar.
+
+    """
+    from oceanarray.mooring.grid import MooringGridder
+
+    return bool(
+        MooringGridder(proc_dir=str(proc_dir)).grid(
+            mooring, p_start=p_start, p_end=p_end, dp=dp, force=force
+        )
+    )
+
+
+#: Pipeline stages in execution order.  Single source of truth for
+#: :func:`process`, the CLI, the re-run rule (plan §7), and the parametrised
+#: re-run tests (test plan §7d).
+STAGES: tuple[Stage, ...] = (
+    Stage("stage1", 1, "instrument", _run_stage1),
+    Stage("stage2", 2, "instrument", _run_stage2),
+    Stage("stage3", 3, "instrument", _run_stage3),
+    Stage("stack", None, "mooring", _run_stack),
+    Stage("grid", None, "mooring", _run_grid),
+)
+
+
+def resolve_stage(stage: int | str) -> Stage:
+    """Return the :class:`Stage` named or numbered by *stage*.
+
+    Parameters
+    ----------
+    stage : int or str
+        ``1``, ``2``, or ``3``; or a canonical name — ``"stage1"``,
+        ``"stage2"``, ``"stage3"``, ``"stack"``, ``"grid"``.  Names are
+        matched case-insensitively.  Integer ``4`` is deliberately an error:
+        ``stack`` and ``grid`` have no number so there is no valid integer
+        shorthand for them.
+
+    Returns
+    -------
+    Stage
+        The matching :class:`Stage` entry from :data:`STAGES`.
+
+    Raises
+    ------
+    ValueError
+        If *stage* matches no entry.  The message lists every valid value.
+
+    """
+    for s in STAGES:
+        if stage == s.number or (isinstance(stage, str) and stage.lower() == s.name):
+            return s
+    valid_ints = ", ".join(str(s.number) for s in STAGES if s.number is not None)
+    valid_names = ", ".join(repr(s.name) for s in STAGES)
+    msg = f"unknown stage {stage!r}; expected one of: {valid_ints}, {valid_names}"
+    raise ValueError(msg)
+
+
+def process(
+    mooring: str,
+    stage: int | str | None = None,
+    *,
+    proc_dir: PathLike,
+    raw_dir: Optional[PathLike] = None,
+    force: bool = False,
+    **kw: Any,
+) -> bool:
+    """Run one pipeline stage, or every stage in order, for *mooring*.
+
+    Parameters
+    ----------
+    mooring : str
+        Mooring name (the subdirectory under *proc_dir*).
+    stage : int or str, optional
+        Which stage to run — ``1``, ``2``, ``3``, ``"stage1"``, ``"stack"``,
+        ``"grid"``, etc.  ``None`` (the default) runs all five stages in
+        :data:`STAGES` order.
+    proc_dir : path-like
+        Processing root directory (parent containing per-mooring subdirectories).
+    raw_dir : path-like, optional
+        Raw-data root.  Required only when *stage* includes stage 1.
+    force : bool, default False
+        Re-run even when the output is newer than its inputs.
+    **kw
+        Extra keyword arguments forwarded to the stage's ``run`` callable
+        (e.g. ``serials``, ``dt_seconds``, ``p_start``, ``p_end``, ``dp``).
+
+    Returns
+    -------
+    bool
+        ``True`` if every requested stage succeeded, ``False`` if any failed.
+
+    """
+    proc_dir = Path(proc_dir)
+    raw_dir_path = Path(raw_dir) if raw_dir is not None else None
+
+    stages_to_run: tuple[Stage, ...] = (
+        STAGES if stage is None else (resolve_stage(stage),)
+    )
+
+    overall = True
+    for s in stages_to_run:
+        ok = s.run(
+            mooring,
+            proc_dir,
+            raw_dir=raw_dir_path,
+            force=force,
+            **kw,
+        )
+        if not ok:
+            overall = False
+    return overall

--- a/oceanarray/processors/__init__.py
+++ b/oceanarray/processors/__init__.py
@@ -93,10 +93,9 @@ def _run_stage1(
         Restrict to these serial numbers.
 
     """
-    from oceanarray.instrument.stage1 import MooringProcessor
-
     if raw_dir is None:
         raise ValueError("stage1 requires raw_dir")  # noqa: TRY003
+    from oceanarray.instrument.stage1 import MooringProcessor
     proc = MooringProcessor(raw_dir=str(raw_dir), proc_dir=str(proc_dir))
     return bool(proc.process_mooring(mooring, serials=serials, force=force))
 

--- a/tests/unit/test_process_api.py
+++ b/tests/unit/test_process_api.py
@@ -1,0 +1,184 @@
+"""Tests for the processors registry and public process() API."""
+
+import dataclasses
+
+import pytest
+
+from oceanarray.processors import STAGES, Stage, process, resolve_stage
+
+
+class TestStagesRegistry:
+    def test_has_five_stages(self):
+        assert len(STAGES) == 5
+
+    def test_stage_names(self):
+        names = [s.name for s in STAGES]
+        assert names == ["stage1", "stage2", "stage3", "stack", "grid"]
+
+    def test_numbered_stages(self):
+        numbered = [(s.name, s.number) for s in STAGES if s.number is not None]
+        assert numbered == [("stage1", 1), ("stage2", 2), ("stage3", 3)]
+
+    def test_unnumbered_stages(self):
+        unnumbered = [s.name for s in STAGES if s.number is None]
+        assert unnumbered == ["stack", "grid"]
+
+    def test_scopes(self):
+        scopes = {s.name: s.scope for s in STAGES}
+        assert scopes["stage1"] == "instrument"
+        assert scopes["stage2"] == "instrument"
+        assert scopes["stage3"] == "instrument"
+        assert scopes["stack"] == "mooring"
+        assert scopes["grid"] == "mooring"
+
+    def test_all_stages_have_callable_run(self):
+        for s in STAGES:
+            assert callable(s.run), f"{s.name}.run is not callable"
+
+    def test_stage_is_frozen(self):
+        s = STAGES[0]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            s.name = "changed"  # type: ignore[misc]
+
+
+class TestResolveStage:
+    @pytest.mark.parametrize("stage", [1, 2, 3])
+    def test_resolve_by_int(self, stage):
+        s = resolve_stage(stage)
+        assert s.number == stage
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("stage1", "stage1"),
+            ("stage2", "stage2"),
+            ("stage3", "stage3"),
+            ("stack", "stack"),
+            ("grid", "grid"),
+        ],
+    )
+    def test_resolve_by_name(self, name, expected):
+        assert resolve_stage(name).name == expected
+
+    @pytest.mark.parametrize("name", ["STAGE1", "Stage2", "GRID", "Stack"])
+    def test_resolve_case_insensitive(self, name):
+        s = resolve_stage(name)
+        assert s.name == name.lower()
+
+    def test_integer_4_raises(self):
+        with pytest.raises(ValueError, match="unknown stage"):
+            resolve_stage(4)
+
+    def test_integer_0_raises(self):
+        with pytest.raises(ValueError, match="unknown stage"):
+            resolve_stage(0)
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(ValueError, match="unknown stage"):
+            resolve_stage("bogus")
+
+    def test_error_message_lists_valid_values(self):
+        with pytest.raises(ValueError) as exc_info:
+            resolve_stage(99)
+        msg = str(exc_info.value)
+        assert "1" in msg
+        assert "grid" in msg
+
+
+def _make_spy(call_list: list, name: str, *, ok: bool = True):
+    """Return a Stage.run-compatible callable that appends *name* to *call_list*."""
+
+    def run(_mooring, _proc_dir, **_kw):
+        call_list.append(name)
+        return ok
+
+    return run
+
+
+def _patch_stages(monkeypatch, stages):
+    from oceanarray import processors
+
+    monkeypatch.setattr(processors, "STAGES", stages)
+
+
+class TestProcess:
+    def test_process_single_stage_by_int(self, tmp_path, monkeypatch):
+        calls = []
+        orig = STAGES
+        _patch_stages(
+            monkeypatch,
+            (
+                orig[0],
+                Stage("stage2", 2, "instrument", _make_spy(calls, "stage2")),
+                orig[2],
+                orig[3],
+                orig[4],
+            ),
+        )
+        result = process("test_mooring", stage=2, proc_dir=tmp_path)
+        assert result is True
+        assert calls == ["stage2"]
+
+    def test_process_all_stages_calls_each_in_order(self, tmp_path, monkeypatch):
+        call_order = []
+        patched = tuple(
+            Stage(s.name, s.number, s.scope, _make_spy(call_order, s.name))
+            for s in STAGES
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process("my_mooring", proc_dir=tmp_path)
+        assert result is True
+        assert call_order == ["stage1", "stage2", "stage3", "stack", "grid"]
+
+    def test_process_returns_false_if_any_stage_fails(self, tmp_path, monkeypatch):
+        calls = []
+        patched = tuple(
+            Stage(
+                s.name,
+                s.number,
+                s.scope,
+                _make_spy(calls, s.name, ok=(s.name != "stage2")),
+            )
+            for s in STAGES
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process("my_mooring", proc_dir=tmp_path)
+        assert result is False
+
+    def test_process_stage1_requires_raw_dir_via_registry(self, tmp_path):
+        """stage1 wrapper raises ValueError when raw_dir is not provided."""
+        from oceanarray.processors import _run_stage1
+
+        with pytest.raises(ValueError, match="raw_dir"):
+            _run_stage1("test_mooring", tmp_path, raw_dir=None, force=False)
+
+    def test_partial_success_continues_after_failure(self, tmp_path, monkeypatch):
+        """process() does not short-circuit on stage failure — all stages run."""
+        call_order = []
+        patched = (
+            Stage("stage1", 1, "instrument", _make_spy(call_order, "stage1", ok=False)),
+            Stage("stage2", 2, "instrument", _make_spy(call_order, "stage2")),
+            Stage("stage3", 3, "instrument", _make_spy(call_order, "stage3")),
+            Stage("stack", None, "mooring", _make_spy(call_order, "stack")),
+            Stage("grid", None, "mooring", _make_spy(call_order, "grid")),
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process("my_mooring", proc_dir=tmp_path)
+        assert result is False
+        assert call_order == ["stage1", "stage2", "stage3", "stack", "grid"]
+
+    def test_process_by_stage_name(self, tmp_path, monkeypatch):
+        calls = []
+        patched = (
+            *STAGES[:3],
+            Stage("stack", None, "mooring", _make_spy(calls, "stack")),
+            STAGES[4],
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process("my_mooring", stage="stack", proc_dir=tmp_path)
+        assert result is True
+        assert calls == ["stack"]


### PR DESCRIPTION
## Summary

Introduces a `process(stage=…)` entry point at the `oceanarray` top level, backed by a `STAGES` registry that is the single source of truth for pipeline ordering, scope, and dispatch. No files are moved; the registry imports from the existing `instrument/` and `mooring/` subpackages.

## What changed

**`oceanarray/processors/__init__.py`** (new file) — four exports:

- `Stage` — frozen dataclass with `name`, `number`, `scope`, and `run` fields. `number` is `None` for `stack` and `grid` so that `stage=4` is an explicit error rather than a silent wrong dispatch.
- `STAGES: tuple[Stage, ...]` — the five pipeline stages in execution order. Single source of truth for `process()`, the CLI, the re-run rule (plan §7), and the parametrised re-run tests (test plan §7d).
- `resolve_stage(stage: int | str) -> Stage` — case-insensitive lookup by number or name; raises `ValueError` with the full valid-values list on mismatch.
- `process(mooring, stage=None, *, proc_dir, raw_dir=None, force=False, **kw) -> bool` — runs one stage or all five in order. Does not short-circuit on failure: a failed stage is logged and subsequent stages still run.

Five private `_run_*` wrappers normalise each class-based stage entry point to the uniform `(mooring, proc_dir, *, force, **kw) -> bool` signature.

**`oceanarray/__init__.py`** — `process` and `processors` re-exported at the top level.

**`tests/unit/test_process_api.py`** (new file, 29 tests):
- `resolve_stage` accepts `1`, `2`, `3`, `"stage1"`, `"stack"`, `"grid"` (case-insensitive)
- `stage=4` raises `ValueError`; unknown string raises `ValueError`
- `STAGES` has exactly 5 entries in the correct order, correct scopes, all callables
- `Stage` is frozen (assignment raises `FrozenInstanceError`)
- `process(stage=None, ...)` calls all five in order; `process(stage="stack", ...)` calls only stack
- `process()` does not short-circuit on failure — all stages run even if an early one fails
- `_run_stage1` raises `ValueError` when `raw_dir` is not provided

## Breaking changes

None. `process()` is a new public symbol; no existing callers are affected.