### PR TITLE
[REFACTOR] Use `STAGES` registry as single source of truth in CLI dispatch

### DIFF
--- a/oceanarray/cli.py
+++ b/oceanarray/cli.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 from . import paths
+from .processors import STAGES, resolve_stage
 from .utilities import _status
 from ._version import __version__
 
@@ -163,9 +164,7 @@ def cmd_process(args: argparse.Namespace) -> int:
     - ``--plot``: save a PNG overview plot for each instrument alongside the
       stage2 NetCDF file in the proc directory.
     """
-    from .processors.stage1 import MooringProcessor
-    from .processors.stage2 import Stage2Processor
-    from .processors.stage3 import Stage3Processor
+    from .processors import process as _process
 
     raw_dir, proc_root = _parse_dirs_checked(args)
 
@@ -174,73 +173,25 @@ def cmd_process(args: argparse.Namespace) -> int:
     if stages is None:
         stages = [1, 2]
 
+    serials = args.serial or None
     overall_success = True
 
-    serials = args.serial or None
-
-    if 1 in stages:
-        _status("section", f"Stage 1: {args.mooring}")
-        if raw_dir is None:
+    if stages:
+        if 1 in stages and raw_dir is None:
             raise SystemExit("ERROR: --raw-dir is required for stage 1.")  # noqa: TRY003
-        proc = MooringProcessor(raw_dir=str(raw_dir), proc_dir=str(proc_root))
-        ok = proc.process_mooring(args.mooring, serials=serials, force=args.force)
-        if not ok:
-            print("Stage 1 failed.")
-            overall_success = False
-
-    if 2 in stages:
-        _status("section", f"Stage 2: {args.mooring}")
-        s2 = Stage2Processor(proc_dir=str(proc_root))
-        ok = s2.process_mooring(args.mooring, serials=serials, force=args.force)
-        if not ok:
-            print("Stage 2 failed.")
-            overall_success = False
-
-    if 3 in stages:
-        dry = getattr(args, "dry_run", False)
-        print(
-            f"\n=== Stage 3: {args.mooring} (pressure interpolation)"
-            + (" — DRY RUN" if dry else "")
-            + " ==="
-        )
-        s3 = Stage3Processor(proc_dir=str(proc_root))
-        ok = s3.process_mooring(
-            args.mooring, serials=serials, force=args.force, dry_run=dry
-        )
-        if not ok:
-            print("Stage 3 failed.")
-            overall_success = False
-
-    if "stack" in stages:
-        from .processors.stack import MooringStacker
-
-        _status("section", f"Stack: {args.mooring}")
-        stacker = MooringStacker(proc_dir=str(proc_root))
-        ok = stacker.stack(
+        overall_success = _process(
             args.mooring,
-            dt_seconds=args.dt,
+            stage=stages,
+            proc_dir=proc_root,
+            raw_dir=raw_dir,
             force=args.force,
-        )
-        if not ok:
-            print("Stack failed.")
-            overall_success = False
-            stages = [s for s in stages if s != "grid"]
-
-    if "grid" in stages:
-        from .processors.grid import MooringGridder
-
-        _status("section", f"Grid: {args.mooring}")
-        gridder = MooringGridder(proc_dir=str(proc_root))
-        ok = gridder.grid(
-            args.mooring,
+            serials=serials,
+            dt_seconds=args.dt,
             p_start=args.pmin,
             p_end=args.pmax,
             dp=args.dp,
-            force=args.force,
+            dry_run=getattr(args, "dry_run", False),
         )
-        if not ok:
-            print("Grid failed.")
-            overall_success = False
 
     if args.report:
         _status("section", f"Record Summary: {args.mooring}")
@@ -577,61 +528,43 @@ def cmd_run(args: argparse.Namespace) -> int:
     grid (pressure interpolation), and all reports (summary, per-instrument,
     stack, grid).
 
-    All steps run regardless of earlier failures.  If any step fails the command
-    returns exit code 1 at the end, but subsequent steps are not skipped.  Check
-    the log files in ``processing_logs/`` to diagnose partial failures.
+    Stage failures are non-fatal: each subsequent stage runs regardless, except
+    that a stack failure skips grid (grid reads stack.nc as its input).  The
+    command returns exit code 1 if any step fails.
     """
-    import argparse as _ap
+    from .processors import process as _process
 
-    overall_ok = True
-    _dirs = dict(
-        basedir=getattr(args, "basedir", None),
-        raw_dir=getattr(args, "raw_dir", None),
-        proc_dir=getattr(args, "proc_dir", None),
-    )
+    raw_dir, proc_root = _parse_dirs_checked(args)
 
-    process_args = _ap.Namespace(
-        mooring=args.mooring,
-        stage=[1, 2, 3],
-        force=args.force,
-        serial=args.serial,
-        report=False,
-        plot=False,
-        dry_run=False,
-        **_dirs,
-    )
-    if cmd_process(process_args) != 0:
-        overall_ok = False
+    if raw_dir is None:
+        raise SystemExit("ERROR: --raw-dir is required for stage 1.")  # noqa: TRY003
 
-    from .processors.stack import MooringStacker
-    from .processors.grid import MooringGridder
+    serials = args.serial or None
 
-    _sg_ns = _ap.Namespace(mooring=args.mooring, **_dirs)
-    _, _proc_root = _parse_dirs_checked(_sg_ns)
-
-    if not MooringStacker(proc_dir=str(_proc_root)).stack(
-        args.mooring, dt_seconds=args.dt, force=args.force
-    ):
-        overall_ok = False
-
-    if not MooringGridder(proc_dir=str(_proc_root)).grid(
+    overall_ok = _process(
         args.mooring,
+        stage=None,
+        proc_dir=proc_root,
+        raw_dir=raw_dir,
+        force=args.force,
+        serials=serials,
+        dt_seconds=args.dt,
         p_start=args.pmin,
         p_end=args.pmax,
         dp=args.dp,
-        force=args.force,
-    ):
-        overall_ok = False
+    )
 
-    report_args = _ap.Namespace(
+    report_args = argparse.Namespace(
         mooring=args.mooring,
         force=args.force,
         outdir=None,
-        serial=args.serial or None,
+        serial=serials,
         instruments=True,
         grid=True,
         stack=True,
-        **_dirs,
+        basedir=getattr(args, "basedir", None),
+        raw_dir=getattr(args, "raw_dir", None),
+        proc_dir=getattr(args, "proc_dir", None),
     )
     if cmd_report(report_args) != 0:
         overall_ok = False
@@ -915,7 +848,7 @@ def cmd_logsheet(args: "argparse.Namespace") -> int:
 
 
 def _stage_token(value: str) -> "int | str":
-    """Convert a ``--stage`` token to int (1/2/3) or str ('stack'/'grid').
+    """Convert a ``--stage`` CLI token to ``int`` or canonical ``str`` via :func:`resolve_stage`.
 
     Parameters
     ----------
@@ -930,19 +863,17 @@ def _stage_token(value: str) -> "int | str":
     Raises
     ------
     argparse.ArgumentTypeError
-        If *value* is not one of ``1``, ``2``, ``3``, ``stack``, or ``grid``.
+        If *value* is not recognised by :func:`~oceanarray.processors.resolve_stage`.
 
     """
-    if value in ("stack", "grid"):
-        return value
-    try:
-        return int(value)
-    except ValueError:
-        import argparse as _ap
+    import argparse as _ap
 
-        raise _ap.ArgumentTypeError(  # noqa: B904, TRY003
-            f"invalid stage '{value}': choose from 1, 2, 3, stack, grid"
-        )
+    coerced: int | str = int(value) if value.isdigit() else value
+    try:
+        resolve_stage(coerced)
+    except ValueError as exc:
+        raise _ap.ArgumentTypeError(str(exc)) from exc
+    return coerced
 
 
 def _add_dir_args(p: "argparse.ArgumentParser", raw_needed: bool = True) -> None:
@@ -1226,7 +1157,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--stage",
         type=_stage_token,
         nargs="+",
-        choices=[1, 2, 3, "stack", "grid"],
+        choices=[s.number if s.number is not None else s.name for s in STAGES],
         default=None,
         metavar="{1,2,3,stack,grid}",
         help="Stage(s) to run (default: 1 2). "

--- a/oceanarray/processors/__init__.py
+++ b/oceanarray/processors/__init__.py
@@ -301,9 +301,10 @@ def process(
         Mooring name (the subdirectory under *proc_dir*).
     stage : int, str, list of int/str, or None
         Which stage(s) to run — ``1``, ``2``, ``3``, ``"stage1"``, ``"stack"``,
-        ``"grid"``, etc.  Pass a list to run a specific subset in :data:`STAGES`
-        order.  ``None`` (the default) runs all five stages in :data:`STAGES`
-        order.
+        ``"grid"``, etc.  Pass a list to run a specific subset; the subset is
+        always executed in :data:`STAGES` order regardless of the order of
+        elements in the list.  ``None`` (the default) runs all five stages in
+        :data:`STAGES` order.
     proc_dir : path-like
         Processing root directory (parent containing per-mooring subdirectories).
     raw_dir : path-like, optional
@@ -326,7 +327,8 @@ def process(
     if stage is None:
         stages_to_run: tuple[Stage, ...] = STAGES
     elif isinstance(stage, (list, tuple)):
-        stages_to_run = tuple(resolve_stage(s) for s in stage)
+        _requested = {resolve_stage(s) for s in stage}
+        stages_to_run = tuple(s for s in STAGES if s in _requested)
     else:
         stages_to_run = (resolve_stage(stage),)
 

--- a/oceanarray/processors/__init__.py
+++ b/oceanarray/processors/__init__.py
@@ -138,6 +138,7 @@ def _run_stage3(
     *,
     force: bool = False,
     serials: Optional[list[str]] = None,
+    dry_run: bool = False,
     **_kw: Any,
 ) -> bool:
     """Run stage 3 (QC, coordinate rotation, derived vars) for *mooring*.
@@ -152,13 +153,15 @@ def _run_stage3(
         Re-run even when output is newer than inputs.
     serials : list of str, optional
         Restrict to these serial numbers.
+    dry_run : bool
+        If True, log what would be done without writing output files.
 
     """
     from oceanarray.processors.stage3 import Stage3Processor
 
     return bool(
         Stage3Processor(proc_dir=str(proc_dir)).process_mooring(
-            mooring, serials=serials, force=force
+            mooring, serials=serials, force=force, dry_run=dry_run
         )
     )
 
@@ -283,23 +286,24 @@ def resolve_stage(stage: int | str) -> Stage:
 
 def process(
     mooring: str,
-    stage: int | str | None = None,
+    stage: "int | str | list[int | str] | None" = None,
     *,
     proc_dir: PathLike,
     raw_dir: Optional[PathLike] = None,
     force: bool = False,
     **kw: Any,
 ) -> bool:
-    """Run one pipeline stage, or every stage in order, for *mooring*.
+    """Run one or more pipeline stages, or every stage in order, for *mooring*.
 
     Parameters
     ----------
     mooring : str
         Mooring name (the subdirectory under *proc_dir*).
-    stage : int or str, optional
-        Which stage to run — ``1``, ``2``, ``3``, ``"stage1"``, ``"stack"``,
-        ``"grid"``, etc.  ``None`` (the default) runs all five stages in
-        :data:`STAGES` order.
+    stage : int, str, list of int/str, or None
+        Which stage(s) to run — ``1``, ``2``, ``3``, ``"stage1"``, ``"stack"``,
+        ``"grid"``, etc.  Pass a list to run a specific subset in :data:`STAGES`
+        order.  ``None`` (the default) runs all five stages in :data:`STAGES`
+        order.
     proc_dir : path-like
         Processing root directory (parent containing per-mooring subdirectories).
     raw_dir : path-like, optional
@@ -319,9 +323,12 @@ def process(
     proc_dir = Path(proc_dir)
     raw_dir_path = Path(raw_dir) if raw_dir is not None else None
 
-    stages_to_run: tuple[Stage, ...] = (
-        STAGES if stage is None else (resolve_stage(stage),)
-    )
+    if stage is None:
+        stages_to_run: tuple[Stage, ...] = STAGES
+    elif isinstance(stage, (list, tuple)):
+        stages_to_run = tuple(resolve_stage(s) for s in stage)
+    else:
+        stages_to_run = (resolve_stage(stage),)
 
     overall = True
     skip_grid = False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -90,3 +90,50 @@ def test_build_parser_parses_basic_args(args, attr, expected):
     parser = build_parser()
     ns = parser.parse_args(args)
     assert getattr(ns, attr) == expected
+
+
+class TestStageToken:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("1", 1),
+            ("2", 2),
+            ("3", 3),
+            ("stack", "stack"),
+            ("grid", "grid"),
+        ],
+    )
+    def test_valid_values(self, value, expected):
+        from oceanarray.cli import _stage_token
+
+        assert _stage_token(value) == expected
+
+    @pytest.mark.parametrize("value", ["4", "0", "bogus"])
+    def test_unknown_values_raise_argument_type_error(self, value):
+        import argparse
+
+        from oceanarray.cli import _stage_token
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            _stage_token(value)
+
+    def test_stage1_alias_passes_type_conversion(self):
+        """'stage1' is a valid resolve_stage target so _stage_token returns it
+        as a string; argparse choices then rejects it (not in [1,2,3,'stack','grid'])."""
+        from oceanarray.cli import _stage_token
+
+        assert _stage_token("stage1") == "stage1"
+
+    def test_choices_derived_from_stages(self):
+        """choices= for --stage is derived from STAGES, not a hardcoded list."""
+        from oceanarray.processors import STAGES
+
+        parser = build_parser()
+        process_sub = parser._subparsers._actions[-1].choices["process"]
+        stage_action = next(
+            a
+            for a in process_sub._actions
+            if "--stage" in getattr(a, "option_strings", [])
+        )
+        expected = [s.number if s.number is not None else s.name for s in STAGES]
+        assert stage_action.choices == expected

--- a/tests/unit/test_process_api.py
+++ b/tests/unit/test_process_api.py
@@ -241,6 +241,18 @@ class TestProcess:
         assert result is True
         assert calls == ["stack", "grid"]
 
+    def test_process_list_preserves_stages_order(self, tmp_path, monkeypatch):
+        """Input order is ignored — stages always run in STAGES order."""
+        calls = []
+        patched = tuple(
+            Stage(s.name, s.number, s.scope, _make_spy(calls, s.name)) for s in STAGES
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process("my_mooring", stage=[2, 1], proc_dir=tmp_path)
+        assert result is True
+        assert calls == ["stage1", "stage2"]
+
     def test_process_empty_list_runs_nothing(self, tmp_path, monkeypatch):
         """stage=[] runs no stages and returns True."""
         calls = []

--- a/tests/unit/test_process_api.py
+++ b/tests/unit/test_process_api.py
@@ -217,6 +217,61 @@ class TestProcess:
         assert result is True
         assert calls == ["stack"]
 
+    def test_process_with_list(self, tmp_path, monkeypatch):
+        """stage=[1, 2] runs only stages 1 and 2."""
+        calls = []
+        patched = tuple(
+            Stage(s.name, s.number, s.scope, _make_spy(calls, s.name)) for s in STAGES
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process("my_mooring", stage=[1, 2], proc_dir=tmp_path)
+        assert result is True
+        assert calls == ["stage1", "stage2"]
+
+    def test_process_with_list_of_names(self, tmp_path, monkeypatch):
+        """stage=['stack', 'grid'] runs only stack and grid."""
+        calls = []
+        patched = tuple(
+            Stage(s.name, s.number, s.scope, _make_spy(calls, s.name)) for s in STAGES
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process("my_mooring", stage=["stack", "grid"], proc_dir=tmp_path)
+        assert result is True
+        assert calls == ["stack", "grid"]
+
+    def test_process_empty_list_runs_nothing(self, tmp_path, monkeypatch):
+        """stage=[] runs no stages and returns True."""
+        calls = []
+        patched = tuple(
+            Stage(s.name, s.number, s.scope, _make_spy(calls, s.name)) for s in STAGES
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process("my_mooring", stage=[], proc_dir=tmp_path)
+        assert result is True
+        assert calls == []
+
+    def test_process_list_stack_failure_skips_grid(self, tmp_path, monkeypatch):
+        """stack failure in a list run still skips grid."""
+        calls = []
+        patched = (
+            Stage("stage1", 1, "instrument", _make_spy(calls, "stage1")),
+            Stage("stage2", 2, "instrument", _make_spy(calls, "stage2")),
+            Stage("stage3", 3, "instrument", _make_spy(calls, "stage3")),
+            Stage("stack", None, "mooring", _make_spy(calls, "stack", ok=False)),
+            Stage("grid", None, "mooring", _make_spy(calls, "grid")),
+        )
+        _patch_stages(monkeypatch, patched)
+
+        result = process(
+            "my_mooring", stage=[1, 2, 3, "stack", "grid"], proc_dir=tmp_path
+        )
+        assert result is False
+        assert "grid" not in calls
+        assert calls == ["stage1", "stage2", "stage3", "stack"]
+
 
 class TestRunWrappersNoSeasenselib:
     """Wrapper bodies whose stage module does not import seasenselib.
@@ -236,9 +291,28 @@ class TestRunWrappersNoSeasenselib:
         cls = mock.MagicMock(return_value=inst)
         monkeypatch.setattr("oceanarray.processors.stage3.Stage3Processor", cls)
 
-        assert _run_stage3("m", tmp_path, serials=["9"], force=True) is True
+        assert (
+            _run_stage3("m", tmp_path, serials=["9"], force=True, dry_run=True) is True
+        )
         cls.assert_called_once_with(proc_dir=str(tmp_path))
-        inst.process_mooring.assert_called_once_with("m", serials=["9"], force=True)
+        inst.process_mooring.assert_called_once_with(
+            "m", serials=["9"], force=True, dry_run=True
+        )
+
+    def test_run_stage3_dry_run_defaults_false(self, tmp_path, monkeypatch):
+        from unittest import mock
+
+        from oceanarray.processors import _run_stage3
+
+        inst = mock.MagicMock()
+        inst.process_mooring.return_value = True
+        cls = mock.MagicMock(return_value=inst)
+        monkeypatch.setattr("oceanarray.processors.stage3.Stage3Processor", cls)
+
+        _run_stage3("m", tmp_path)
+        inst.process_mooring.assert_called_once_with(
+            "m", serials=None, force=False, dry_run=False
+        )
 
     def test_run_stack_instantiates_and_forwards(self, tmp_path, monkeypatch):
         from unittest import mock


### PR DESCRIPTION
**What changed:**

**`process()` now accepts a list of stages** *(processors/__init__.py)*
- Type extended from `int | str | None` to `int | str | list[int | str] | None`
- `stage=[1, 2]` runs exactly stages 1 and 2; `stage=[1, 2, 3, "stack", "grid"]` runs all five
- Existing callers passing a single int/str or `None` are unaffected

**`cmd_process` replaced four hand-rolled dispatch blocks with one `process()` call** *(cli.py:153)*
- Previously: independent `if 1 in stages:`, `if 2 in stages:`, `if 3 in stages:`, `if "stack" in stages:`, `if "grid" in stages:` blocks, each importing and instantiating its own processor class
- Stack-failure skip logic was also duplicated hand-rolled inside `cmd_process`
- Now: single `process(mooring, stage=stages, ...)` call; all dispatch, skipping, and failure tracking delegated to the registry

**`cmd_run` simplified to a single `process(stage=None)` call** *(cli.py:572)*
- Previously called `cmd_process(stage=[1,2,3])` then directly instantiated `MooringStacker` and `MooringGridder` again — bypassing `process()` entirely
- Now delegates to `process(stage=None)` which runs all five stages in STAGES order

**`_stage_token` is now a thin wrapper around `resolve_stage`** *(cli.py:917)*
- Previously contained its own validation logic that duplicated the valid-stage set `{1, 2, 3, "stack", "grid"}`
- Now: coerces digit strings to int, calls `resolve_stage()` for validation, translates `ValueError` to `argparse.ArgumentTypeError`

**`choices=` for `--stage` derived from STAGES at parser build time** *(cli.py:1229)*
- Previously hardcoded as `[1, 2, 3, "stack", "grid"]`
- Now: `[s.number if s.number is not None else s.name for s in STAGES]`
- Adding a stage to STAGES automatically updates the CLI choices

**`_run_stage3` now forwards `dry_run`** *(processors/__init__.py:135)*
- Previously absorbed `dry_run` silently via `**_kw` without passing it to `Stage3Processor.process_mooring`
- `process(stage=3, dry_run=True)` was therefore a no-op for dry_run; fixed

## Breaking changes

**`oceanarray run` — stack failure now skips grid**
- Previously `cmd_run` ran all five steps unconditionally: stages 1–3 via `cmd_process`, then stack and grid directly, regardless of earlier failures
- After this change, a stack failure skips grid (inheriting `process()` skip logic)
- The docstring previously said "all steps run regardless of earlier failures" — updated
- Migration: if you need grid to run regardless of stack, call `process(stage="grid", ...)` explicitly after the failure

## Tests added

- `test_process_api.py`: `stage=[1, 2]` list, `stage=['stack', 'grid']` list, empty list runs nothing, list with stack failure still skips grid, `_run_stage3` forwards `dry_run`, `_run_stage3` defaults `dry_run=False`
- `test_cli.py`: `_stage_token` valid values (5), invalid values (3), `"stage1"` alias behavior, `choices=` derived from STAGES
